### PR TITLE
Apparently ++tack was also using ~| on wings.

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -9104,7 +9104,7 @@
   ::
   ++  tack
     |=  {hyp/wing mur/span}
-    ~|  [%tack hyp]
+    ~_  (show [%c %tack] %l hyp)
     =+  fid=(find %rite hyp)
     ?>  ?=($& -.fid)
     (take p.p.fid |=(span mur))


### PR DESCRIPTION
See #2