### PR TITLE
scanf was dependant on (cook :_(foo |=(...)))

### DIFF
--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -1024,7 +1024,7 @@
   (scan a (parsf b))
 ++  parsf                                              ::  make parser from:
   |^  |*  a/(pole _;/(*{$^(rule tape)}))            ::  ;"chars{rule}chars"
-      %-  cook  :_  (bill (norm a))
+      =-  (cook - (bill (norm a)))
       |*  (list)
       ?~  +<  ~
       ?~  t  i


### PR DESCRIPTION
Another victim rescued from the dicey pits of electroplating. @cgyarvin, is there a more canonical translation?