### PR TITLE
improve ford performance

### DIFF
--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -262,6 +262,7 @@
   ::
   ++  zo
     ~%  %ford-z  ..is  ~
+    :: =|  dyv/@
     |_  {num/@ud task}
     ++  abet  %_(..zo q.tad.bay (~(put by q.tad.bay) num +<+))
     ++  amok  
@@ -1137,9 +1138,9 @@
       :: =+  ^=  pre
       ::     ?+  -.kas  -.kas
       ::       ^  %cell
-      :: ::      %boil  [-.kas p.kas (tope q.kas)]
-      ::       %bake  [-.kas p.kas (tope q.kas)]
-      ::       %core  [-.kas (tope p.kas)]
+      :: ::      $boil  [-.kas p.kas (tope q.kas)]
+      ::       $bake  [-.kas p.kas (tope q.kas)]
+      ::       $core  [-.kas (tope p.kas)]
       ::     ==
       :: ~&  [dyv `term`(cat 3 %make (fil 3 dyv ' ')) pre]
       :: =-  ~&  [dyv `term`(cat 3 %made (fil 3 dyv ' ')) pre]  -

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -55,7 +55,7 @@
       dep/(set beam)                                    ::  dependencies
   ==                                                    ::
 ++  calx                                                ::  concrete cache line
-  $%  {$hood p/calm q/(pair beam cage) r/hood}          ::  compile
+  $%  {$hood p/calm q/(trel beam beam cage) r/hood}     ::  compile
       {$bake p/calm q/(trel mark coin beam) r/(unit vase)} ::  load
       {$slit p/calm q/{p/span q/span} r/span}           ::  slam type
       {$slim p/calm q/{p/span q/twig} r/(pair span nock)}::  mint
@@ -568,14 +568,12 @@
       %+  cool  |.(leaf+"ford: fade {<[(tope bem)]>}")
       %+  cope  (liar cof %*(. bem s [for s.bem]))
       |=  {cof/cafe cay/cage}
-      %+  (clef %hood)  (fine cof bim(r [%ud 0]) cay)
-      ^-  (burg (pair beam cage) hood)
-      |=  {cof/cafe bum/beam cay/cage}
-      ~|  fade+(tope bum)
-      =+  rul=(fair bum)
+      %+  (clef %hood)  (fine cof bem(r [%ud 0]) bim(r [%ud 0]) cay)
+      ^-  (burg (trel beam beam cage) hood)
+      |=  {cof/cafe bem/beam bim/beam cay/cage}
       ?.  ?=(@ q.q.cay)
         (flaw cof ~)
-      =+  vex=((full rul) [[1 1] (trip q.q.cay)])
+      =+  vex=((full (fair bem)) [[1 1] (trip q.q.cay)])
       ?~  q.vex
         (flaw cof [%leaf "syntax error: {<p.p.vex>} {<q.p.vex>}"] ~)
       (fine cof p.u.q.vex)
@@ -605,7 +603,7 @@
     ::
     ++  fair                                            ::  hood parsing rule
       |=  bem/beam
-      ?>  ?=({$ud $0} r.bem)           ::  XX sentinel
+      ?>  ?=({$ud $0} r.bem)          ::  XX sentinel
       =+  vez=(vang & (tope bem))
       =<  hood
       |%  
@@ -616,8 +614,22 @@
           [~ u=(^case a)]
         nuck:so
       ::
-      ++  hath  (sear plex:vez (stag %conl poor:vez))   ::  hood path
+      ++  hath  (sear plex (stag %conl poor)):vez       ::  hood path
       ++  have  (sear tome ;~(pfix fas hath))           ::  hood beam
+      ++  hith                                          ::  static path
+        =>  vez
+        (sear plex (stag %conl (more fas hasp)))
+      ::
+      ++  hive                                          ::  late-bound path
+        ;~  pfix  fas
+          %+  cook  |=(a/hops a)
+          =>  vez
+          ;~  plug
+            (stag ~ gash)
+            ;~(pose (stag ~ ;~(pfix cen porc)) (easy ~))
+          ==
+        ==
+      ::
       ++  hood
         %+  ifix  [gay gay]
         ;~  plug
@@ -716,7 +728,7 @@
               ++  for
                 %+  rail  fail
                 =-  ;~(sfix (star -) gap duz)
-                ;~(pfix gap fas ;~(plug hath day))
+                ;~(pfix gap fas ;~(plug hith day))
           ::
               ++  lin
                 %+  rail
@@ -738,8 +750,8 @@
           ::
               ++  see
                 %+  rail  
-                  ;~(plug ;~(sfix have col) day)
-                ;~(pfix gap ;~(plug have day))
+                  ;~(plug ;~(sfix hive col) day)
+                ;~(pfix gap ;~(plug hive day))
           ::
               ++  sic
                 %+  rail  
@@ -1498,8 +1510,14 @@
           (flux |=(a/vase noun+a))
         ::
             $see
-          =.  r.p.hon  ?:(?=({$ud $0} r.p.hon) r.how r.p.hon)
-          $(hon q.hon, how p.hon)
+          =+  vez=(vang & (tope how))
+          =+  tuz=(posh:vez p.hon)
+          ?~  tuz  (flaw cof leaf+"bad tusk: {<p.hon>}" ~)
+          =+  pax=(plex:vez %conl u.tuz)
+          ?~  pax  (flaw cof leaf+"bad path: {<u.tuz>}" ~)
+          =+  bem=(tome u.pax)
+          ?~  bem  (flaw cof leaf+"bad beam: {<u.pax>}" ~)
+          $(hon q.hon, how u.bem)
         ::
             $sic
           %+  cope  $(hon q.hon)
@@ -1759,7 +1777,7 @@
   ~
 ::
 ++  load                                                ::  highly forgiving
-  |=(old/axle ..^$(+>- old))
+  :: |=(old/axle ..^$(+>- old))
   ::=.  old  
   ::    ?.  ?=([%0 *] old)  old                           ::  remove at 1
   ::    :-  %1 
@@ -1768,13 +1786,13 @@
   ::    ?>  ?=([n=[p=* q=[tad=* dym=* deh=* jav=*]] l=* r=*] +.old)
   ::    :-  [p.n.+.old [tad.q.n.+.old dym.q.n.+.old deh.q.n.+.old ~]]
   ::    [$(+.old l.+.old) $(+.old r.+.old)]
-  ::|=  old=*
-  ::=+  lox=((soft axle) old)
-  ::^+  ..^$
-  ::?~  lox
-  ::  ~&  %ford-reset
-  ::  ..^$
-  ::..^$(+>- u.lox)
+  |=  old/*
+  =+  lox=((soft axle) old)
+  ^+  ..^$
+  ?~  lox
+   ~&  %ford-reset
+   ..^$
+  ..^$(+>- u.lox)
 ::
 ++  scry
   |=  {fur/(unit (set monk)) ren/@tas who/ship syd/desk lot/coin tyl/path}

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -559,6 +559,7 @@
       %_(+> mow :_(mow [hen %give gef]))
     ::
     ++  fade                                            ::  compile to hood
+      ~/  %fade
       |=  {cof/cafe for/mark bem/beam}
       ^-  (bolt hood)
       %+  cool  |.(leaf+"ford: fade {<[(tope bem)]>}")
@@ -1013,8 +1014,9 @@
       (fall ((soft (list mark)) q) ~)
     ::
     ++  lima                                            ::  load at depth
+      ~/  %lima
       |=  {cof/cafe for/mark arg/coin bem/beam}
-      %+  (clef %bake)  [p=cof q=[%0 p=[bem `~] q=[for arg bem]]]
+      %+  (clef %bake)  (flag bem (fine cof for arg bem))
       |=  {cof/cafe for/mark arg/coin bem/beam}
       ^-  (bolt (unit vase))
       %+  cope  (laze cof bem)
@@ -1039,6 +1041,7 @@
       (leap cof [-.bem /[for]/ren] bem arg)
     ::
     ++  link                                            ::  translate
+      ~/  %link
       |=  {cof/cafe too/mark for/mark vax/vase}
       ^-  (bolt vase)
       :: %+  cool   |.(leaf+"ford: link {<too>} {<for>} {<p.vax>}")
@@ -1064,8 +1067,9 @@
       (maul cof u.zat vax)
     ::
     ++  lion                                            ::  translation search
+      ~/  %lion
       |=  {cof/cafe too/mark fro/(set mark)}
-      :: ~&  lion+[too=too fro=(silt fro)]
+      ::  ~&  lion+[too=too fro=fro]
       ^-  (bolt (list mark))
       =-  %+  coop  (gro cof too ~ ~)                    :: XX better grab layer
           |=  cof/cafe
@@ -1105,6 +1109,7 @@
       ^$(cof cof, for i.yaw, yaw t.yaw, vax yed)
     ::
     ++  mail                                            ::  cached mint
+      ~/  %mail
       |=  {cof/cafe sut/span gen/twig}
       ^-  (bolt (pair span nock))
       %+  (clef %slim)  (fine cof sut gen)
@@ -1301,6 +1306,7 @@
       ==
     ::
     ++  malt                                            ::  cached slit
+      ~/  %slit
       |=  {cof/cafe gat/span sam/span}
       ^-  (bolt span)
       %+  (clef %slit)  (fine cof gat sam)

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -262,7 +262,7 @@
   ::
   ++  zo
     ~%  %ford-z  ..is  ~
-    :: =|  dyv/@
+    =|  dyv/@
     |_  {num/@ud task}
     ++  abet  %_(..zo q.tad.bay (~(put by q.tad.bay) num +<+))
     ++  amok  
@@ -561,12 +561,14 @@
     ++  fade                                            ::  compile to hood
       ~/  %fade
       |=  {cof/cafe for/mark bem/beam}
+      :: ~&  fade+(tope bem)
       ^-  (bolt hood)
       %+  cool  |.(leaf+"ford: fade {<[(tope bem)]>}")
       %+  cope  (liar cof %*(. bem s [for s.bem]))
       |=  {cof/cafe cay/cage}
       %+  (clef %hood)  (fine cof bem(r [%ud 0]) cay)
       ^-  (burg (pair beam cage) hood)
+      ~%  %hood-miss  ..abet  ~
       |=  {cof/cafe bem/beam cay/cage}
       ?.  ?=(@ q.q.cay)
         (flaw cof ~)
@@ -576,6 +578,7 @@
       (fine cof p.u.q.vex)
     ::
     ++  fame                                            ::  beam with - as /
+      ~/  %fame
       |=  {cof/cafe bem/beam}
       ^-  (bolt beam)
       %+  cope  
@@ -596,6 +599,7 @@
     ::
     ++  fang                                            ::  protocol door
       |=  {cof/cafe for/mark}  ^-  (bolt vase)
+      :: ~&  fang+for
       (lear cof bek /[for]/mar)
     ::
     ++  fair                                            ::  hood parsing rule
@@ -990,6 +994,7 @@
       (flag bem (fine cof arc))
     ::
     ++  liar                                            ::  load cage
+      ~/  %liar
       |=  {cof/cafe bem/beam}
       ^-  (bolt cage)
       ?:  =([%ud 0] r.bem)
@@ -1002,6 +1007,7 @@
       (fine cof u.u.von)
     ::
     ++  lily
+      ~/  %lily
       |=  {cof/cafe for/mark}  ^-  (bolt (set @tas))
       %+  cope  (coop (fang cof for) |=(cof/cafe (fine cof %void ~)))
       %-  flux
@@ -1043,6 +1049,8 @@
     ++  link                                            ::  translate
       ~/  %link
       |=  {cof/cafe too/mark for/mark vax/vase}
+      =*  link-jet  .
+      :: ~$  link
       ^-  (bolt vase)
       :: %+  cool   |.(leaf+"ford: link {<too>} {<for>} {<p.vax>}")
       ?:  =(too for)  (fine cof vax)
@@ -1050,28 +1058,39 @@
         ((lake too) cof vax)
       %+  cope  (fang cof for)
       |=  {cof/cafe pro/vase}  ^-  (bolt vase)
-      ?:  &((slob %grow p.pro) (slob too p:(slap pro [%limb %grow])))
+      ?:  :: =<  $  ~%  %limb-grow  link-jet  ~  |.
+          &((slob %grow p.pro) (slob too p:(slap pro [%limb %grow])))
+        :: ~$  link-grow
+        :: =<  $  ~%  %grow  link-jet  ~  |.
         %+  cope  (keel cof pro [[%& 6]~ vax]~)
         |=  {cof/cafe pox/vase}
         (maim cof pox [%per [%limb %grow] [%limb too]])
       %+  cope  (fang cof too)
+      ~%  %grab  link-jet  ~
       |=  {cof/cafe pro/vase}
-      =+  ^=  zat  ^-  (unit vase)
+      =+  :: =<  $  ~%  %limb-grab  +  ~  |.
+          ^=  zat  ^-  (unit vase)
           ?.  (slob %grab p.pro)  ~
           =+  gab=(slap pro [%limb %grab])
           ?.  (slob for p.gab)  ~
           `(slap gab [%limb for])
       ?~  zat
+        :: ~$  link-miss
         (flaw cof [%leaf "ford: no link: {<[for too]>}"]~)
+      :: ~$  link-grab
       ~|  [%link-maul for too] 
       (maul cof u.zat vax)
     ::
     ++  lion                                            ::  translation search
       ~/  %lion
       |=  {cof/cafe too/mark fro/(set mark)}
-      ::  ~&  lion+[too=too fro=fro]
+      =*  lion-jet  .
+      :: ~&  lion+[too=too fro=fro]
+      :: =-  =+  (cope - (flux |=(a/(list mark) ~&(lioned+a ~))))
+      ::     +<
       ^-  (bolt (list mark))
       =-  %+  coop  (gro cof too ~ ~)                    :: XX better grab layer
+          ~%  %grab  lion-jet  ~
           |=  cof/cafe
           %+  cope  (fang cof too)
           |=  {cof/cafe vax/vase}  ^-  (bolt (list mark))
@@ -1121,6 +1140,7 @@
       ==
     ::
     ++  maim                                            ::  slap
+      ~/  %maim
       |=  {cof/cafe vax/vase gen/twig}
       ^-  (bolt vase)
       %+  cope  (mail cof p.vax gen)
@@ -1146,7 +1166,7 @@
       ::     ==
       :: ~?  !=(%$ pre)  [dyv `term`(cat 3 %make (fil 3 dyv ' ')) pre]
       :: =-  ~?  !=(%$ pre)  [dyv `term`(cat 3 %made (fil 3 dyv ' ')) pre]  -
-      :: =.  dyv  +(dyv)
+      =.  dyv  +(dyv)
       ^-  (bolt gage)
       ?-    -.kas
           ^
@@ -1209,6 +1229,9 @@
         %+  cope  $(kas q.kas)
         %-  tabl-run
         |=  {cof/cafe cay/cage}
+        :: ~$  make-cast
+        :: ~>  %live.  :: ~$(make-cast-{to}--{from} ~)
+        ::   (rap 3 %make-cast- p.kas '--' p.cay ~)
         ^-  (bolt gage)
         %+  cool  |.(leaf+"ford: casting {<p.cay>} to {<p.kas>}")
         %+  cope  (lion cof p.kas p.cay `~)
@@ -1320,6 +1343,7 @@
       ==
     ::
     ++  maul                                            ::  slam
+      ~/  %maul
       |=  {cof/cafe gat/vase sam/vase}
       ^-  (bolt vase)
       %+  cope  (malt cof p.gat p.sam)

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -56,7 +56,7 @@
   ==                                                    ::
 ++  calx                                                ::  concrete cache line
   $%  {$hood p/calm q/(pair beam cage) r/hood}          ::  compile
-      {$bake p/calm q/(trel mark coin beam) r/(unit vase)} ::  load
+      {$bake p/calm q/(pair mark beam) r/(unit vase)}   ::  load
       {$slit p/calm q/{p/span q/span} r/span}           ::  slam type
       {$slim p/calm q/{p/span q/twig} r/(pair span nock)}::  mint
       {$slap p/calm q/{p/vase q/twig} r/vase}           ::  compute
@@ -584,7 +584,7 @@
         ?~  opt  (flue cof)
         |-  ^-  (bolt (unit beam))
         =.  i.s.bem  (tack opt)
-        %+  cope  (lima cof %hoon many+~ bem)
+        %+  cope  (lima cof %hoon bem)
         |=  {cof/cafe vax/(unit vase)}  ^-  (bolt (unit beam))
         ?^  vax  (fine cof `bem)
         ?~  t.opt  (flue cof)
@@ -904,8 +904,8 @@
       |=  {cof/cafe arc/arch}
       (fine cof (bind fil.arc $~))
     ::
-    ++  lace                                            ::  load real or virtual
-      |=  {cof/cafe for/mark arg/coin bem/beam}
+    ++  lace                                            ::  load file
+      |=  {cof/cafe for/mark bem/beam}
       ^-  (bolt vase)
       %+  cool  |.(leaf+"ford: load {<for>} {<(tope bem)>}")
       =.  s.bem  [for s.bem]
@@ -968,10 +968,10 @@
     ::
     ++  lear                                            ::  load core
       |=  {cof/cafe bem/beam}  ^-  (bolt vase)
-      (leap cof bem bem many+~)
+      (leap cof many+~ bem bem)
     ::
     ++  leap                                            :: XX load with path
-      |=  {cof/cafe bem/beam bom/beam arg/coin}
+      |=  {cof/cafe arg/coin bem/beam bom/beam}
       %+  cope  (lamp cof bem)
       |=  {cof/cafe bem/beam}
       %+  cope  (fame cof bem)
@@ -1015,30 +1015,30 @@
     ::
     ++  lima                                            ::  load at depth
       ~/  %lima
-      |=  {cof/cafe for/mark arg/coin bem/beam}
-      %+  (clef %bake)  (flag bem (fine cof for arg bem))
-      |=  {cof/cafe for/mark arg/coin bem/beam}
+      |=  {cof/cafe for/mark bem/beam}
+      %+  (clef %bake)  (flag bem (fine cof for bem))
+      |=  {cof/cafe for/mark bem/beam}
       ^-  (bolt (unit vase))
       %+  cope  (laze cof bem)
       |=  {cof/cafe mal/(map mark $~)}
       ?:  (~(has by mal) for)
-        (cope (lace cof for arg bem) (flux some))
+        (cope (lace cof for bem) (flux some))
       =+  opt=(silt (turn (~(tap by mal)) head))        ::  XX asymptotics  
       %+  cope  (lion cof for opt)
       |=  {cof/cafe wuy/(list @tas)}
       ?~  wuy  (flue cof)
       %+  cope  
-        (lace cof i.wuy arg bem)
+        (lace cof i.wuy bem)
       |=  {cof/cafe hoc/vase}
       (cope (lope cof i.wuy t.wuy hoc) (flux some))
     ::
     ++  lime                                            ::  load beam
       |=  {cof/cafe for/mark arg/coin bem/beam}
       ^-  (bolt vase)
-      %+  cope  (lima cof for arg bem)
+      %+  cope  (lima cof for bem)
       |=  {cof/cafe vux/(unit vase)}
       ?^  vux  (fine cof u.vux)
-      (leap cof [-.bem /[for]/ren] bem arg)
+      (leap cof arg [-.bem /[for]/ren] bem)
     ::
     ++  link                                            ::  translate
       ~/  %link

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -693,7 +693,7 @@
               (stag %nap ;~(pfix cab day:read))
               (stag %now ;~(pfix pat day:read))
               (stag %saw ;~(pfix sem saw:read))
-              (stag %see ;~(pfix col see:read))
+              (stag %sei ;~(pfix col sei:read))
               (stag %sic ;~(pfix ket sic:read))
               (stag %toy ;~(sfix toy:read fas))
             ==
@@ -751,7 +751,7 @@
                   ;~(plug ;~(sfix wide:vez sem) day)
                 ;~(pfix gap ;~(plug tall:vez day))
           ::
-              ++  see
+              ++  sei                 :: XX see
                 %+  rail  
                   ;~(plug ;~(sfix hive col) day)
                 ;~(pfix gap ;~(plug hive day))
@@ -1542,7 +1542,11 @@
           %+  cope  (maul cof gat sam)
           (flux |=(a/vase noun+a))
         ::
-            $see
+            $see                      ::  XX remove on breach
+          =.  r.p.hon  ?:(?=({$ud $0} r.p.hon) r.how r.p.hon)
+          $(hon q.hon, how p.hon)
+        ::
+            $sei                      ::  XX see
           =+  vez=(vang & (tope how))
           =+  tuz=(posh:vez p.hon)
           ?~  tuz  (flaw cof leaf+"bad tusk: {<p.hon>}" ~)

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -1128,17 +1128,19 @@
       %+  cope  (lamp cof bek ~)
       |=({cof/cafe byk/beak *} (make(bek byk) cof kas))
     ::
+    ++  abbrev                                          ::  shorten coin
+      |=(a/coin ?-(-.a $$ a, $blob a(p (mug p.a)), $many a(p (turn p.a ..$))))
+    ::
     ++  make                                            ::  reduce silk
       |=  {cof/cafe kas/silk}
       :: =+  ^=  pre
-      ::     ?+  -.kas  -.kas
+      ::     ?+  -.kas  `term`-.kas
       ::       ^  %cell
-      :: ::      $boil  [-.kas p.kas (tope q.kas)]
-      ::       $bake  [-.kas p.kas (tope q.kas)]
+      ::       $bake  [-.kas p.kas (tope r.kas) ~(rent co (abbrev q.kas))]
       ::       $core  [-.kas (tope p.kas)]
       ::     ==
-      :: ~&  [dyv `term`(cat 3 %make (fil 3 dyv ' ')) pre]
-      :: =-  ~&  [dyv `term`(cat 3 %made (fil 3 dyv ' ')) pre]  -
+      :: ~?  !=(%$ pre)  [dyv `term`(cat 3 %make (fil 3 dyv ' ')) pre]
+      :: =-  ~?  !=(%$ pre)  [dyv `term`(cat 3 %made (fil 3 dyv ' ')) pre]  -
       :: =.  dyv  +(dyv)
       ^-  (bolt gage)
       ?-    -.kas

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -57,6 +57,7 @@
 ++  calx                                                ::  concrete cache line
   $%  {$hood p/calm q/(pair beam cage) r/hood}          ::  compile
       {$bake p/calm q/(pair mark beam) r/(unit vase)}   ::  load
+      {$boil p/calm q/(trel coin beam beam) r/vase}     ::  execute
       {$slit p/calm q/{p/span q/span} r/span}           ::  slam type
       {$slim p/calm q/{p/span q/twig} r/(pair span nock)}::  mint
       {$slap p/calm q/{p/vase q/twig} r/vase}           ::  compute
@@ -82,6 +83,7 @@
   ?+  sem  !!
     $hood  ?>(?=($hood -.cax) r.cax)
     $bake  ?>(?=($bake -.cax) r.cax)
+    $boil  ?>(?=($boil -.cax) r.cax)
     $slap  ?>(?=($slap -.cax) r.cax)
     $slam  ?>(?=($slam -.cax) r.cax)
     $slim  ?>(?=($slim -.cax) r.cax)
@@ -975,6 +977,9 @@
       (leap cof many+~ bem bem)
     ::
     ++  leap                                            :: XX load with path
+      ~/  %leap
+      |=  {cof/cafe arg/coin bem/beam bom/beam}
+      %+  (clef %boil)  (fine cof arg bem bom)
       |=  {cof/cafe arg/coin bem/beam bom/beam}
       %+  cope  (lamp cof bem)
       |=  {cof/cafe bem/beam}

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -55,7 +55,7 @@
       dep/(set beam)                                    ::  dependencies
   ==                                                    ::
 ++  calx                                                ::  concrete cache line
-  $%  {$hood p/calm q/(trel beam beam cage) r/hood}     ::  compile
+  $%  {$hood p/calm q/(pair beam cage) r/hood}          ::  compile
       {$bake p/calm q/(trel mark coin beam) r/(unit vase)} ::  load
       {$slit p/calm q/{p/span q/span} r/span}           ::  slam type
       {$slim p/calm q/{p/span q/twig} r/(pair span nock)}::  mint
@@ -561,17 +561,12 @@
     ++  fade                                            ::  compile to hood
       |=  {cof/cafe for/mark bem/beam}
       ^-  (bolt hood)
-      (fape cof for bem bem)
-    ::
-    ++  fape                                            ::  XX compile at path
-      |=  {cof/cafe for/mark bem/beam bim/beam}
-      ^-  (bolt hood)
       %+  cool  |.(leaf+"ford: fade {<[(tope bem)]>}")
       %+  cope  (liar cof %*(. bem s [for s.bem]))
       |=  {cof/cafe cay/cage}
-      %+  (clef %hood)  (fine cof bem(r [%ud 0]) bim(r [%ud 0]) cay)
-      ^-  (burg (trel beam beam cage) hood)
-      |=  {cof/cafe bem/beam bim/beam cay/cage}
+      %+  (clef %hood)  (fine cof bem(r [%ud 0]) cay)
+      ^-  (burg (pair beam cage) hood)
+      |=  {cof/cafe bem/beam cay/cage}
       ?.  ?=(@ q.q.cay)
         (flaw cof ~)
       =+  vex=((full (fair bem)) [[1 1] (trip q.q.cay)])
@@ -980,7 +975,7 @@
       |=  {cof/cafe bem/beam}
       %+  cope  (fame cof bem)
       |=  {cof/cafe bem/beam}
-      (cope (fape cof %hoon bem bom) abut:(meow bom arg))
+      (cope (fade cof %hoon bem) abut:(meow bom arg))
     ::
     ++  lend                                            ::  load arch
       |=  {cof/cafe bem/beam}

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -10364,20 +10364,15 @@
     (welp (scow %ud (div (mul 100 euq.mon) tot)) "e ")
   ==
 ::
-++  pi-tell                                             ::  produce dump
+++  pi-tell                                              ::  produce dump
   |=  day/doss
   ^-  (list tape)
   ?:  =(day *doss)  ~
   =+  tot=(pi-moth mon.day)
   ;:  welp
-    [(welp "events: " (pi-mumm mon.day)) ~]
-  ::
-    %+  turn
-      (~(tap by hit.day) ~)
-    |=  {nam/term num/@ud}
-    :(welp (trip nam) ": " (scow %ud num))
     ["" ~]
   ::
+    ^-  wall
     %-  zing
     ^-  (list (list tape))
     %+  turn
@@ -10399,7 +10394,7 @@
         |=({{* a/@ud} {* b/@ud}} (lth a b))
       |=  {pax/path num/@ud}
       ^-  (unit tape)
-      ?:  (lth (mul 10 num) ott)  ~
+      ?:  (lth (mul 20 num) ott)  ~
       (some :(welp "  " (spud pax) ": " (scow %ud num)))
     ::
       ?:  =(~ inn.hup)  ~
@@ -10410,12 +10405,18 @@
         |=({{* a/@ud} {* b/@ud}} (lth a b))
       |=  {pax/path num/@ud}
       ^-  (unit tape)
-      ?:  (lth (mul 10 num) ott)  ~
+      ?:  (lth (mul 20 num) ott)  ~
       (some :(welp "  " (spud pax) ": " (scow %ud num)))
     ::
       ["" ~]
-      ~
     ==
+  ::
+    [(welp "events: " (pi-mumm mon.day)) "" ~]
+  ::
+    %+  turn
+      (~(tap by hit.day) ~)
+    |=  {nam/term num/@ud}
+    :(welp (trip nam) ": " (scow %ud num))
   ==
 --
 ::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -10380,10 +10380,10 @@
       %+  turn  (~(tap by cut.day))
       |=({p/path q/hump} [(pi-moth mon.q) p q])
     |=  {ott/@u pax/path hup/hump}
-    ?:  (lth (mul 10 ott) tot)  ~                       :: omit misc
+    ?:  (lth (mul 20 ott) tot)  ~                       :: omit misc
     ;:  welp
       [(welp "label: " (spud pax)) ~]
-      [(welp "price: " (scow %ud (div (mul 100 ott) tot))) ~]
+      [(welp "price: " (scow %ud (div (mul 100.000 ott) tot))) ~]
       [(welp "shape: " (pi-mumm mon.hup)) ~]
     ::
       ?:  =(~ out.hup)  ~
@@ -10395,6 +10395,7 @@
       |=  {pax/path num/@ud}
       ^-  (unit tape)
       ?:  (lth (mul 20 num) ott)  ~
+      =.  num  (div (mul 100.000 num) tot)
       (some :(welp "  " (spud pax) ": " (scow %ud num)))
     ::
       ?:  =(~ inn.hup)  ~
@@ -10406,6 +10407,7 @@
       |=  {pax/path num/@ud}
       ^-  (unit tape)
       ?:  (lth (mul 20 num) ott)  ~
+      =.  num  (div (mul 100.000 num) tot)
       (some :(welp "  " (spud pax) ": " (scow %ud num)))
     ::
       ["" ~]

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -10380,25 +10380,15 @@
       %+  turn  (~(tap by cut.day))
       |=({p/path q/hump} [(pi-moth mon.q) p q])
     |=  {ott/@u pax/path hup/hump}
-    ?:  (lth (mul 20 ott) tot)  ~                       :: omit misc
+    ?:  (lth (mul 15 ott) tot)  ~                       :: omit misc
     ;:  welp
       [(welp "label: " (spud pax)) ~]
-      [(welp "price: " (scow %ud (div (mul 100.000 ott) tot))) ~]
+      [(welp "price: " (scow %ud (div (mul 100 ott) tot))) ~]
       [(welp "shape: " (pi-mumm mon.hup)) ~]
     ::
-      ?:  =(~ out.hup)  ~
-      :-  "into:"
-      ^-  wall
-      %+  murn
-        %+  sort  (~(tap by out.hup) ~)
-        |=({{* a/@ud} {* b/@ud}} (lth a b))
-      |=  {pax/path num/@ud}
-      ^-  (unit tape)
-      ?:  (lth (mul 20 num) ott)  ~
-      =.  num  (div (mul 100.000 num) tot)
-      (some :(welp "  " (spud pax) ": " (scow %ud num)))
-    ::
       ?:  =(~ inn.hup)  ~
+      ?:  &(?=([^ ~ ~] inn.hup) =(ott q.n.inn.hup))
+        ["from: {(spud p.n.inn.hup)}" ~]
       :-  "from:"
       ^-  wall
       %+  murn
@@ -10407,7 +10397,21 @@
       |=  {pax/path num/@ud}
       ^-  (unit tape)
       ?:  (lth (mul 20 num) ott)  ~
-      =.  num  (div (mul 100.000 num) tot)
+      =.  num  (div (mul 100 num) ott)
+      (some :(welp "  " (spud pax) ": " (scow %ud num)))
+    ::
+      ?:  =(~ out.hup)  ~
+      :: ?:  &(?=([^ ~ ~] out.hup) =(ott q.n.out.hup))
+      ::   ["into: {(spud p.n.out.hup)}" ~]
+      :-  "into:"
+      ^-  wall
+      %+  murn
+        %+  sort  (~(tap by out.hup) ~)
+        |=({{* a/@ud} {* b/@ud}} (lth a b))
+      |=  {pax/path num/@ud}
+      ^-  (unit tape)
+      ?:  (lth (mul 20 num) ott)  ~
+      =.  num  (div (mul 100 num) ott)
       (some :(welp "  " (spud pax) ": " (scow %ud num)))
     ::
       ["" ~]

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -10385,6 +10385,7 @@
       %+  turn  (~(tap by cut.day))
       |=({p/path q/hump} [(pi-moth mon.q) p q])
     |=  {ott/@u pax/path hup/hump}
+    ?:  (lth (mul 10 ott) tot)  ~                       :: omit misc
     ;:  welp
       [(welp "label: " (spud pax)) ~]
       [(welp "price: " (scow %ud (div (mul 100 ott) tot))) ~]
@@ -10392,21 +10393,25 @@
     ::
       ?:  =(~ out.hup)  ~
       :-  "into:"
-      %+  turn
+      ^-  wall
+      %+  murn
         %+  sort  (~(tap by out.hup) ~)
         |=({{* a/@ud} {* b/@ud}} (lth a b))
       |=  {pax/path num/@ud}
-      ^-  tape
-      :(welp "  " (spud pax) ": " (scow %ud num))
+      ^-  (unit tape)
+      ?:  (lth (mul 10 num) ott)  ~
+      (some :(welp "  " (spud pax) ": " (scow %ud num)))
     ::
       ?:  =(~ inn.hup)  ~
       :-  "from:"
-      %+  turn
+      ^-  wall
+      %+  murn
         %+  sort  (~(tap by inn.hup) ~)
         |=({{* a/@ud} {* b/@ud}} (lth a b))
       |=  {pax/path num/@ud}
-      ^-  tape
-      :(welp "  " (spud pax) ": " (scow %ud num))
+      ^-  (unit tape)
+      ?:  (lth (mul 10 num) ott)  ~
+      (some :(welp "  " (spud pax) ": " (scow %ud num)))
     ::
       ["" ~]
       ~

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -10381,11 +10381,10 @@
     %-  zing
     ^-  (list (list tape))
     %+  turn
-      %+  sort  (~(tap by cut.day))
-      |=  {one/(pair path hump) two/(pair path hump)}
-      (gth (pi-moth mon.q.one) (pi-moth mon.q.two))
-    |=  {pax/path hup/hump}
-    =+  ott=(pi-moth mon.hup)
+      =-  (sort - lor)
+      %+  turn  (~(tap by cut.day))
+      |=({p/path q/hump} [(pi-moth mon.q) p q])
+    |=  {ott/@u pax/path hup/hump}
     ;:  welp
       [(welp "label: " (spud pax)) ~]
       [(welp "price: " (scow %ud (div (mul 100 ott) tot))) ~]
@@ -10395,7 +10394,7 @@
       :-  "into:"
       %+  turn
         %+  sort  (~(tap by out.hup) ~)
-        |=({{* a/@ud} {* b/@ud}} (gth a b))
+        |=({{* a/@ud} {* b/@ud}} (lth a b))
       |=  {pax/path num/@ud}
       ^-  tape
       :(welp "  " (spud pax) ": " (scow %ud num))
@@ -10404,7 +10403,7 @@
       :-  "from:"
       %+  turn
         %+  sort  (~(tap by inn.hup) ~)
-        |=({{* a/@ud} {* b/@ud}} (gth a b))
+        |=({{* a/@ud} {* b/@ud}} (lth a b))
       |=  {pax/path num/@ud}
       ^-  tape
       :(welp "  " (spud pax) ": " (scow %ud num))

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2212,7 +2212,8 @@
       {$nap p/horn}                                     ::  /_  homo map
       {$now p/horn}                                     ::  /@  list by @da
       {$saw p/twig q/horn}                              ::  /;  operate on
-      {$see p/hops q/horn}                              ::  /:  relative to
+      {$see p/beam q/horn}                              ::  XX remove on breach
+      {$sei p/hops q/horn}                              ::  /:  relative to XX see
       {$sic p/twig q/horn}                              ::  /^  cast
       {$toy p/? q/mark}                                 ::  /mark/  static/hook
   ==                                                    ::

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2197,6 +2197,7 @@
   $%  {$& p/twig}                                       ::  direct twig
       {$| p/beam}                                       ::  resource location   
   ==                                                    ::
+++  hops   {pre/(unit tyke) pof/(unit {p/@ud q/tyke})}  ::  XX late-bound path
 ++  horn                                                ::  resource tree
   $%  {$ape p/twig}                                     ::  /~  twig by hand
       {$arg p/twig}                                     ::  /$  argument
@@ -2211,7 +2212,7 @@
       {$nap p/horn}                                     ::  /_  homo map
       {$now p/horn}                                     ::  /@  list by @da
       {$saw p/twig q/horn}                              ::  /;  operate on
-      {$see p/beam q/horn}                              ::  /:  relative to
+      {$see p/hops q/horn}                              ::  /:  relative to
       {$sic p/twig q/horn}                              ::  /^  cast
       {$toy p/? q/mark}                                 ::  /mark/  static/hook
   ==                                                    ::

--- a/mar/tree/comments.hoon
+++ b/mar/tree/comments.hoon
@@ -1,0 +1,23 @@
+::
+::::  /hoon/comments/tree/mar
+  ::
+/?    310
+/+    react
+!:
+::::
+  ::
+|_  all/(list (pair time manx))
+::
+++  grow                                                ::  convert to
+  |%
+  ++  json
+    :-  %a 
+    %+  turn
+      (sort all |=({a/* b/*} (lor b a)))
+    |=  {a/time b/manx}  ^-  ^json
+    (jobe time+(jode a) body+(react-to-json:react b) ~)
+  --
+++  grab  |%                                            ::  convert from
+          ++  noun  (list {time manx})                  ::  clam from %noun
+          ::++  elem  |=(a=manx `_all`[[/ ((getall %h1) a)] ~ ~])
+--        --

--- a/ren/tree/combine.hoon
+++ b/ren/tree/combine.hoon
@@ -9,17 +9,15 @@
 /=    sect    /&json&/tree-index/
 /=    snip    /&snip&elem&/tree-elem/
 /=    meta    /&json&front&/|(/front/ /~[~])
-/=    comt    /^  (list (pair time manx))
-              /:  /%/comments    /@  /&elem&/md/
+/=    comt    /&json&/tree-comments/
 !:
 ^-    tree-include
 =+  rj=react-to-json:react
-=+  cj=|=({a/time b/manx} (jobe time+(jode a) body+(rj b) ~))
 :*  mime
     (rj body)
     (rj /h1 hed.snip)   :: head
     (rj /div tal.snip)  :: snip
     meta
     sect
-    [%a (turn (sort comt |=({a/* b/*} (lor b a))) cj)]
+    comt
 ==

--- a/ren/tree/comments.hoon
+++ b/ren/tree/comments.hoon
@@ -1,0 +1,9 @@
+::
+::::  /hoon/comments/tree/ren
+  ::
+/?    310
+/:    /%/comments    /@  /&elem&/md/    :: XX descend horn
+::
+::::
+  ::
+`(list (pair time manx))`-.-


### PR DESCRIPTION
- results of dynamically executed code now cached(renderers) like it used to be (hook files)
- renderers also no longer parsed per resource path, with `/: %/foo` syntax handled by passing through "at current path, /foo" as a literal to be bound to the resource-specific path at compilation.
  + this in turn means that their compilation is largely cached, as stack trace information is no longer (mistakenly) the resource path. Fixing urbit/urbit#697.
  + tree comments have been moved to a separate renderer, isolating their /: usage

Additionally,
- jet hints throughout ford for aid in profiling
- various tweaks to ++pi-tell to make the profiler output format more readable