### PR TITLE
renamed security driver arms

### DIFF
--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -67,10 +67,10 @@
 ++  whir-of  {p/knot:ship q/term r/wire}                ::  path in dock
 ++  whir-se  ?($core vi-arm)                            ::  build/call
 ++  vi-arm
-  $?  $out                                              ::  ++out mod request
-      $res                                              ::  ++res use result
-      $bak                                              ::  ++bak auth response
-      $in                                               ::  ++in handle code 
+  $?  $filter-request                                   ::  ++out mod request
+      $filter-response                                  ::  ++res use result
+      $receive-auth-response                            ::  ++bak auth response
+      $receive-auth-query-string                        ::  ++in handle code 
   ==                                                    ::
 --                                                      ::
 |%                                                      ::  models
@@ -1670,9 +1670,9 @@
         [[%& 12]~ %$ bale+!>(*(bale @))]  :: XX specify on type?
       ?~  cor  ~
       ?~  u.cor  ~
-      ?:  (has-arm %wyp)  ~
-      ?:  (has-arm %upd)
-        [[%& 13]~ ride+[limb+%upd prep-cor]]~
+      ?:  (has-arm %discard-state)  ~
+      ?:  (has-arm %update)
+        [[%& 13]~ ride+[limb+%update prep-cor]]~
       [[%& 13]~ %$ noun+(slot 13 u.cor)]~
     ::
     ++  call
@@ -1704,8 +1704,8 @@
       ?~  ole  abet
       ::  process hiss
       =.  hen  p.u.ole
-      ?~  u.cor  (eyre-them %out r.u.ole)  :: don't process
-      (call %out hiss+r.u.ole)
+      ?~  u.cor  (eyre-them %filter-request r.u.ole)  :: don't process
+      (call %filter-request hiss+r.u.ole)
     ::
     ++  fin-httr
       |=  vax/vase:httr
@@ -1717,26 +1717,31 @@
     ::  Interfaces
     ::
     ++  get-news  _build
-    ++  get-quay  |=(quy/quay (call %in quay+!>(quy)))
+    ++  get-quay  |=(quy/quay (call %receive-auth-query-string quay+!>(quy)))
     ++  get-req   |=(a/{mark vase:hiss} pump(req (~(put to req) hen a)))
     ++  get-thou
       |=  {wir/whir-se hit/httr}
       ?+  wir  !!
-        $in  (call %bak httr+!>(hit))
-        $out
-          ?.  (has-arm %res)  (fin-httr !>(hit))
-          (call %res httr+!>(hit))
+        $receive-auth-query-string  (call %receive-auth-response httr+!>(hit))
+        $filter-request
+          ?.  (has-arm %filter-response)  (fin-httr !>(hit))
+          (call %filter-response httr+!>(hit))
       ==
     ::
     ++  get-made
       |=  {wir/whir-se dep/@uvH res/(each cage tang)}  ^+  abet
       ?:  ?=($core wir)  (update dep res)
       %.  res
-      ?-(wir $out res-out, $res res-res, $bak res-bak, $in res-in)
+      ?-  wir
+        $filter-request             res-out
+        $filter-response            res-res
+        $receive-auth-response      res-bak
+        $receive-auth-query-string  res-in
+      ==
     ::
     ++  update  
       |=  {dep/@uvH gag/(each cage tang)}
-      :: ~&  got-upd/dep
+      :: ~&  got-update/dep
       =.  ..vi  (pass-note %core [%f [%wasp our dep &]])
       ?~  -.gag  pump(cor `q.p.gag)
       ?:  &(=(~ cor) =(%$ usr))
@@ -1803,13 +1808,13 @@
     ::
     ++  res-in
       %+  on-error  dead-this  |.
-      (handle-moves send+(do-send %in) ~)
+      (handle-moves send+(do-send %receive-auth-query-string) ~)
     ::
     ++  res-res
       %+  on-error  dead-hiss  |.
       %-  handle-moves  :~
         give+do-give
-        send+(do-send %out)
+        send+(do-send %filter-request)
         redo+_pump
       ==
     ::
@@ -1817,7 +1822,7 @@
       %+  on-error  dead-this  |.
       %-  handle-moves  :~
         give+do-give
-        send+(do-send %in)
+        send+(do-send %receive-auth-query-string)
         redo+_pump(..vi (give-html 200 ~ exit:xml))
       ==
     ::
@@ -1826,7 +1831,7 @@
       %+  on-error  warn  |.
       %-  handle-moves  :~
         give+do-give
-        send+(do-send %out)
+        send+(do-send %filter-request)
         show+do-show
       ==
 --  --

--- a/sec/com/asana.hoon
+++ b/sec/com/asana.hoon
@@ -18,10 +18,10 @@
 ::  most common handling of oauth2 semantics. see lib/oauth2 for more details,
 ::  and examples at the bottom of the file.
 ++  aut  (~(standard oauth2 bal tok) . |=(tok/token:oauth2 +>(tok tok)))
-++  out  (out-add-header:aut scope=~ dialog-url)
+++  filter-request  (out-add-header:aut scope=~ dialog-url)
 ::
-++  in   (in-code-to-token:aut exchange-url)
-++  bak  bak-save-token:aut
+++  receive-auth-query-string   (in-code-to-token:aut exchange-url)
+++  receive-auth-response       bak-save-token:aut
 --
 ::  create a developer app by logging into https://app.asana.com/, and clicking
 ::  "My Profile Settings" > Apps > "Manage my developer apps"

--- a/sec/com/digitalocean.hoon
+++ b/sec/com/digitalocean.hoon
@@ -18,10 +18,10 @@
 ::  most common handling of oauth2 semantics. see lib/oauth2 for more details,
 ::  and examples at the bottom of the file.
 ++  aut  (~(standard oauth2 bal tok) . |=(tok/token:oauth2 +>(tok tok)))
-++  out  (out-add-header:aut scope=~[%read %write] dialog-url)
+++  filter-request  (out-add-header:aut scope=~[%read %write] dialog-url)
 ::
-++  in   (in-code-to-token:aut exchange-url)
-++  bak  bak-save-token:aut
+++  receive-auth-query-string  (in-code-to-token:aut exchange-url)
+++  receive-auth-response      bak-save-token:aut
 --
 ::  create a developer app on https://cloud.digitalocean.com/settings/api/applications/new
 ::  to get a client id and secret

--- a/sec/com/dropboxapi.hoon
+++ b/sec/com/dropboxapi.hoon
@@ -18,10 +18,10 @@
 ::  most common handling of oauth2 semantics. see lib/oauth2 for more details,
 ::  and examples at the bottom of the file.
 ++  aut  (~(standard oauth2 bal tok) . |=(tok/token:oauth2 +>(tok tok)))
-++  out  (out-add-header:aut scope=~ dialog-url)
+++  filter-request  (out-add-header:aut scope=~ dialog-url)
 ::
-++  in   (in-code-to-token:aut exchange-url)
-++  bak  bak-save-token:aut
+++  receive-auth-query-string  (in-code-to-token:aut exchange-url)
+++  receive-auth-response      bak-save-token:aut
 --
 ::  create a developer app on https://www.dropbox.com/developers-v1/apps to get a
 ::  client id and secret.

--- a/sec/com/facebook.hoon
+++ b/sec/com/facebook.hoon
@@ -21,14 +21,14 @@
   %+  ~(standard oauth2 bal access-token)  .
   |=(access-token/token:oauth2 +>(access-token access-token))
 ::
-++  out
+++  filter-request
   %^  out-add-query-param:aut  'access_token'
     scope=~['user_about_me' 'user_posts']
   dialog-url
 ::
-++  in  (in-code-to-token:aut exchange-url)
+++  receive-auth-query-string  (in-code-to-token:aut exchange-url)
 ::
-++  bak
+++  receive-auth-response
   |=  a/httr  ^-  core-move:aut
   ?:  (bad-response:aut p.a)
     [%give a]  :: [%redo ~]  ::  handle 4xx?

--- a/sec/com/github.hoon
+++ b/sec/com/github.hoon
@@ -6,5 +6,5 @@
 !:
 |_  {bal/(bale keys:basic-auth) $~}
 ++  aut  ~(standard basic-auth bal ~)
-++  out  out-adding-header:aut
+++  filter-request  out-adding-header:aut
 --

--- a/sec/com/googleapis.hoon
+++ b/sec/com/googleapis.hoon
@@ -44,12 +44,12 @@
   =+  a=~(standard-refreshing oauth2 bal ber.own)
   (a(state-usr &) ..auth ref.own |=(a/user-state ..auth(own a)))
 ::
-++  out  (out-refresh-or-add-header:auth exchange-url scopes dialog-url)
+++  filter-request  (out-refresh-or-add-header:auth exchange-url scopes dialog-url)
 ++  dialog-url  (auth-usr usr.bal)
 ::
-++  res  res-save-after-refresh:auth
+++  filter-response  res-save-after-refresh:auth
 ::
-++  in   (in-code-to-token:auth exchange-url)
-++  bak  bak-save-both-tokens:auth
-:: ++  upd  *user-state
+++  receive-auth-query-string  (in-code-to-token:auth exchange-url)
+++  receive-auth-response      bak-save-both-tokens:auth
+:: ++  update  *user-state
 --

--- a/sec/com/instagram.hoon
+++ b/sec/com/instagram.hoon
@@ -18,13 +18,13 @@
 ::  most common handling of oauth2 semantics. see lib/oauth2 for more details,
 ::  and examples at the bottom of the file.
 ++  aut  (~(standard oauth2 bal tok) . |=(tok/token:oauth2 +>(tok tok)))
-++  out
+++  filter-request
   %^  out-add-query-param:aut  'access_token'
     scope=~[%basic]
   dialog-url
 ::
-++  in   (in-code-to-token:aut exchange-url)
-++  bak  bak-save-token:aut
+++  receive-auth-query-string  (in-code-to-token:aut exchange-url)
+++  receive-auth-response      bak-save-token:aut
 --
 ::  create a developer app on https://www.instagram.com/developer/ to get a
 ::  client id and secret

--- a/sec/com/slack.hoon
+++ b/sec/com/slack.hoon
@@ -11,11 +11,11 @@
 ::  most common handling of oauth2 semantics. see lib/oauth2 for more details,
 ::  and examples at the bottom of the file.
 ++  aut  (~(standard oauth2 bal tok) . |=(tok/token:oauth2 +>(tok tok)))
-++  out
+++  filter-request
   %^  out-add-query-param:aut  'token'
     scope=~[%client %admin]
   oauth-dialog='https://slack.com/oauth/authorize'
 ::
-++  in   (in-code-to-token:aut url='https://slack.com/api/oauth.access')
-++  bak  bak-save-token:aut
+++  receive-auth-query-string  (in-code-to-token:aut url='https://slack.com/api/oauth.access')
+++  receive-auth-response      bak-save-token:aut
 --

--- a/sec/com/twitter.hoon
+++ b/sec/com/twitter.hoon
@@ -11,17 +11,17 @@
 ::  most common handling of oauth1 semantics. see lib/oauth1 for more details,
 ::  and examples at the bottom of the file.
 ++  aut  (~(standard oauth1 bal tok) . |=(tok/token:oauth1 +>(tok tok)))
-++  out
+++  filter-request
   %+  out-add-header:aut
     token-request='https://api.twitter.com/oauth/request_token'
   oauth-dialog='https://api.twitter.com/oauth/authorize'
 ::
-++  res  res-handle-request-token:aut
+++  filter-response  res-handle-request-token:aut
 ::
-++  in
+++  receive-auth-query-string
   %-  in-exchange-token:aut
   exchange-url='https://api.twitter.com/oauth/access_token'
 ::
-++  bak  bak-save-token:aut
-:: ++  wyp  ~
+++  receive-auth-response  bak-save-token:aut
+:: ++  discard-state  ~
 --


### PR DESCRIPTION
As discussed in https://github.com/urbit/urbit/issues/692, renamed security driver arms as follows:

```
++  out -> filter-request
++  res -> filter-response
++  in -> receive-auth-query-string
++  bak -> receive-auth-response
++  upd -> update
++  wyp -> discard-state
```

All the drivers have been updated, and they all compile, but I haven't done an end-to-end test of any of them except Github.  My testing of the others consisted of verifying that `+https://domain.com` produced an `%oauth-no-keys` error.  If @ault011 or @ohAitch want to test them, that'd be great.  Would like @ohAitch to review, in any case.

Currently this is a breaching change because for some reason wires are a part of eyre's state somewhere.  I'm not familiar enough with eyre to quickly write a state adapter.