### PR TITLE
Address ford cache memory leak

### DIFF
--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -619,7 +619,9 @@
       ::
       ++  wide                                          ::  match segments
         |=  sub/(list term)  ^-  (bolt (unit beam))
-        ?:  =(~ sub)  opts
+        ?~  sub  opts
+        ?~  t.sub  opts(s.bem [i.sub s.bem])
+        =>  .(sub `(list term)`sub)                     ::  TMI
         =-  (cope - flat)
         %^  lash  cof  bem
         |=  {cof/cafe dir/knot}  ^-  (bolt (unit beam))

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -1024,10 +1024,10 @@
     ++  leap                                            :: XX load with path
       ~/  %leap
       |=  {cof/cafe arg/coin bem/beam bom/beam}
-      %+  (clef %boil)  (fine cof arg bem bom)
-      |=  {cof/cafe arg/coin bem/beam bom/beam}
       %+  cope  (lamp cof bem)
       |=  {cof/cafe bem/beam}
+      %+  (clef %boil)  (fine cof arg bem bom)
+      |=  {cof/cafe arg/coin bem/beam bom/beam}
       %+  cope  (fame cof bem)
       |=  {cof/cafe bem/beam}
       (cope (fade cof %hoon bem) abut:(meow bom arg))

--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -156,7 +156,7 @@
   (rap 3 |-([i.a ?~(t.a ~ ['-' $(a t.a)])]))
 ::
 ++  tear                                                ::  split term
-  =-  |=(a/term `(list term)`(rash a (most hep sym)))
+  =-  |=(a/term `(list term)`(fall (rush a (most hep sym)) /[a]))
   sym=(cook crip ;~(plug low (star ;~(pose low nud))))
 ::
 ++  za                                                  ::  per event


### PR DESCRIPTION
Which was uncovered by #113, preventing piers from booting due to a cache invalidation issue.

Closes #120, #118 