### PR TITLE
fixes run:in (map over a set, producing a set)

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2452,10 +2452,13 @@
     $(a r.a, +<+.b $(a l.a, +<+.b (b n.a +<+.b)))
   ::
   +-  run                                               ::  apply gate to values
-    |*  {b/gate c/*}
-    |-
-    ?~  a  c
-    $(a r.a, c [(b n.a) $(a l.a)])
+    ~/  %run
+    |*  b/gate
+    =|  c/(set _?>(?=(^ a) (b n.a)))
+    |-  ?~  a  c
+    =.  c  (~(put in c) (b n.a))
+    =.  c  $(a l.a, c c)
+    $(a r.a, c c)
   ::
   +-  tap                                               ::  convert to list
     ~/  %tap


### PR DESCRIPTION
The current implementation produces an "improper list" (ie, non-terminated), and requires an unusual calling convention. This version just takes a gate and applies to every item in the set (from left to right), producing a new set containing the products of the gate.

```
=+  a=(sy ~[1 2 3])
(~(run in a) |=(a/@ (gth 2 a)))
```

produces `{%.y %.n}`