### PR TITLE
updates +moon to print an error message instead of a stack trace

### DIFF
--- a/gen/moon.hoon
+++ b/gen/moon.hoon
@@ -10,8 +10,10 @@
         $~
         $~
     ==
-:-  %noun
-?>  =(1 (met 5 p.bec))
+:-  %tang  :_  ~  :-  %leaf
+=+  ran=(clan p.bec)
+?:  ?=({?($earl $pawn)} ran)
+  "can't create a moon from a {?:(?=($earl ran) "moon" "comet")}"
 =+  mon=(mix (lsh 5 1 (end 5 1 eny)) p.bec)
 =+  tic=.^(@ /a/(scot %p p.bec)/tick/(scot %da now)/(scot %p mon))
 "moon: {<`@p`mon>}; ticket: {<`@p`tic>}"


### PR DESCRIPTION
...when run on a non-planet ship, such as a comet.

Some of the tutorials recommend creating a moon, and just print the stack trace isn't beginner-friendly.