### PR TITLE
fix sso crash

### DIFF
--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -1466,6 +1466,8 @@
     ++  foreign-hat
       |=  {him/ship hat/hart}  ^+  ..ya
       ~|  way
+      ?.  (~(has by way) him)  :: XX crashes should be handled by ames
+        ~&(strange-auth+[way him hat] ..ya)
       =^  pul  hen  (~(got by way) him)
       =:  way       (~(del by way) him)
           dop       (~(put by dop) r.hat him)


### PR DESCRIPTION
Going to webtalk on ~tabbyn-falrud with a fakezod cookie caused repeated stack traces in the console (every thirty seconds or so).  @ohAitch gave me a fix.