### PR TITLE
adds support for meta (alt) keyboard shortcuts

### DIFF
--- a/app/hood.hoon
+++ b/app/hood.hoon
@@ -1,14 +1,14 @@
 ::                                                      ::  ::
 ::::  /hoon/hood/app                                    ::  ::
   ::                                                    ::  ::
-/?    310                                                 ::  zuse version
+/?    310                                               ::  zuse version
 /+  sole, talk, helm, kiln, drum, write                 ::  libraries
 [. helm kiln drum]
 ::                                                      ::  ::
 ::::                                                    ::  ::
   !:                                                    ::  ::
 =>  |%                                                  ::  module boilerplate
-    ++  hood-0                                          :: 
+    ++  hood-0                                          ::
       {$0 lac/(map @tas hood-part)}                     ::
     ++  hood-good                                       ::
       |*  hed/hood-head                                 ::
@@ -19,17 +19,27 @@
         $kiln  ?>(?=($kiln -.paw) `kiln-part`paw)       ::
         $write  ?>(?=($write -.paw) `part:write`paw)    ::
       ==                                                ::
-    ++  hood-head  _-:*hood-part                     ::
+    ++  hood-head  _-:*hood-part                        ::
     ++  hood-make                                       ::
       |*  {our/@p hed/hood-head}                        ::
       ?-  hed                                           ::
-        $drum  (drum-port our)                          ::
+        $drum  (drum-make our)                          ::
         $helm  *helm-part                               ::
         $kiln  *kiln-part                               ::
-         $write  *part:write                             ::
+        $write  *part:write                             ::
       ==                                                ::
+    ++  hood-part-old                                   ::
+      $?  hood-part                                     ::
+          {$drum $0 drum-pith-0}                        ::
+      ==                                                ::
+    ++  hood-port                                       ::
+      |=  paw/hood-part-old  ^-  hood-part              ::
+      ?+  -.paw  paw                                    ::
+        $drum    (drum-port paw)                        ::
+      ==                                                ::
+    ::                                                  ::
     ++  hood-part                                       ::
-      $%  {$drum $0 drum-pith}                          ::
+      $%  {$drum $1 drum-pith}                          ::
           {$helm $0 helm-pith}                          ::
           {$kiln $0 kiln-pith}                          ::
           {$write $0 pith:write}                        ::
@@ -53,6 +63,12 @@
 ::                                                      ::  ::
 ::::                                                    ::  ::
   ::                                                    ::  ::
+++  prep                                                ::
+  |=  old/(unit hood-0)  ^-  (quip _!! +>)
+  :-  ~
+  ?~  old  +>
+  +>(lac (~(run by lac.u.old) hood-port))
+::
 ++  coup-kiln-fancy  (wrap take-coup-fancy):from-kiln
 ++  coup-kiln-spam                                      ::
   |=  {way/wire saw/(unit tang)}

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -698,7 +698,19 @@
     =.  +>  (ta-dog(say.inp (~(commit sole say.inp) ted)) ted)
     +>
   ::
-  ++  alnum
+  ++  lcas                                            ::  lowercase
+    |*  a/(list @)
+    ^+  a
+    %+  turn  a
+    |=(a/@ ?.(&((gte a 'A') (lte a 'Z')) a (add 32 a)))
+  ::
+  ++  ucas                                            ::  uppercase
+    |*  a/(list @)
+    ^+  a
+    %+  turn  a
+    |=(a/@ ?.(&((gte a 'a') (lte a 'z')) a (sub a 32)))
+  ::
+  ++  alnm
     |=  a/@  ^-  ?
     ?|  &((gte a '0') (lte a '9'))
         &((gte a 'A') (lte a 'Z'))
@@ -707,10 +719,11 @@
   ::
   ++  next-edge
     |=  buf/(list @c)
-    =+  [i=0 m=|]
-    |-  ^-  @ud
+    =|  i/@ud
+    =+  m=|
+    |-  ^+  i
     ?~  buf  i
-    =+  w=(alnum i.buf)
+    =+  w=(alnm i.buf)
     =.  m  |(m w)
     ?:  &(m !|(=(0 i) w))
       i
@@ -718,9 +731,9 @@
   ::
   ++  next-word
     |=  buf/(list @c)
-    =+  i=0
-    |-  ^-  @ud
-    ?:  |(?=($~ buf) (alnum i.buf))
+    =|  i/@ud
+    |-  ^+  i
+    ?:  |(?=($~ buf) (alnm i.buf))
       i
     $(i +(i), buf t.buf)
   ::
@@ -761,7 +774,7 @@
             :~  %mor
               [%del sop]
               :+  %ins  sop
-              (turf (cuss [(tuft (snag sop buf.say.inp))]~))
+              (head (ucas (limo [(snag sop buf.say.inp)]~)))
             ==
             ::
       $d    ?:  =(pos.inp (lent buf.say.inp))
@@ -793,13 +806,13 @@
       ?($u $l)
             ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            =+  case=?:(?=($u key) cuss cass)
+            =+  case=?:(?=($u key) ucas lcas)
             =+  sop=(add pos.inp (next-word (slag pos.inp buf.say.inp)))
             =+  f=(jump-fwrd sop buf.say.inp)
             %-  ta-hom
             :~  %mor
               (ta-cut sop (sub f pos.inp))
-              (ta-cat sop (tuba (trip (case (tufa (slag sop (scag f buf.say.inp)))))))
+              (ta-cat sop (case (slag sop (scag f buf.say.inp))))
             ==
     ==
   ::

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -710,42 +710,42 @@
     %+  turn  a
     |=(a/@ ?.(&((gte a 'a') (lte a 'z')) a (sub a 32)))
   ::
-  ++  alnm
+  ++  alnm                                            ::  alpha-numeric
     |=  a/@  ^-  ?
     ?|  &((gte a '0') (lte a '9'))
         &((gte a 'A') (lte a 'Z'))
         &((gte a 'a') (lte a 'z'))
     ==
   ::
-  ++  next-edge
-    |=  buf/(list @c)
+  ++  nedg                                            ::  next boundary offset
+    |=  a/(list @)
     =|  i/@ud
-    =+  m=|
+    =+  b=|
     |-  ^+  i
-    ?~  buf  i
-    =+  w=(alnm i.buf)
-    =.  m  |(m w)
-    ?:  &(m !|(=(0 i) w))
+    ?~  a  i
+    =+  c=(alnm i.a)
+    =.  b  |(b c)
+    ?:  &(b !|(=(0 i) c))
       i
-    $(i +(i), buf t.buf)
+    $(i +(i), a t.a)
   ::
-  ++  next-word
-    |=  buf/(list @c)
+  ++  nwrd                                            ::  word-offset
+    |=  a/(list @)
     =|  i/@ud
     |-  ^+  i
-    ?:  |(?=($~ buf) (alnm i.buf))
+    ?:  |(?=($~ a) (alnm i.a))
       i
-    $(i +(i), buf t.buf)
+    $(i +(i), a t.a)
   ::
-  ++  jump-bwrd
-    |=  {pos/@ud buf/(list @c)}
+  ++  bwrd                                            :: prev pos by offset
+    |=  {a/@ud b/(list @) c/$-((list @) @)}
     ^-  @ud
-    (sub pos (next-edge (flop (scag pos buf))))
+    (sub a (c (flop (scag a b))))
   ::
-  ++  jump-fwrd
-    |=  {pos/@ud buf/(list @c)}
+  ++  fwrd                                            :: next pos by offset
+    |=  {a/@ud b/(list @) c/$-((list @) @)}
     ^-  @ud
-    (add pos (next-edge (slag pos buf)))
+    (add a (c (slag a b)))
   ::
   ++  ta-met                                          ::  meta key
     |=  key/@ud
@@ -753,24 +753,24 @@
       $dot  ?.  &(?=(^ old.hit) ?=(^ -.old.hit))
               ta-bel
             =+  old=`(list @c)`-.old.hit
-            =+  b=(jump-bwrd (lent old) old)
+            =+  b=(bwrd (lent old) old nedg)
             %-  ta-hom(ris ~)
             (ta-cat pos.inp (slag b old))
             ::
       $bac  ?:  =(0 pos.inp)
               ta-bel
-            =+  b=(jump-bwrd pos.inp buf.say.inp)
+            =+  b=(bwrd pos.inp buf.say.inp nedg)
             %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
             (ta-cut b (sub pos.inp b))
             ::
       $b    ?:  =(0 pos.inp)
               ta-bel
-            +>(pos.inp (jump-bwrd pos.inp buf.say.inp))
+            +>(pos.inp (bwrd pos.inp buf.say.inp nedg))
             ::
       $c    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            =+  sop=(add pos.inp (next-word (slag pos.inp buf.say.inp)))
-            %-  ta-hom(pos.inp (jump-fwrd sop buf.say.inp))
+            =+  sop=(fwrd pos.inp buf.say.inp nwrd)
+            %-  ta-hom(pos.inp (fwrd sop buf.say.inp nedg))
             :~  %mor
               [%del sop]
               :+  %ins  sop
@@ -779,13 +779,13 @@
             ::
       $d    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            =+  f=(jump-fwrd pos.inp buf.say.inp)
+            =+  f=(fwrd pos.inp buf.say.inp nedg)
             %-  ta-hom(kil `(slag pos.inp (scag f buf.say.inp)), ris ~)
             (ta-cut pos.inp (sub f pos.inp))
             ::
       $f    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            +>(pos.inp (jump-fwrd pos.inp buf.say.inp))
+            +>(pos.inp (fwrd pos.inp buf.say.inp nedg))
             ::
       $r    %-  ta-hom(lay.hit (~(put by lay.hit) pos.hit ~))
             :~  %mor
@@ -795,12 +795,12 @@
               (snag (sub num.hit +(pos.hit)) old.hit)
             ==
             ::
-      $t    =+  a=(jump-fwrd pos.inp buf.say.inp)
-            =+  b=(jump-bwrd a buf.say.inp)
-            =+  c=(jump-bwrd b buf.say.inp)
+      $t    =+  a=(fwrd pos.inp buf.say.inp nedg)
+            =+  b=(bwrd a buf.say.inp nedg)
+            =+  c=(bwrd b buf.say.inp nedg)
             ?:  =(b c)
               ta-bel
-            =+  prev=`(pair @ud @ud)`[c (jump-fwrd c buf.say.inp)]
+            =+  prev=`(pair @ud @ud)`[c (fwrd c buf.say.inp nedg)]
             =+  next=`(pair @ud @ud)`[b a]
             %-  ta-hom(pos.inp q.next)
             :~  %mor
@@ -814,8 +814,8 @@
             ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             =+  case=?:(?=($u key) ucas lcas)
-            =+  sop=(add pos.inp (next-word (slag pos.inp buf.say.inp)))
-            =+  f=(jump-fwrd sop buf.say.inp)
+            =+  sop=(fwrd pos.inp buf.say.inp nwrd)
+            =+  f=(fwrd sop buf.say.inp nedg)
             %-  ta-hom
             :~  %mor
               (ta-cut sop (sub f pos.inp))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -698,10 +698,66 @@
     =.  +>  (ta-dog(say.inp (~(commit sole say.inp) ted)) ted)
     +>
   ::
+  ++  alnum
+    |=  a/@c  ^-  ?
+    ?|  &((gte a 48) (lte a 57))                      ::  0-9
+        &((gte a 65) (lte a 90))                      ::  A-Z
+        &((gte a 97) (lte a 122))                     ::  a-z
+    ==
+  ::
+  ++  next-word-pos
+    |=  buf/(list @c)
+    =+  i=0
+    |-  ^-  @ud
+    ?:  |(?=($~ buf) !|(=(0 i) (alnum i.buf)))
+      i
+    $(i +(i), buf t.buf)
+  ::
+  ++  jump-bwrd
+    |=  {pos/@ud buf/(list @c)}
+    ^-  @ud
+    (sub pos (next-word-pos (flop (scag pos buf))))
+  ::
+  ++  jump-fwrd
+    |=  {pos/@ud buf/(list @c)}
+    ^-  @ud
+    (add pos (next-word-pos (slag pos buf)))
+  ::
   ++  ta-met                                          ::  meta key
     |=  key/@ud
-    ~&  [%ta-met key]
-    +>
+    ?.  ?=(?($b $d $f) key)
+      ~&  [%ta-met key]
+      +>
+    ?-    key
+      :: ::
+      :: ::  TODO: meta dot
+      :: ::
+      :: ??  ?.  &(?=(^ old.hit) ?=(^ -.old.hit))
+      ::       ta-bel
+      ::     =+  old=`(list @c)`-.old.hit
+      ::     %-  ta-hom(ris ~)
+      ::     (ta-cat pos.inp (slag (jump-bwrd (dec (lent old)) old) old))
+      :: ::
+      :: ::  TODO: meta backspace
+      :: ::
+      :: ??  ?:  =(0 pos.inp)
+      ::       ta-bel
+      ::     =+  b=(jump-bwrd pos.inp buf.say.inp)
+      ::     %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
+      ::     (ta-cut b (sub pos.inp b))
+      :: ::
+      $b  ?:  =(0 pos.inp)
+            ta-bel
+          +>(pos.inp (jump-bwrd pos.inp buf.say.inp))
+      $d  ?:  =(pos.inp (lent buf.say.inp))
+            ta-bel
+          =+  f=(jump-fwrd pos.inp buf.say.inp)
+          %-  ta-hom(kil `(slag pos.inp (scag f buf.say.inp)), ris ~)
+          (ta-cut pos.inp (sub f pos.inp))
+      $f  ?:  =(pos.inp (lent buf.say.inp))
+            ta-bel
+          +>(pos.inp (jump-fwrd pos.inp buf.say.inp))
+    ==
   ::
   ++  ta-mov                                          ::  move in history
     |=  sop/@ud

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -623,6 +623,11 @@
             %-  ta-hom(kil `(scag pos.inp buf.say.inp), ris ~)
             (ta-cut 0 pos.inp)
         $v  ta-bel
+        $w  ?:  =(0 pos.inp)
+              ta-bel
+            =+  b=(bwrd pos.inp buf.say.inp nace)
+            %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
+            (ta-cut b (sub pos.inp b))
         $x  +>(+> se-anon)
         $y  ?~  kil  ta-bel
             (ta-hom(ris ~) (ta-cat pos.inp u.kil))
@@ -716,6 +721,18 @@
         &((gte a 'A') (lte a 'Z'))
         &((gte a 'a') (lte a 'z'))
     ==
+  ::
+  ++  nace                                            ::  next ace offset
+    |=  a/(list @)
+    =|  i/@ud
+    =+  b=|
+    |-  ^+  i
+    ?~  a  i
+    =+  c=.=(32 i.a)
+    =.  b  |(b c)
+    ?:  &(b !|(=(0 i) c))
+      i
+    $(i +(i), a t.a)
   ::
   ++  nedg                                            ::  next boundary offset
     |=  a/(list @)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -775,7 +775,20 @@
             +>(pos.inp (jump-fwrd pos.inp buf.say.inp))
             ::
       $r    ta-bel
-      $t    ta-bel
+      $t    =+  a=(jump-fwrd pos.inp buf.say.inp)
+            =+  b=(jump-bwrd a buf.say.inp)
+            =+  c=(jump-bwrd b buf.say.inp)
+            ?:  =(b c)
+              ta-bel
+            =+  prev=`(pair @ud @ud)`[c (jump-fwrd c buf.say.inp)]
+            =+  next=`(pair @ud @ud)`[b a]
+            %-  ta-hom(pos.inp q.next)
+            :~  %mor
+              (ta-cut p.next (sub q.next p.next))
+              (ta-cat p.next (slag p.prev (scag q.prev buf.say.inp)))
+              (ta-cut p.prev (sub q.prev p.prev))
+              (ta-cat p.prev (slag p.next (scag q.next buf.say.inp)))
+            ==
             ::
       ?($u $l)
             ?:  =(pos.inp (lent buf.say.inp))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -11,8 +11,8 @@
 |%                                                      ::  ::
 ++  drum-part  {$drum $0 drum-pith}                     ::
 ++  drum-pith                                           ::
-  $:  eel/(set gill)                                    ::  connect to 
-      ray/(set well)                                    ::  
+  $:  eel/(set gill)                                    ::  connect to
+      ray/(set well)                                    ::
       fur/(map dude (unit server))                      ::  servers
       bin/(map bone source)                             ::  terminals
   ==                                                    ::
@@ -93,7 +93,7 @@
 ::
 ++  deft-pipe                                           ::  default source
   |=  our/ship                                          ::
-  ^-  source                                            ::  
+  ^-  source                                            ::
   :*  80                                                ::  edg
       0                                                 ::  off
       ~                                                 ::  kil
@@ -105,7 +105,7 @@
 ++  deft-tart  *target                                  ::  default target
 ++  drum-port                                           ::  initial part
   |=  our/ship
-  ^-  drum-part 
+  ^-  drum-part
   :*  %drum
       %0
       (deft-fish our)                                   ::  eel
@@ -147,7 +147,7 @@
     --
 |_  {moz/(list move) biz/(list dill-blit)}
 ++  diff-sole-effect-phat                             ::
-  |=  {way/wire fec/sole-effect}  
+  |=  {way/wire fec/sole-effect}
   =<  se-abet  =<  se-view
   =+  gyl=(drum-phat way)
   ?:  (se-aint gyl)  +>.$
@@ -164,12 +164,12 @@
   se-view:(se-text "[{<src>}, driving {<our>}]")
 ::
 ++  poke-dill-belt                                    ::
-  |=  bet/dill-belt   
+  |=  bet/dill-belt
   =<  se-abet  =<  se-view
   (se-belt bet)
 ::
 ++  poke-start                                        ::
-  |=  wel/well  
+  |=  wel/well
   =<  se-abet  =<  se-view
   (se-born wel)
 ::
@@ -187,7 +187,7 @@
 ::   |=(~ se-abet:(se-blit `dill-blit`[%qit ~]))  ::  XX find bone
 :: ::
 ++  reap-phat                                         ::
-  |=  {way/wire saw/(unit tang)}  
+  |=  {way/wire saw/(unit tang)}
   =<  se-abet  =<  se-view
   =+  gyl=(drum-phat way)
   ?~  saw
@@ -195,7 +195,7 @@
   (se-dump:(se-drop & gyl) u.saw)
 ::
 ++  take-coup-phat                                    ::
-  |=  {way/wire saw/(unit tang)}  
+  |=  {way/wire saw/(unit tang)}
   =<  se-abet  =<  se-view
   ?~  saw  +>
   =+  gyl=(drum-phat way)
@@ -204,7 +204,7 @@
   (se-dump:(se-drop & gyl) u.saw)
 ::
 ++  take-onto                                         ::
-  |=  {way/wire saw/(each suss tang)}  
+  |=  {way/wire saw/(each suss tang)}
   =<  se-abet  =<  se-view
   ?>  ?=({@ @ $~} way)
   ?>  (~(has by fur) i.t.way)
@@ -213,11 +213,11 @@
     $|  (se-dump p.saw)
     $&  ?>  =(q.wel p.p.saw)
         ::  =.  +>.$  (se-text "live {<p.saw>}")
-        +>.$(fur (~(put by fur) q.wel `[p.wel %da r.p.saw]))  
-  == 
+        +>.$(fur (~(put by fur) q.wel `[p.wel %da r.p.saw]))
+  ==
 ::
 ++  quit-phat                                         ::
-  |=  way/wire  
+  |=  way/wire
   =<  se-abet  =<  se-view
   =+  gyl=(drum-phat way)
   ~&  [%drum-quit src ost gyl]
@@ -233,7 +233,7 @@
   =.  .  se-subze:se-adze:se-adit
   :_  %_(+>+>+<+ bin (~(put by bin) ost `source`+>+<))
   ^-  (list move)
-  %+  welp  (flop moz) 
+  %+  welp  (flop moz)
   ^-  (list move)
   ?~  biz  ~
   [ost %diff %dill-blit ?~(t.biz i.biz [%mor (flop biz)])]~
@@ -245,7 +245,7 @@
   =<  .(con +>)
   |=  {wel/well con/_..se-adit}  ^+  con
   =.  +>.$  con
-  =+  hig=(~(get by fur) q.wel) 
+  =+  hig=(~(get by fur) q.wel)
   ?:  &(?=(^ hig) |(?=($~ u.hig) =(p.wel syd.u.u.hig)))  +>.$
   =.  +>.$  (se-text "activated app {(trip p.wel)}/{(trip q.wel)}")
   %-  se-emit(fur (~(put by fur) q.wel ~))
@@ -353,7 +353,7 @@
   ?.  (~(has by fug) gyl)  +>.$
   =.  fug  (~(del by fug) gyl)
   =.  eel  ?.(pej eel (~(del in eel) gyl))
-  =.  +>.$  ?.  &(?=(^ lag) !=(gyl u.lag))  
+  =.  +>.$  ?.  &(?=(^ lag) !=(gyl u.lag))
               +>.$(inx 0)
             (se-alas u.lag)
   =.  +>.$  (se-text "[unlinked from {<gyl>}]")
@@ -393,7 +393,7 @@
 ++  se-like                                           ::  act in master
   |=  kus/ukase
   ?-    -.kus
-      $add  
+      $add
     |-  ^+  +>.^$
     ?~  p.kus  +>.^$
     $(p.kus t.p.kus, +>.^$ (se-link i.p.kus))
@@ -453,7 +453,7 @@
   =.  +>  ?:(=(p.mir p.lin) +> (se-blit %hop p.lin))
   +>(mir lin)
 ::
-++  se-just                                           ::  adjusted buffer 
+++  se-just                                           ::  adjusted buffer
   |=  lin/(pair @ud (list @c))
   ^+  +>
   =.  off  ?:((lth p.lin edg) 0 (sub p.lin edg))
@@ -472,8 +472,8 @@
   |=  mov/move
   %_(+> moz [mov moz])
 ::
-++  se-talk  
-  |=  tac/(list tank) 
+++  se-talk
+  |=  tac/(list tank)
   ^+  +>
   :: XX talk should be usable for stack traces, see urbit#584 which this change
   :: closed for the problems there
@@ -516,7 +516,7 @@
       ==                                              ::
   ++  ta-abet                                         ::  resolve
     ^+  ..ta
-    ?.  liv  
+    ?.  liv
       ?:   (~(has in (deft-fish our)) gyl)
         (se-blit qit+~)
       (se-nuke gyl)
@@ -534,7 +534,7 @@
     ^+  +>
     ?-  key
       $d  =.  ris  ~
-          ?.  =(num.hit pos.hit) 
+          ?.  =(num.hit pos.hit)
             (ta-mov +(pos.hit))
           ?:  =(0 (lent buf.say.inp))
             ta-bel
@@ -596,21 +596,21 @@
             (ta-hom(pos.hit num.hit, ris ~) [%set ~])
         $k  =+  len=(lent buf.say.inp)
             ?:  =(pos.inp len)
-              ta-bel 
+              ta-bel
             %-  ta-hom(kil `(slag pos.inp buf.say.inp), ris ~)
             (ta-cut pos.inp (sub len pos.inp))
         $l  +>(+> (se-blit %clr ~))
         $n  (ta-aro %d)
         $p  (ta-aro %u)
-        $r  ?~  ris 
-              +>(ris `[pos.hit ~]) 
+        $r  ?~  ris
+              +>(ris `[pos.hit ~])
             ?:  =(0 pos.u.ris)
               ta-bel
             (ta-ser ~)
         $t  =+  len=(lent buf.say.inp)
             ?:  |(=(0 pos.inp) (lth len 2))
               ta-bel
-            =+  sop=?:(=(len pos.inp) (dec pos.inp) pos.inp) 
+            =+  sop=?:(=(len pos.inp) (dec pos.inp) pos.inp)
             =.  pos.inp  +(sop)
             =.  ris  ~
             %-  ta-hom
@@ -640,7 +640,7 @@
     (ta-hom %del pos.inp)
   ::
   ++  ta-erl                                          ::  hear local error
-    |=  pos/@ud 
+    |=  pos/@ud
     ta-bel(pos.inp (min pos (lent buf.say.inp)))
   ::
   ++  ta-err                                          ::  hear remote error
@@ -829,8 +829,8 @@
     ?:  =(sop pos.hit)  +>
     %+  %=  ta-hom
           pos.hit  sop
-          lay.hit  %+  ~(put by lay.hit)  
-                     pos.hit 
+          lay.hit  %+  ~(put by lay.hit)
+                     pos.hit
                    buf.say.inp
         ==
       %set
@@ -870,7 +870,7 @@
             ?~(a & ?~(b | &(=(i.a i.b) $(a t.a, b t.b))))
         |=  {a/(list @c) b/(list @c)}  ^-  ?
         ?~(a & ?~(b | |((beg a b) $(b t.b))))
-    =+  ^=  sup  
+    =+  ^=  sup
         |-  ^-  (unit @ud)
         ?~  dol  ~
         ?:  (ser tot i.dol)
@@ -902,7 +902,7 @@
     ?^  ris
       %=    $
           ris  ~
-          cad.pom 
+          cad.pom
         :(welp "(reverse-i-search)'" (tufa str.u.ris) "': ")
       ==
     =-  [(add pos.inp (lent p.vew)) (weld (tuba p.vew) q.vew)]
@@ -917,8 +917,8 @@
             "> "
           ==
         ==
-    =+  len=(lent buf.say.inp) 
-    |-  ^-  (list @c) 
+    =+  len=(lent buf.say.inp)
+    |-  ^-  (list @c)
     ?:(=(0 len) ~ [`@c`'*' $(len (dec len))])
   --
 --

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -699,47 +699,49 @@
     +>
   ::
   ++  alnum
-    |=  a/@c  ^-  ?
-    ?|  &((gte a 48) (lte a 57))                      ::  0-9
-        &((gte a 65) (lte a 90))                      ::  A-Z
-        &((gte a 97) (lte a 122))                     ::  a-z
+    |=  a/@  ^-  ?
+    ?|  &((gte a '0') (lte a '9'))
+        &((gte a 'A') (lte a 'Z'))
+        &((gte a 'a') (lte a 'z'))
     ==
   ::
-  ++  next-word-pos
+  ++  next-edge
     |=  buf/(list @c)
-    =+  i=0
+    =+  [i=0 m=|]
     |-  ^-  @ud
-    ?:  |(?=($~ buf) !|(=(0 i) (alnum i.buf)))
+    ?~  buf  i
+    =+  w=(alnum i.buf)
+    =.  m  |(m w)
+    ?:  &(m !|(=(0 i) w))
       i
     $(i +(i), buf t.buf)
   ::
   ++  jump-bwrd
     |=  {pos/@ud buf/(list @c)}
     ^-  @ud
-    (sub pos (next-word-pos (flop (scag pos buf))))
+    (sub pos (next-edge (flop (scag pos buf))))
   ::
   ++  jump-fwrd
     |=  {pos/@ud buf/(list @c)}
     ^-  @ud
-    (add pos (next-word-pos (slag pos buf)))
+    (add pos (next-edge (slag pos buf)))
   ::
   ++  ta-met                                          ::  meta key
     |=  key/@ud
-    ?.  ?=(?($dot $bac $b $d $f) key)
-      ~&  [%ta-met key]
-      +>
-    ?-  key
+    ?+    key    ta-bel
       $dot  ?.  &(?=(^ old.hit) ?=(^ -.old.hit))
               ta-bel
             =+  old=`(list @c)`-.old.hit
             =+  b=(jump-bwrd (lent old) old)
             %-  ta-hom(ris ~)
             (ta-cat pos.inp (slag b old))
+            ::
       $bac  ?:  =(0 pos.inp)
               ta-bel
             =+  b=(jump-bwrd pos.inp buf.say.inp)
             %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
             (ta-cut b (sub pos.inp b))
+            ::
       $b    ?:  =(0 pos.inp)
               ta-bel
             +>(pos.inp (jump-bwrd pos.inp buf.say.inp))
@@ -748,6 +750,7 @@
             =+  f=(jump-fwrd pos.inp buf.say.inp)
             %-  ta-hom(kil `(slag pos.inp (scag f buf.say.inp)), ris ~)
             (ta-cut pos.inp (sub f pos.inp))
+            ::
       $f    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             +>(pos.inp (jump-fwrd pos.inp buf.say.inp))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -9,7 +9,15 @@
 ::::                                                    ::  ::
   ::                                                    ::  ::
 |%                                                      ::  ::
-++  drum-part  {$drum $0 drum-pith}                     ::
+++  drum-part  {$drum $1 drum-pith}                     ::
+++  drum-part-any                                       ::
+  $:  $drum                                             ::
+      $%  {$1 drum-pith}                                ::
+          {$0 drum-pith-0}                              ::
+  ==  ==                                                ::
+++  drum-pith-0                                         ::  old drum-pith
+  %+  cork  drum-pith  |=  drum-pith                    ::
+  +<(bin *(map bone source-0))                          ::
 ++  drum-pith                                           ::
   $:  eel/(set gill)                                    ::  connect to
       ray/(set well)                                    ::
@@ -24,10 +32,23 @@
   $:  syd/desk                                          ::  app identity
       cas/case                                          ::  boot case
   ==                                                    ::
+++  kill-0  (unit (list @c))                            ::  old kill buffer
+++  kill                                                ::  kill ring
+  $:  pos/@ud                                           ::  ring position
+      num/@ud                                           ::  number of entries
+      max/_60                                           ::  max entries
+      old/(list (list @c))                              ::  entries proper
+  ==                                                    ::
+++  source-0                                            ::  old source without
+  %+  cork  source  |=  source                          ::  kill ring or
+  %=  +<                                                ::  blt.target
+    kil  *kill-0                                        ::
+    fug  *(map gill (unit target-0))                    ::
+  ==                                                    ::
 ++  source                                              ::  input device
   $:  edg/_80                                           ::  terminal columns
       off/@ud                                           ::  window offset
-      kil/(unit (list @c))                              ::  kill buffer
+      kil/kill                                          ::  kill buffer
       inx/@ud                                           ::  ring index
       fug/(map gill (unit target))                      ::  connections
       mir/(pair @ud (list @c))                          ::  mirrored terminal
@@ -46,8 +67,11 @@
   $:  pos/@ud                                           ::  search position
       str/(list @c)                                     ::  search string
   ==                                                    ::
+++  target-0                                            ::  target without blt
+  (cork target |=(target |1.+<))                        ::
 ++  target                                              ::  application target
-  $:  ris/(unit search)                                 ::  reverse-i-search
+  $:  blt/(pair (unit dill-belt) (unit dill-belt))      ::  curr & prev belts
+      ris/(unit search)                                 ::  reverse-i-search
       hit/history                                       ::  all past input
       pom/sole-prompt                                   ::  static prompt
       inp/sole-command                                  ::  input state
@@ -85,6 +109,7 @@
   |=  our/ship
   ^-  master
   :*  %&
+      [~ ~]
       *(unit search)
       *history
       [%& %sole "{(scow %p our)}/ "]
@@ -96,23 +121,38 @@
   ^-  source                                            ::
   :*  80                                                ::  edg
       0                                                 ::  off
-      ~                                                 ::  kil
+      [0 0 60 ~]                                        ::  kil
       0                                                 ::  inx
       ~                                                 ::  fug
       [0 ~]                                             ::  mir
   ==
 ::
 ++  deft-tart  *target                                  ::  default target
-++  drum-port                                           ::  initial part
+++  drum-make                                           ::  initial part
   |=  our/ship
   ^-  drum-part
   :*  %drum
-      %0
+      %1
       (deft-fish our)                                   ::  eel
       (deft-apes our)                                   ::  ray
       ~                                                 ::  fur
       ~                                                 ::  bin
   ==                                                    ::
+::
+++  drum-port
+  |=  old/drum-part-any
+  ^-  drum-part
+  ?:  ?=($1 &2.old)  old
+  ~&  [%drum-porting &2.old]
+  =;  bin  [%drum %1 |2.old(bin bin)]
+  %-  ~(run by bin.old)
+  |=  source-0
+  %=  +<
+    kil  (kill ?~(kil ~ [1 1 60 [u.kil]~]))
+    fug  %-  ~(run by fug)
+         |=  t/(unit target-0)
+         ?~(t ~ [~ [[~ ~] u.t]])
+  ==
 ::
 ++  drum-path                                           ::  encode path
   |=  gyl/gill
@@ -326,6 +366,7 @@
   =+  tur=`(unit (unit target))`?~(gul ~ (~(get by fug) u.gul))
   ?:  |(=(~ gul) =(~ tur) =([~ ~] tur))  (se-blit %bel ~)
   =+  taz=~(. ta [& (need gul)] `target`(need (need tur)))
+  =.  blt.taz  [q.blt.taz `bet]
   =<  ta-abet
   ?-  -.bet
     $aro  (ta-aro:taz p.bet)
@@ -548,7 +589,8 @@
           ?:(=(0 pos.hit) ta-bel (ta-mov (dec pos.hit)))
     ==
   ::
-  ++  ta-bel  .(+> (se-blit %bel ~))                  ::  beep
+  ++  ta-bel                                          ::  beep
+    .(+> (se-blit %bel ~), q.blt ~)
   ++  ta-cat                                          ::  mass insert
     |=  {pos/@ud txt/(list @c)}
     ^-  sole-edit
@@ -580,6 +622,31 @@
     =+  pre=(dec pos.inp)
     (ta-hom %del pre)
   ::
+  ++  ta-kil                                          ::  build kil
+    |=  {a/?($l $r) b/(list @c)}
+    ^-  kill
+    =+  max=|=(a/(list (list @c)) (scag max.kil a))
+    ?.  ?&  ?=(^ p.blt)
+            ?|  ?=({$ctl p/?($k $u $w)} u.p.blt)
+                ?=({$met p/?($d $bac)} u.p.blt)
+        ==  ==
+      %=  kil
+        num  +(num.kil)
+        pos  +(num.kil)
+        old  (max [b old.kil])
+      ==
+    %=  kil
+      pos  num.kil
+      old  ?~  old.kil
+             [b]~
+           %-  max
+           :_  t.old.kil
+           ?-  a
+             $l  (welp b i.old.kil)
+             $r  (welp i.old.kil b)
+           ==
+    ==
+  ::
   ++  ta-ctl                                          ::  hear control
     |=  key/@ud
     ^+  +>
@@ -597,7 +664,10 @@
         $k  =+  len=(lent buf.say.inp)
             ?:  =(pos.inp len)
               ta-bel
-            %-  ta-hom(kil `(slag pos.inp buf.say.inp), ris ~)
+            %-  %=  ta-hom
+                  ris  ~
+                  kil  (ta-kil %r (slag pos.inp buf.say.inp))
+                ==
             (ta-cut pos.inp (sub len pos.inp))
         $l  +>(+> (se-blit %clr ~))
         $n  (ta-aro %d)
@@ -620,17 +690,25 @@
             ==
         $u  ?:  =(0 pos.inp)
               ta-bel
-            %-  ta-hom(kil `(scag pos.inp buf.say.inp), ris ~)
+            %-  %=  ta-hom
+                  ris  ~
+                  kil  (ta-kil %l (scag pos.inp buf.say.inp))
+                ==
             (ta-cut 0 pos.inp)
         $v  ta-bel
         $w  ?:  =(0 pos.inp)
               ta-bel
             =+  b=(bwrd pos.inp buf.say.inp nace)
-            %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
+            %-  %=  ta-hom
+                  ris  ~
+                  kil  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
+                ==
             (ta-cut b (sub pos.inp b))
         $x  +>(+> se-anon)
-        $y  ?~  kil  ta-bel
-            (ta-hom(ris ~) (ta-cat pos.inp u.kil))
+        $y  ?:  =(0 num.kil)
+              ta-bel
+            %-  ta-hom(ris ~)
+            (ta-cat pos.inp (snag (sub num.kil pos.kil) old.kil))
     ==
   ::
   ++  ta-cru                                          ::  hear crud
@@ -777,7 +855,10 @@
       $bac  ?:  =(0 pos.inp)
               ta-bel
             =+  b=(bwrd pos.inp buf.say.inp nedg)
-            %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
+            %-  %=  ta-hom
+                  ris  ~
+                  kil  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
+                ==
             (ta-cut b (sub pos.inp b))
             ::
       $b    ?:  =(0 pos.inp)
@@ -797,7 +878,10 @@
       $d    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             =+  f=(fwrd pos.inp buf.say.inp nedg)
-            %-  ta-hom(kil `(slag pos.inp (scag f buf.say.inp)), ris ~)
+            %-  %=  ta-hom
+                  ris  ~
+                  kil  (ta-kil %r (slag pos.inp (scag f buf.say.inp)))
+                ==
             (ta-cut pos.inp (sub f pos.inp))
             ::
       $f    ?:  =(pos.inp (lent buf.say.inp))
@@ -837,6 +921,21 @@
             :~  %mor
               (ta-cut sop (sub f pos.inp))
               (ta-cat sop (case (slag sop (scag f buf.say.inp))))
+            ==
+            ::
+      $y    ?.  ?&  (gth num.kil 0)
+                    ?=(^ p.blt)
+                    ?|  ?=({$ctl p/$y} u.p.blt)
+                        ?=({$met p/$y} u.p.blt)
+                ==  ==
+              ta-bel
+            =+  las=(lent (snag (sub num.kil pos.kil) old.kil))
+            =+  sop=(sub pos.inp las)
+            =+  pos=?:(=(1 pos.kil) num.kil (dec pos.kil))
+            %-  ta-hom(pos.kil pos, ris ~)
+            :~  %mor
+              (ta-cut sop las)
+              (ta-cat sop (snag (sub num.kil pos) old.kil))
             ==
     ==
   ::

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -716,6 +716,14 @@
       i
     $(i +(i), buf t.buf)
   ::
+  ++  next-word
+    |=  buf/(list @c)
+    =+  i=0
+    |-  ^-  @ud
+    ?:  |(?=($~ buf) (alnum i.buf))
+      i
+    $(i +(i), buf t.buf)
+  ::
   ++  jump-bwrd
     |=  {pos/@ud buf/(list @c)}
     ^-  @ud
@@ -745,6 +753,17 @@
       $b    ?:  =(0 pos.inp)
               ta-bel
             +>(pos.inp (jump-bwrd pos.inp buf.say.inp))
+            ::
+      $c    ?:  =(pos.inp (lent buf.say.inp))
+              ta-bel
+            =+  sop=(add pos.inp (next-word (slag pos.inp buf.say.inp)))
+            %-  ta-hom(pos.inp (jump-fwrd sop buf.say.inp))
+            :~  %mor
+              [%del sop]
+              :+  %ins  sop
+              (turf (cuss [(tuft (snag sop buf.say.inp))]~))
+            ==
+            ::
       $d    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             =+  f=(jump-fwrd pos.inp buf.say.inp)
@@ -754,6 +773,21 @@
       $f    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             +>(pos.inp (jump-fwrd pos.inp buf.say.inp))
+            ::
+      $r    ta-bel
+      $t    ta-bel
+            ::
+      ?($u $l)
+            ?:  =(pos.inp (lent buf.say.inp))
+              ta-bel
+            =+  case=?:(?=($u key) cuss cass)
+            =+  sop=(add pos.inp (next-word (slag pos.inp buf.say.inp)))
+            =+  f=(jump-fwrd sop buf.say.inp)
+            %-  ta-hom
+            :~  %mor
+              (ta-cut sop (sub f pos.inp))
+              (ta-cat sop (tuba (trip (case (tufa (slag sop (scag f buf.say.inp)))))))
+            ==
     ==
   ::
   ++  ta-mov                                          ::  move in history

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -787,7 +787,14 @@
               ta-bel
             +>(pos.inp (jump-fwrd pos.inp buf.say.inp))
             ::
-      $r    ta-bel
+      $r    %-  ta-hom(lay.hit (~(put by lay.hit) pos.hit ~))
+            :~  %mor
+              (ta-cut 0 (lent buf.say.inp))
+              %+  ta-cat  0
+              ?:  =(pos.hit num.hit)  ~
+              (snag (sub num.hit +(pos.hit)) old.hit)
+            ==
+            ::
       $t    =+  a=(jump-fwrd pos.inp buf.say.inp)
             =+  b=(jump-bwrd a buf.say.inp)
             =+  c=(jump-bwrd b buf.say.inp)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -725,38 +725,32 @@
   ::
   ++  ta-met                                          ::  meta key
     |=  key/@ud
-    ?.  ?=(?($b $d $f) key)
+    ?.  ?=(?($dot $bac $b $d $f) key)
       ~&  [%ta-met key]
       +>
-    ?-    key
-      :: ::
-      :: ::  TODO: meta dot
-      :: ::
-      :: ??  ?.  &(?=(^ old.hit) ?=(^ -.old.hit))
-      ::       ta-bel
-      ::     =+  old=`(list @c)`-.old.hit
-      ::     %-  ta-hom(ris ~)
-      ::     (ta-cat pos.inp (slag (jump-bwrd (dec (lent old)) old) old))
-      :: ::
-      :: ::  TODO: meta backspace
-      :: ::
-      :: ??  ?:  =(0 pos.inp)
-      ::       ta-bel
-      ::     =+  b=(jump-bwrd pos.inp buf.say.inp)
-      ::     %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
-      ::     (ta-cut b (sub pos.inp b))
-      :: ::
-      $b  ?:  =(0 pos.inp)
-            ta-bel
-          +>(pos.inp (jump-bwrd pos.inp buf.say.inp))
-      $d  ?:  =(pos.inp (lent buf.say.inp))
-            ta-bel
-          =+  f=(jump-fwrd pos.inp buf.say.inp)
-          %-  ta-hom(kil `(slag pos.inp (scag f buf.say.inp)), ris ~)
-          (ta-cut pos.inp (sub f pos.inp))
-      $f  ?:  =(pos.inp (lent buf.say.inp))
-            ta-bel
-          +>(pos.inp (jump-fwrd pos.inp buf.say.inp))
+    ?-  key
+      $dot  ?.  &(?=(^ old.hit) ?=(^ -.old.hit))
+              ta-bel
+            =+  old=`(list @c)`-.old.hit
+            =+  b=(jump-bwrd (lent old) old)
+            %-  ta-hom(ris ~)
+            (ta-cat pos.inp (slag b old))
+      $bac  ?:  =(0 pos.inp)
+              ta-bel
+            =+  b=(jump-bwrd pos.inp buf.say.inp)
+            %-  ta-hom(kil `(slag b (scag pos.inp buf.say.inp)), ris ~)
+            (ta-cut b (sub pos.inp b))
+      $b    ?:  =(0 pos.inp)
+              ta-bel
+            +>(pos.inp (jump-bwrd pos.inp buf.say.inp))
+      $d    ?:  =(pos.inp (lent buf.say.inp))
+              ta-bel
+            =+  f=(jump-fwrd pos.inp buf.say.inp)
+            %-  ta-hom(kil `(slag pos.inp (scag f buf.say.inp)), ris ~)
+            (ta-cut pos.inp (sub f pos.inp))
+      $f    ?:  =(pos.inp (lent buf.say.inp))
+              ta-bel
+            +>(pos.inp (jump-fwrd pos.inp buf.say.inp))
     ==
   ::
   ++  ta-mov                                          ::  move in history


### PR DESCRIPTION
Also adds implementations of meta-. and meta-backspace;  they're working (ie, tested with other keys), but commented out. Wiring them up will take changes to `dill-belt`, and the code-paths that construct instances of it. I tried changing `mar/dill/belt/hoon`, but it didn't seem to make a difference ...

Questions:

- where should the utility functions go (and how should they be named)?
- is there a better pattern to use in `++alnum`?
- what do I need to change to get meta+ backspace or `.` combinations into the `++ta-met` codepath?