### PR TITLE
Put robots.txt back in eyre :/

### DIFF
--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -1108,7 +1108,7 @@
           %^  resp  200  text+/plain
           %-  role
           :~  'User-agent: *'
-              'Disallow: /'
+              'Disallow: '
           ==
         ==
       ::

--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -1103,7 +1103,13 @@
           %^  resp  200  image+/png
           favi
         ::
-          ::  {$txt $robots $~}  !!
+            {$txt $robots $~}
+          :-  ~
+          %^  resp  200  text+/plain
+          %-  role
+          :~  'User-agent: *'
+              'Disallow: /'
+          ==
         ==
       ::
       ++  is-spur  |(?~(q.pok & ((sane %ta) i.q.pok)))

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: 


### PR DESCRIPTION
Upon review, /robots.txt is actually a magic web filename, which shouldn't interact with the tree frontend etc.
This PR keep the config change from "DENY" to "ALLOW"