### PR TITLE
disallow dup arms

### DIFF
--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -76,9 +76,6 @@
   $%  {$nice $~}                                        ::
       {$init p/ship}                                    ::
   ==                                                    ::
-++  sign-gall                                           ::  see %gall
-  $%  {$onto p/(unit tang)}                             ::
-  ==                                                    ::
 ++  sign-clay                                           ::
   $%  {$mere p/(each (set path) (pair term tang))}      ::
       {$note p/@tD q/tank}                              ::

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -778,24 +778,6 @@
   ^+  t.a
   [i.a $(a (skim t.a |=(c/_i.a !(b c i.a))))]
 ::
-++  spin
-  |*  {a/(list) b/_|=({* *} [** +<+]) c/*}
-  ::  ?<  ?=($-([_?<(?=($~ a) i.a) _c] [* _c]) b)
-  |-
-  ?~  a
-    ~
-  =+  v=(b i.a c)
-  [i=-.v t=$(a t.a, c +.v)]
-::
-++  spun
-  |*  {a/(list) b/_|=({* *} [** +<+])}
-  =|  c/_+<+.b
-  |-
-  ?~  a
-    ~
-  =+  v=(b i.a c)
-  [i=-.v t=$(a t.a, c +.v)]
-::
 ++  swag                                                ::  infix
   |*  {{a/@ b/@} c/(list)}
   (scag +<-> (slag +<-< c))
@@ -10079,7 +10061,16 @@
     ++  wisp                                            ::  core tail
       %-  ulva
       %+  cook
-        |=(a/(list {p/term q/foot}) (~(gas by *(map term foot)) a))
+        |=  a/(list {p/term q/foot})
+        =|  take/(set term)
+        =+  cur=a
+        |-
+          ?~  cur
+            (~(gas by *(map term foot) a))
+          ?:  (~(has in take) p.i.cur)
+            ~|  taken-name+p.i.cur
+            !!
+          $(take (~(put in take) p.i.cur), cur t.cur)
       (most muck boog)
     ::
     ++  toad                                            ::  untrap parser exp

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -1661,13 +1661,6 @@
               heg/(map hand code)                       ::  proposed
               qim/(map hand code)                       ::  inbound
           ==                                            ::
-++  coal  *                                             ::  untyped vase
-++  code  @uvI                                          ::  symmetric key
-++  cone                                                ::  reconfiguration
-          $%  {$& p/twig}                               ::  transform
-              {$| p/(list @tas)}                        ::  alter
-          ==                                            ::
-++  chum  @uvI                                          ::  hashed passcode
 ++  claw                                                ::  startup chain
           $:  joy/(unit coal)                           ::  local context
               ran/(unit coal)                           ::  arguments
@@ -1680,7 +1673,7 @@
 ++  coal  *                                             ::  untyped vase
 ++  code  @uvI                                          ::  symmetric key
 ++  cone                                                ::  reconfiguration
-          $%  {$& p/twig}                                ::  transform
+          $%  {$& p/twig}                               ::  transform
               {$| p/(list @tas)}                        ::  alter
           ==                                            ::
 ++  coop  (unit ares)                                   ::  e2e ack


### PR DESCRIPTION
Putting this in the issue tracker because I can't figure out why hoon.hoon nest-fails when it's integrated. (Ignore all the changes outside ++wisp, they're in error.)