### PR TITLE
Fix incremental fetching for stations already seen

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -122,6 +122,20 @@
         (runt [(sub len lez) '-'] nez)
       :(welp pre (scag (dec len) nez) "+")  
     ++  glyphs  `wall`~[">=+-" "}),." "\"'`^" "$%&@"]     :: station char pool
+    ++  peer-type                                       ::  stream requests
+      =<  apex
+      |%
+      ++  apex  ?($a-group $f-grams $v-glyph $x-cabal)  ::  options
+      ++  encode  |=(a/apex ^-(char (end 3 1 a)))       ::  by first char
+      ++  decode                                        ::  discriminate
+        |=  a/char  ^-  apex
+        ?+  a  ~|(bad-subscription-designator+a !!)
+          $a  %a-group
+          $f  %f-grams
+          $v  %v-glyph
+          $x  %x-cabal
+        ==
+      --
     --
 |_  {hid/bowl house}
 ++  ra                                                  ::  per transaction
@@ -313,7 +327,10 @@
       =<  sh-prod
       %_    .
           +>
-        (ra-subscribe:(ra-subscribe her.she ~) her.she [%afx man.she ~])
+        =/  typ
+          =+  (ly ~[%a-group %f-grams %x-cabal])
+          (rap 3 (turn - encode:peer-type))
+        (ra-subscribe:(ra-subscribe her.she ~) her.she [typ man.she ~])
       ==
     ::
     ++  sh-prod                                         ::  show prompt
@@ -1426,7 +1443,7 @@
       (ra-house(general (~(put in general) ost.hid)) ost.hid)
     ?.  ?=({@ @ *} pax)
       (ra-evil %talk-bad-path)
-    =+  vab=(~(gas in *(set @tas)) (rip 3 i.pax))
+    =+  vab=(~(gas in *(set peer-type)) (turn (rip 3 i.pax) decode:peer-type))
     =+  pur=(~(get by stories) i.t.pax)
     ?~  pur
       ~&  [%bad-subscribe-story-c i.t.pax]
@@ -1435,10 +1452,10 @@
     ?.  (pa-visible:soy her)
       (ra-evil %talk-no-story)
     =^  who  +>.$  (ra-human her)
-    =.  soy  ?.((~(has in vab) %a) soy (pa-watch-group:soy her))
-    =.  soy  ?.((~(has in vab) %v) soy (pa-watch-glyph:soy her))
-    =.  soy  ?.((~(has in vab) %x) soy (pa-watch-cabal:soy her))
-    =.  soy  ?.((~(has in vab) %f) soy (pa-watch-grams:soy her t.t.pax))
+    =.  soy  ?.((~(has in vab) %a-group) soy (pa-watch-group:soy her))
+    =.  soy  ?.((~(has in vab) %v-glyph) soy (pa-watch-glyph:soy her))
+    =.  soy  ?.((~(has in vab) %x-cabal) soy (pa-watch-cabal:soy her))
+    =.  soy  ?.((~(has in vab) %f-grams) soy (pa-watch-grams:soy her t.t.pax))
     =.  soy  (pa-notify:soy her %hear who)
     pa-abet:soy
   ::
@@ -1640,6 +1657,9 @@
       ^-  (list card)
       :: =+  num=(fall (~(get by sequence) tay) 0) :: XX unused
       =+  old=(sub now.hid ~d1)
+      =/  typ
+        =+  (ly ~[%a-group %f-grams %x-cabal])
+        (rap 3 (turn - encode:peer-type))
       ?-  -.tay
         $|  !!
         $&  ::  ~&  [%pa-acquire [our.hid man] [p.p.tay q.p.tay]]
@@ -1647,7 +1667,7 @@
             :*  %peer
                 /friend/show/[man]/(scot %p p.p.tay)/[q.p.tay]
                 [p.p.tay %talk] 
-                /afx/[q.p.tay]/(scot %da old)
+                /[typ]/[q.p.tay]/(scot %da old)
             ==
       ==
     ::

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1655,8 +1655,9 @@
       %+  turn  tal
       |=  tay/partner
       ^-  (list card)
-      :: =+  num=(fall (~(get by sequence) tay) 0) :: XX unused
-      =+  old=(sub now.hid ~d1)
+      =+  num=(~(get by sequence) tay)
+      =+  old=(sub now.hid ~d1)                         :: XX full backlog
+      =+  ini=?^(num (scot %ud u.num) (scot %da old))
       =/  typ
         =+  (ly ~[%a-group %f-grams %x-cabal])
         (rap 3 (turn - encode:peer-type))
@@ -1667,7 +1668,7 @@
             :*  %peer
                 /friend/show/[man]/(scot %p p.p.tay)/[q.p.tay]
                 [p.p.tay %talk] 
-                /[typ]/[q.p.tay]/(scot %da old)
+                /[typ]/[q.p.tay]/[ini]
             ==
       ==
     ::


### PR DESCRIPTION
I was wrong about subscription reconnections not pulling a day of backlog: they used to use the last-seen message number, defaulting to 0, but this was broken by the only-pull-last-day "fix". Changed so that pull-last-day is only used in the new-station case.