### PR TITLE
updates |cp and |mv to print errors without stacktraces

### DIFF
--- a/gen/hood/cp.hoon
+++ b/gen/hood/cp.hoon
@@ -6,10 +6,10 @@
 |=  {^ {input/path output/path $~} $~}
 :-  %kiln-info
 ?.  =(-:(flop input) -:(flop output))
-  ["Can't move to a different mark" *toro]
+  ["Can't move to a different mark" ~]
 =+  dir=.^(arch %cy input)
 ?~  fil.dir
   ~&  "No such file:"
-  [<input> *toro]
+  [<input> ~]
 :-  "copied"
-(foal output -:(flop input) [%atom %t ~] .^(* %cx input))    ::  XX type
+`(foal output -:(flop input) [%atom %t ~] .^(* %cx input))    ::  XX type

--- a/gen/hood/cp.hoon
+++ b/gen/hood/cp.hoon
@@ -4,13 +4,12 @@
 /?    310
 :-  %say
 |=  {^ {input/path output/path $~} $~}
+:-  %kiln-info
 ?.  =(-:(flop input) -:(flop output))
-  ~&  "Can't move to a different mark"
-  ~
+  ["Can't move to a different mark" *toro]
 =+  dir=.^(arch %cy input)
 ?~  fil.dir
   ~&  "No such file:"
-  ~&  <input>
-  ~
-:+  %kiln-info  "copied"
+  [<input> *toro]
+:-  "copied"
 (foal output -:(flop input) [%atom %t ~] .^(* %cx input))    ::  XX type

--- a/gen/hood/mv.hoon
+++ b/gen/hood/mv.hoon
@@ -4,14 +4,13 @@
 /?    310
 :-  %say
 |=  {^ {input/path output/path $~} $~}
+:-  %kiln-info
 ?.  =(-:(flop input) -:(flop output))
-  ~&  "Can't move to a different mark"
-  ~
+  ["Can't move to a different mark" *toro]
 =+  dir=.^(arch %cy input)
 ?~  fil.dir
   ~&  "No such file:"
-  ~&  <input>
-  ~
-:+  %kiln-info  "moved"
+  [<input> *toro]
+:-  "moved"
 %+  furl  (fray input)
 (foal output -:(flop input) [%noun .^(* %cx input)])

--- a/gen/hood/mv.hoon
+++ b/gen/hood/mv.hoon
@@ -6,11 +6,11 @@
 |=  {^ {input/path output/path $~} $~}
 :-  %kiln-info
 ?.  =(-:(flop input) -:(flop output))
-  ["Can't move to a different mark" *toro]
+  ["Can't move to a different mark" ~]
 =+  dir=.^(arch %cy input)
 ?~  fil.dir
   ~&  "No such file:"
-  [<input> *toro]
-:-  "moved"
+  [<input> ~]
+:-  "moved"  :-  ~
 %+  furl  (fray input)
 (foal output -:(flop input) [%noun .^(* %cx input)])

--- a/lib/kiln.hoon
+++ b/lib/kiln.hoon
@@ -47,8 +47,6 @@
         cas/case                                        ::
         gim/?($auto germ)                               ::
     ==                                                  ::
-++  kiln-cp  {input/path output/path}                   ::
-++  kiln-mv  {input/path output/path}                   ::
 --                                                      ::
 ::                                                      ::  ::
 ::::                                                    ::  ::

--- a/lib/kiln.hoon
+++ b/lib/kiln.hoon
@@ -154,8 +154,10 @@
   abet:(emit %drop /cancel our syd)
 ::
 ++  poke-info
-  |=  {mez/tape tor/toro}
-  abet:(emit:(spam leaf+mez ~) %info /kiln our tor)
+  |=  {mez/tape tor/(unit toro)}
+  ?~  tor
+    abet:(spam leaf+mez ~)
+  abet:(emit:(spam leaf+mez ~) %info /kiln our u.tor)
 ::
 ++  poke-rm
   |=  a/path
@@ -163,19 +165,19 @@
   ?~  fil.b
     =+  ~[leaf+"No such file:" leaf+"{<a>}"]
     abet:(spam -)
-  (poke-info "removed" (fray a))
+  (poke-info "removed" `(fray a))
 ::
 ++  poke-label
   |=  {syd/desk lab/@tas}
   =+  pax=/(scot %p our)/[syd]/[lab]
-  (poke-info "labeled {(spud pax)}" [syd %| lab])
+  (poke-info "labeled {(spud pax)}" `[syd %| lab])
 ::
 ++  poke-schedule
   |=  {where/path tym/@da eve/@t}
   =.  where  (welp where /sched)
   %+  poke-info  "scheduled"
   =+  old=;;((map @da cord) (fall (file where) ~))
-  (foal where %sched !>((~(put by old) tym eve)))
+  `(foal where %sched !>((~(put by old) tym eve)))
 ::
 ++  poke-autoload
   |=  lod/(unit ?)


### PR DESCRIPTION
As a follow-up to #203, this prints the error messages *without* stacktraces.

Note: I'm passing a bunted `++toro` along with the error messages, so that I can use `++poke-kiln-info` in `hood`. That bunted `toro` is included in the move that's passed to `++emit`, so it ends up in `moz`, the `kiln` state. If that's a problem, I could add a `++poke-kiln-error` or somesuch gate that doesn't produce a `move`.