### PR TITLE
Apply electroplating to roll and reel results.

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -951,7 +951,7 @@
       ::
       ++  glyph
         |=  idx/@
-        =<  cha.ole
+        =<  cha
         %+  reel  glyphs
         |=  {all/tape ole/{cha/char num/@}}
         =+  new=(snag (mod idx (lent all)) all)

--- a/arvo/behn.hoon
+++ b/arvo/behn.hoon
@@ -125,7 +125,7 @@
   ++  gas
     |=  b/(list {k/key n/val})
     ^+  a
-    q:(roll b |=({{k/key n/val} q/_a} (put(a q) k n)))
+    (roll b |=({{k/key n/val} q/_a} (put(a q) k n)))
   ::
   ++  tap
     ^-  (list {k/key n/val})

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -737,7 +737,7 @@
 ++  reel                                                ::  right fold
   ~/  %reel
   |*  {a/(list) b/_|=({* *} +<+)}
-  |-  ^+  +<+.b
+  |-  ^+  ,.+<+.b
   ?~  a
     +<+.b
   (b i.a $(a t.a))
@@ -745,7 +745,7 @@
 ++  roll                                                ::  left fold
   ~/  %roll
   |*  {a/(list) b/_|=({* *} +<+)}
-  |-  ^+  +<+.b
+  |-  ^+  ,.+<+.b
   ?~  a
     +<+.b
   $(a t.a, b b(+<+ (b i.a +<+.b)))
@@ -9480,7 +9480,7 @@
         =-  [a (welp - ?~(c d [[[%rock %tas p.c] q.c] d]))]
         =-  (~(tap by -))
         %.  |=(e/(list tank) [%knit ~(ram re %rose [" " `~] e)])
-        =<  ~(run by f:(reel b .))
+        =<  ~(run by (reel b .))
         |=  {e/{p/term q/term} f/(jar twig tank)}
         (~(add ja f) [%rock %tas p.e] [%leaf (trip q.e)])
       ;~  plug


### PR DESCRIPTION
This keeps the reducing gate's sample face from bleeding into the result span.

Before:

```
> (roll ~ add)
b=0
> (turn (roll ~ |=({a/* b/_(ly ~[42])} !!)) dec)
-find.i.a
```

After:

```
> (roll ~ add)
0
> (turn (roll ~ |=({a/* b/_(ly ~[42])} !!)) dec)
~[41]
```

I also did a quick grep through all existing uses of `roll` and `reel`, AFAICT the change only broke the three uses that I've updated in this PR.