### PR TITLE
:time app, measures time between poke and subsequent wakeup

### DIFF
--- a/app/time.hoon
+++ b/app/time.hoon
@@ -1,0 +1,19 @@
+::
+::::  /hoon/time/app
+  ::
+/?    310
+|%
+++  card  {$wait wire @da}
+--
+|_  {bowl $~}
+++  poke-noun
+  |=  *
+  :_  +>.$  :_  ~
+  [ost %wait /(scot %da now) +(now)]
+::
+++  wake
+  |=  {wir/wire $~}
+  ?>  ?=({@ $~} wir)
+  ~&  [%took `@dr`(sub now (slav %da i.wir))]
+  [~ +>.$]
+--


### PR DESCRIPTION
`:time expr` roughly measures the time it takes to compute `expr`. It's a very crude approximation because it includes the time it takes the kernel and gall to parse and route a value to the app and then wait for a wakeup, but it's easy enough to get a sense of that overhead (and its variation) by running `:time ~` a few times.