### PR TITLE
adds styled text molds to ++dill-blit and ++sole-effect

### DIFF
--- a/app/hood.hoon
+++ b/app/hood.hoon
@@ -32,7 +32,7 @@
         $womb  *part:womb                               ::
         $write  *part:write                             ::
       ==                                                ::
-    ++  hood-part-old  ?(hood-part)  :: drum-part-old   ::
+    ++  hood-part-old  ?(hood-part drum-part-old)       ::
     ++  hood-port                                       ::
       |=  paw/hood-part-old  ^-  hood-part              ::
       ?+  -.paw  paw                                    ::
@@ -40,7 +40,7 @@
       ==                                                ::
     ::                                                  ::
     ++  hood-part                                       ::
-      $%  {$drum $1 drum-pith-1}                        ::
+      $%  {$drum $2 drum-pith-2}                        ::
           {$helm $0 helm-pith}                          ::
           {$kiln $0 kiln-pith}                          ::
           {$womb $1 pith:womb}                          ::

--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -181,14 +181,8 @@
               [%hop pos]
           ==
         ?:  ?=($klr -.bit)
-          =/  out/(list @c)
-              %-  zing
-              %+  turn  p.bit
-              |=  a/_?>(?=(^ p.bit) i.p.bit)
-              ~&  [p.a (tufa q.a)]
-              q.a
           %+  done  %blit
-          :~  [%lin out]
+          :~  [%lin (cvrt:ansi p.bit)]
               [%mor ~]
               [%lin see]
               [%hop pos]
@@ -200,6 +194,40 @@
         ?:  ?=($qit -.bit)
           (dump %logo ~)
         (done %blit [bit ~])
+      ::
+      ++  ansi
+        |%
+        ++  cvrt
+          |=  a/stub
+          %-  zing
+          %+  turn  a
+          |=  a/(pair styd (list @c))
+          ^-  (list @c)
+          %-  zing  %-  limo
+          :~  ?:  =(0 ~(wyt in p.p.a))
+                ~
+              `(list @c)`(zing (turn (~(tap in p.p.a)) ef))
+              ::  (bg p.q.p.a)                          ::  XX: colors disabled
+              ::  (fg q.q.p.a)
+              q.a
+              ?~(p.p.a ~ (ef ~))
+              :: (bg ~)                                 ::  XX: colors disabled
+              :: (fg ~)
+          ==
+        ::
+        ++  ef  |=(a/^deco (scap (deco a)))
+        ++  bg  |=(a/^tint (scap (add 10 (tint a))))
+        ++  fg  |=(a/^tint (scap (tint a)))
+        ++  scap  |=(a/@ ((list @c) (limo ~[27 91 a 109])))
+        ::
+        ++  deco
+          |=  a/^deco
+          ?-(a $~ 48, $br 49, $un 52, $bl 53)
+        ::
+        ++  tint
+          |=  a/^tint
+          ?-(a $k 30, $r 31, $g 32, $y 33, $b 34, $m 35, $c 36, $w 37, $~ 39)
+        --
       ::
       ++  heft
         %_    .

--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -189,6 +189,9 @@
           ==
         ?:  ?=($pro -.bit)
           (done(see p.bit) %blit [[%lin p.bit] [%hop pos] ~])
+        ?:  ?=($pom -.bit)
+          =.  see  (cvrt:ansi p.bit)
+          (done %blit [[%lin see] [%hop pos] ~])
         ?:  ?=($hop -.bit)
           (done(pos p.bit) %blit [bit ~])
         ?:  ?=($qit -.bit)

--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -210,26 +210,49 @@
           :~  ?:  =(0 ~(wyt in p.p.a))
                 ~
               `(list @c)`(zing (turn (~(tap in p.p.a)) ef))
-              ::  (bg p.q.p.a)                          ::  XX: colors disabled
-              ::  (fg q.q.p.a)
+              (bg p.q.p.a)
+              (fg q.q.p.a)
               q.a
               ?~(p.p.a ~ (ef ~))
-              :: (bg ~)                                 ::  XX: colors disabled
-              :: (fg ~)
+              (bg ~)
+              (fg ~)
           ==
         ::
         ++  ef  |=(a/^deco (scap (deco a)))
-        ++  bg  |=(a/^tint (scap (add 10 (tint a))))
+        ++  bg  |=(a/^tint (scap =<([+(p) q] (tint a))))
         ++  fg  |=(a/^tint (scap (tint a)))
-        ++  scap  |=(a/@ ((list @c) (limo ~[27 91 a 109])))
+        ::
+        ++  scap
+          |=  a/$^((pair @ @) @)
+          %-  (list @c)                ::  XX: hard?
+          ?@  a
+            [27 91 a 109 ~]            ::  "\033[{a}m"
+          [27 91 p.a q.a 109 ~]
         ::
         ++  deco
           |=  a/^deco
-          ?-(a $~ 48, $br 49, $un 52, $bl 53)
+          ^-  @
+          ?-  a
+            $~   48  ::  0
+            $br  49  ::  1
+            $un  52  ::  4
+            $bl  53  ::  5
+          ==
         ::
         ++  tint
           |=  a/^tint
-          ?-(a $k 30, $r 31, $g 32, $y 33, $b 34, $m 35, $c 36, $w 37, $~ 39)
+          ^-  (pair @ @)
+          ?-  a
+            $k  [51 48]  ::  30
+            $r  [51 49]  ::  31
+            $g  [51 50]  ::  32
+            $y  [51 51]  ::  33
+            $b  [51 52]  ::  34
+            $m  [51 53]  ::  35
+            $c  [51 54]  ::  36
+            $w  [51 55]  ::  37
+            $~  [51 57]  ::  39
+          ==
         --
       ::
       ++  heft

--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -204,7 +204,7 @@
           |=  a/stub
           %-  zing
           %+  turn  a
-          |=  a/(pair styd (list @c))
+          |=  a/(pair stye (list @c))
           ^-  (list @c)
           %-  zing  %-  limo
           :~  ?:  =(0 ~(wyt in p.p.a))

--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -200,15 +200,14 @@
       ::
       ++  ansi
         |%
-        ++  cvrt
-          |=  a/stub
-          %-  zing
-          %+  turn  a
+        ++  cvrt                                        ::  stub to (list @c)
+          |=  a/stub                                    ::  with ANSI codes
+          ^-  (list @c)
+          %-  zing  %+  turn  a
           |=  a/(pair stye (list @c))
           ^-  (list @c)
-          %-  zing  %-  limo
-          :~  ?:  =(0 ~(wyt in p.p.a))
-                ~
+          ;:  weld
+              ?:  =(0 ~(wyt in p.p.a))  ~
               `(list @c)`(zing (turn (~(tap in p.p.a)) ef))
               (bg p.q.p.a)
               (fg q.q.p.a)
@@ -218,40 +217,44 @@
               (fg ~)
           ==
         ::
-        ++  ef  |=(a/^deco (scap (deco a)))
-        ++  bg  |=(a/^tint (scap =<([+(p) q] (tint a))))
-        ++  fg  |=(a/^tint (scap (tint a)))
+        ++  ef  |=(a/^deco (scap (deco a)))             ::  ANSI effect
         ::
-        ++  scap
+        ++  fg  |=(a/^tint (scap (tint a)))             ::  ANSI foreground
+        ::
+        ++  bg                                          ::  ANSI background
+          |=  a/^tint
+          %-  scap
+          =>((tint a) [+(p) q])                         ::  (add 10 fg)
+        ::
+        ++  scap                                        ::  ANSI escape seq
           |=  a/$^((pair @ @) @)
-          %-  (list @c)                ::  XX: hard?
-          ?@  a
-            [27 91 a 109 ~]            ::  "\033[{a}m"
-          [27 91 p.a q.a 109 ~]
+          %-  (list @c)
+          :+  27  '['                                   ::  "\033[{a}m"
+          ?@(a :~(a 'm') :~(p.a q.a 'm'))
         ::
-        ++  deco
-          |=  a/^deco
-          ^-  @
+        ++  deco                                        ::  ANSI effects
+          |=  a/^deco  ^-  @
           ?-  a
-            $~   48  ::  0
-            $br  49  ::  1
-            $un  52  ::  4
-            $bl  53  ::  5
+            $~   '0'
+            $br  '1'
+            $un  '4'
+            $bl  '5'
           ==
         ::
-        ++  tint
+        ++  tint                                        ::  ANSI colors (fg)
           |=  a/^tint
           ^-  (pair @ @)
+          :-  '3'
           ?-  a
-            $k  [51 48]  ::  30
-            $r  [51 49]  ::  31
-            $g  [51 50]  ::  32
-            $y  [51 51]  ::  33
-            $b  [51 52]  ::  34
-            $m  [51 53]  ::  35
-            $c  [51 54]  ::  36
-            $w  [51 55]  ::  37
-            $~  [51 57]  ::  39
+            $k  '0'
+            $r  '1'
+            $g  '2'
+            $y  '3'
+            $b  '4'
+            $m  '5'
+            $c  '6'
+            $w  '7'
+            $~  '9'
           ==
         --
       ::

--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -180,6 +180,19 @@
               [%lin see]
               [%hop pos]
           ==
+        ?:  ?=($klr -.bit)
+          =/  out/(list @c)
+              %-  zing
+              %+  turn  p.bit
+              |=  a/_?>(?=(^ p.bit) i.p.bit)
+              ~&  [p.a (tufa q.a)]
+              q.a
+          %+  done  %blit
+          :~  [%lin out]
+              [%mor ~]
+              [%lin see]
+              [%hop pos]
+          ==
         ?:  ?=($pro -.bit)
           (done(see p.bit) %blit [[%lin p.bit] [%hop pos] ~])
         ?:  ?=($hop -.bit)

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2610,10 +2610,10 @@
 ++  sock  {p/ship q/ship}                               ::  outgoing [from to]
 ++  spur  path                                          ::  ship desk case spur
 ++  step  {p/bray q/gens r/pass}                        ::  identity stage
-++  stub  (list (pair styd (list @c)))                  ::  styled tuba
-++  styd  (pair (set deco) (pair tint tint))            ::  decos/bg/fg
+++  stub  (list (pair stye (list @c)))                  ::  styled tuba
+++  stye  (pair (set deco) (pair tint tint))            ::  decos/bg/fg
 ++  styl                                                ::
-  (pair (unit deco) (pair (unit tint) (unit tint)))     ::  cascading styd
+  (pair (unit deco) (pair (unit tint) (unit tint)))     ::  cascading stye
 ++  styx  (list $@(@t (pair styl styx)))                ::  styled text
 ++  suba  (list {p/path q/misu})                        ::  delta
 ++  tako  @                                             ::  yaki ref

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2327,6 +2327,7 @@
               cip/(each @if @is)                        ::  client IP
               cum/(map @tas *)                          ::  custom dirt
           ==                                            ::
+++  deco  ?($~ $bl $br $un)                             ::  text decoration
 ++  deed  {p/@ q/step r/?}                              ::  sig stage fake?
 ++  dome                                                ::  project state
           $:  ank/ankh                                  ::  state
@@ -2609,9 +2610,15 @@
 ++  sock  {p/ship q/ship}                               ::  outgoing [from to]
 ++  spur  path                                          ::  ship desk case spur
 ++  step  {p/bray q/gens r/pass}                        ::  identity stage
+++  stub  (list (pair styd (list @c)))                  ::  styled tuba
+++  styd  (pair (set deco) (pair tint tint))            ::  decos/bg/fg
+++  styl                                                ::
+  (pair (unit deco) (pair (unit tint) (unit tint)))     ::  cascading styd
+++  styx  (list $@(@t (pair styl styx)))                ::  styled text
 ++  suba  (list {p/path q/misu})                        ::  delta
 ++  tako  @                                             ::  yaki ref
 ++  tick  @ud                                           ::  process id
+++  tint  ?($~ $r $g $b $c $m $y $k $w)                 ::  text color
 ++  toro  {p/@ta q/nori}                                ::  general change
 ++  town                                                ::  all security state
           $:  lit/@ud                                   ::  imperial modulus
@@ -2750,6 +2757,7 @@
 ++  dill-blit                                           ::  new blit
   $%  {$bel $~}                                         ::  make a noise
       {$clr $~}                                         ::  clear the screen
+      {$klr p/stub}                                     ::  styled text
       {$hop p/@ud}                                      ::  set cursor position
       {$mor p/(list dill-blit)}                         ::  multiple blits
       {$pro p/(list @c)}                                ::  show as cursor+line

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2761,6 +2761,7 @@
       {$hop p/@ud}                                      ::  set cursor position
       {$mor p/(list dill-blit)}                         ::  multiple blits
       {$pro p/(list @c)}                                ::  show as cursor+line
+      {$pom p/stub}                                     ::  styled prompt
       {$qit $~}                                         ::  close console
       {$out p/(list @c)}                                ::  send output line
       {$sag p/path q/*}                                 ::  save to jamfile

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -408,9 +408,53 @@
   |=  lin/(pair @ud stub)
   ^+  +>
   =.  off  ?:((lth p.lin edg) 0 (sub p.lin edg))
-  ::  XX: wrap q.lin??
-  ::  (se-show (sub p.lin off) (scag edg (slag off q.lin)))
-  (se-show (sub p.lin off) q.lin)
+  (se-show (sub p.lin off) (scag-stub edg (slag-stub off q.lin)))
+::
+++  lents-stub
+  |=  a/stub
+  %+  turn  a
+  |=  a/(pair styd (list @c))
+  %+  add
+    (lent (tail a))
+  =+  d=~(wyt in p.p.a)
+  (mul 4 ?:(=(0 d) 0 +(d)))
+::
+++  break-stub
+  |=  {a/(list @) b/@}
+  =|  {c/@ i/@}
+  |-  ^-  (unit (pair @ @))
+  ?~  a  ~
+  =.  c  (add i.a c)
+  ?:  (gte c b)
+    `[i c]
+  $(i +(i), a t.a)
+::
+++  slag-stub
+  |=  {a/@ b/stub}
+  ^-  stub
+  =+  c=(lents-stub b)
+  =+  i=(break-stub c a)
+  ?~  i  b
+  =+  r=(slag +(p.u.i) b)
+  ?:  =(a q.u.i)
+    r
+  =+  n=(snag p.u.i b)
+  :_  r  :-  p.n
+  (slag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
+::
+++  scag-stub
+  |=  {a/@ b/stub}
+  ^-  stub
+  =+  c=(lents-stub b)
+  =+  i=(break-stub c a)
+  ?~  i  b
+  ?:  =(a q.u.i)
+    (scag +(p.u.i) b)
+  %+  welp
+    (scag p.u.i b)
+  =+  n=(snag p.u.i b)
+  :_  ~  :-  p.n
+  (scag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
 ::
 ++  se-view                                           ::  flush buffer
   ^+  .
@@ -858,16 +902,8 @@
     ^-  (pair @ud stub)
     =;  vew/(pair (list @c) styx)
       =/  lin/stub
-        (flatten-styx q.vew)
-      =/  len
-        %-  (curr roll add)
-        %+  turn
-          lin
-        |=  a/(pair styd (list @c))
-        %+  add
-          (lent (tail a))
-        =+  d=~(wyt in p.p.a)
-        (mul 4 ?:(=(0 d) 0 +(d)))
+        (flatten-styx p.vew)
+      =+  len=((curr roll add) (lents-stub lin))
       [(add pos.inp len) (welp lin [*styd p.vew]~)]
     ?:  vis.pom
       :-  buf.say.inp                                 ::  default prompt

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -9,10 +9,18 @@
 ::::                                                    ::  ::
   ::                                                    ::  ::
 |%                                                      ::  ::
-++  drum-part  {$drum $1 drum-pith-1}                   ::
-++  drum-part-old  {$drum $0 drum-pith-0}               ::
-++  drum-pith-0  _!!                                    ::  forgotten
-++  drum-pith-1                                         ::
+++  drum-part      {$drum $2 drum-pith-2}               ::
+++  drum-part-old  {$drum $1 drum-pith-1}               ::
+::                                                      ::
+++  drum-pith-1                                         ::  pre-style
+  %+  cork  drum-pith-2                                 ::
+  |=(drum-pith-2 +<(bin *(map bone source-1)))          ::
+::                                                      ::
+++  source-1                                            ::
+  %+  cork  source                                      ::
+  |=(source +<(mir *(pair @ud (list @c))))              ::  style-less mir
+::                                                      ::
+++  drum-pith-2                                         ::
   $:  sys/(unit bone)                                   ::  local console
       eel/(set gill)                                    ::  connect to
       ray/(set well)                                    ::
@@ -38,7 +46,7 @@
       kil/kill                                          ::  kill buffer
       inx/@ud                                           ::  ring index
       fug/(map gill (unit target))                      ::  connections
-      mir/(pair @ud (list @c))                          ::  mirrored terminal
+      mir/(pair @ud stub)                               ::  mirrored terminal
   ==                                                    ::
 ++  history                                             ::  past input
   $:  pos/@ud                                           ::  input position
@@ -85,7 +93,7 @@
   |=  our/ship
   ^-  drum-part
   :*  %drum
-      %1
+      %2
       ~                                                 ::  sys
       (deft-fish our)                                   ::  eel
       (deft-apes our)                                   ::  ray
@@ -96,8 +104,13 @@
 ++  drum-port
   |=  old/?(drum-part drum-part-old)  ^-  drum-part
   ?-  &2.old
-    $1  old
-    $0  !!  :: XX unreachable, see issue #242
+    $2  old
+    $1  %=  old
+          &2   %2
+          bin  %-  ~(run by bin.old)
+               |=  source-1  ^-  source
+               +<(mir [(add 20 p.mir) [[*stye q.mir] ~]])
+        ==
   ==
 ::
 ++  drum-path                                           ::  encode path
@@ -384,18 +397,20 @@
   (se-emit [u.sys %diff %dill-blit bil])
 ::
 ++  se-show                                           ::  show buffer, raw
-  |=  lin/(pair @ud (list @c))
+  |=  lin/(pair @ud stub)
   ^+  +>
   ?:  =(mir lin)  +>
-  =.  +>  ?:(=(q.mir q.lin) +> (se-blit %pro q.lin))
+  =.  +>  ?:(=(q.mir q.lin) +> (se-blit %pom q.lin))
   =.  +>  ?:(=(p.mir p.lin) +> (se-blit %hop p.lin))
   +>(mir lin)
 ::
 ++  se-just                                           ::  adjusted buffer
-  |=  lin/(pair @ud (list @c))
+  |=  lin/(pair @ud stub)
   ^+  +>
   =.  off  ?:((lth p.lin edg) 0 (sub p.lin edg))
-  (se-show (sub p.lin off) (scag edg (slag off q.lin)))
+  ::  XX: wrap q.lin??
+  ::  (se-show (sub p.lin off) (scag edg (slag off q.lin)))
+  (se-show (sub p.lin off) q.lin)
 ::
 ++  se-view                                           ::  flush buffer
   ^+  .
@@ -576,36 +591,34 @@
     |=  pos/@ud
     (ta-erl (~(transpose sole say.inp) pos))
   ::
+  ++  flatten-styx
+    |=  a/styx
+    =|  b/styd
+    %+  reel
+    |-  ^-  stub
+    %-  zing
+    %+  turn  a
+    |=  a/$@(@t (pair styl styx))
+    ?@  a
+      [b (tuba (trip a))]~
+    %=  ^$
+      a  q.a
+      b  :+  ?~  p.p.a  p.b
+               ?~(u.p.p.a ~ (~(put in p.b) u.p.p.a))
+             ?~(p.q.p.a p.q.b u.p.q.p.a)
+             ?~(q.q.p.a q.q.b u.q.q.p.a)
+    ==
+    ::
+    |=  {a/(pair styd (list @c)) b/stub}
+    ?~  b
+      [a]~
+    ?.  =(p.a p.i.b)
+      [a b]
+    [[p.a (weld q.a q.i.b)] t.b]
+  ::
   ++  ta-klr                                          ::  render styled text
     |=  a/styx
-    =<  =.  +>+>.$  (se-klr (flatten a))
-        +>.$
-    |%
-    ++  flatten
-      |=  a/styx
-      =|  b/styd
-      %+  reel
-      |-  ^-  stub
-      %-  zing
-      %+  turn  a
-      |=  a/_?>(?=(^ a) i.a)
-      ?@  a
-        [b (tuba (trip a))]~
-      %=  ^$
-        a  q.a
-        b  :+  ?~  p.p.a  p.b
-                 ?~(u.p.p.a ~ (~(put in p.b) u.p.p.a))
-               ?~(p.q.p.a p.q.b u.p.q.p.a)
-               ?~(q.q.p.a q.q.b u.q.q.p.a)
-      ==
-      ::
-      |=  {a/(pair styd (list @c)) b/stub}
-      ?~  b
-        [a]~
-      ?.  =(p.a p.i.b)
-        [a b]
-      [[p.a (weld q.a q.i.b)] t.b]
-    --
+    +>(..ta (se-klr (flatten-styx a)))
   ::
   ++  ta-fec                                          ::  apply effect
     |=  fec/sole-effect
@@ -842,9 +855,20 @@
     (ta-hom (cat:edit pos.inp txt))
   ::
   ++  ta-vew                                          ::  computed prompt
-    |-  ^-  (pair @ud (list @c))
-    =;  vew/(pair (list @c) tape)
-      [(add pos.inp (lent q.vew)) (weld (tuba q.vew) p.vew)]
+    ^-  (pair @ud stub)
+    =;  vew/(pair (list @c) styx)
+      =/  lin/stub
+        (flatten-styx q.vew)
+      =/  len
+        %-  (curr roll add)
+        %+  turn
+          lin
+        |=  a/(pair styd (list @c))
+        %+  add
+          (lent (tail a))
+        =+  d=~(wyt in p.p.a)
+        (mul 4 ?:(=(0 d) 0 +(d)))
+      [(add pos.inp len) (welp lin [*styd p.vew]~)]
     ?:  vis.pom
       :-  buf.say.inp                                 ::  default prompt
       ?~  ris

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -421,6 +421,10 @@
   ?.  se-ably  (se-talk [%leaf txt]~)
   (se-blit %out (tuba txt))
 ::
+++  se-klr                                            ::  return styled text
+  |=  a/stub
+  ^+(+> (se-blit %klr a))
+::
 ++  se-poke                                           ::  send a poke
   |=  {gyl/gill par/pear}
   (se-emit [ost.hid %poke (drum-path gyl) gyl par])
@@ -572,6 +576,37 @@
     |=  pos/@ud
     (ta-erl (~(transpose sole say.inp) pos))
   ::
+  ++  ta-klr                                          ::  render styled text
+    |=  a/styx
+    =<  =.  +>+>.$  (se-klr (flatten a))
+        +>.$
+    |%
+    ++  flatten
+      |=  a/styx
+      =|  b/styd
+      %+  reel
+      |-  ^-  stub
+      %-  zing
+      %+  turn  a
+      |=  a/_?>(?=(^ a) i.a)
+      ?@  a
+        [b (tuba (trip a))]~
+      %=  ^$
+        a  q.a
+        b  :+  ?~  p.p.a  p.b
+                 ?~(u.p.p.a ~ (~(put in p.b) u.p.p.a))
+               ?~(p.q.p.a p.q.b u.p.q.p.a)
+               ?~(q.q.p.a q.q.b u.q.q.p.a)
+      ==
+      ::
+      |=  {a/(pair styd (list @c)) b/stub}
+      ?~  b
+        [a]~
+      ?.  =(p.a p.i.b)
+        [a b]
+      [[p.a (weld q.a q.i.b)] t.b]
+    --
+  ::
   ++  ta-fec                                          ::  apply effect
     |=  fec/sole-effect
     ^+  +>
@@ -581,6 +616,7 @@
       {$clr *}  +>(..ta (se-blit fec))
       {$det *}  (ta-got +.fec)
       {$err *}  (ta-err p.fec)
+      {$klr *}  (ta-klr p.fec)
       {$mor *}  |-  ^+  +>.^$
                 ?~  p.fec  +>.^$
                 $(p.fec t.p.fec, +>.^$ ^$(fec i.p.fec))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -905,29 +905,27 @@
 ++  klr                                               ::  styx/stub engine
   |%
   ++  make                                            ::  stub from styx
-    |=  a/styx
+    |=  a/styx  ^-  stub
     =|  b/stye
     %+  reel
     |-  ^-  stub
-    %-  zing
-    %+  turn  a
+    %-  zing  %+  turn  a
     |=  a/$@(@t (pair styl styx))
-    ?@  a
-      [b (tuba (trip a))]~
-    %=  ^$
-      a  q.a
-      b  :+  ?~  p.p.a  p.b
-               ?~(u.p.p.a ~ (~(put in p.b) u.p.p.a))
-             ?~(p.q.p.a p.q.b u.p.q.p.a)
-             ?~(q.q.p.a q.q.b u.q.q.p.a)
-    ==
+    ?@  a  [b (tuba (trip a))]~
+    ^$(a q.a, b (styd p.a b))
     ::
     |=  {a/(pair stye (list @c)) b/stub}
-    ?~  b
-      [a]~
-    ?.  =(p.a p.i.b)
-      [a b]
+    ?~  b  [a ~]
+    ?.  =(p.a p.i.b)  [a b]
     [[p.a (weld q.a q.i.b)] t.b]
+  ::
+  ++  styd                                            ::  stye from styl
+    |=  {a/styl b/stye}  ^+  b                        ::  with inheritance
+    :+  ?~  p.a  p.b
+        ?~  u.p.a  ~
+        (~(put in p.b) u.p.a)
+     (fall p.q.a p.q.b)
+     (fall q.q.a q.q.b)
   ::
   ++  lent-stye
     |=  a/stub  ^-  @

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -400,8 +400,8 @@
   |=  lin/(pair @ud stub)
   ^+  +>
   ?:  =(mir lin)  +>
+  =.  +>  ?:(=(p.mir p.lin) +> (se-blit %hop (add p.lin (lent-stye:klr q.lin))))
   =.  +>  ?:(=(q.mir q.lin) +> (se-blit %pom q.lin))
-  =.  +>  ?:(=(p.mir p.lin) +> (se-blit %hop p.lin))
   +>(mir lin)
 ::
 ++  se-just                                           ::  adjusted buffer
@@ -824,7 +824,7 @@
     =;  vew/(pair (list @c) styx)
       =+  lin=(make:klr q.vew)
       :_  (welp lin [*stye p.vew]~)
-      (add pos.inp (roll (lnts:klr lin) add))
+      (add pos.inp (lent-char:klr lin))
     ?:  vis.pom
       :-  buf.say.inp                                 ::  default prompt
       ?~  ris
@@ -929,14 +929,30 @@
       [a b]
     [[p.a (weld q.a q.i.b)] t.b]
   ::
-  ++  lnts                                            ::  stub pair lengths
-    |=  a/stub
+  ++  lent-stye
+    |=  a/stub  ^-  @
+    (roll (lnts-stye a) add)
+  ::
+  ++  lent-char
+    |=  a/stub  ^-  @
+    (roll (lnts-char a) add)
+  ::
+  ++  lnts-stye                                       ::  stub pair head lengths
+    |=  a/stub  ^-  (list @)
     %+  turn  a
     |=  a/(pair stye (list @c))
-    %+  add
-      (lent q.a)
-    =+  d=~(wyt in p.p.a)
-    (mul 4 ?:(=(0 d) 0 +(d)))
+    ;:  add                        ::  presumes impl of cvrt:ansi in %dill
+        (mul 5 2)                  ::  bg
+        (mul 5 2)                  ::  fg
+        =+  b=~(wyt in p.p.a)      ::  effect
+        ?:(=(0 b) 0 (mul 4 +(b)))
+    ==
+  ::
+  ++  lnts-char                                       ::  stub pair tail lengths
+    |=  a/stub  ^-  (list @)
+    %+  turn  a
+    |=  a/(pair stye (list @c))
+    (lent q.a)
   ::
   ++  brek                                            ::  index + incl-len of
     |=  {a/@ b/(list @)}                              ::  stub pair w/ idx a
@@ -951,7 +967,7 @@
   ++  slag                                            ::  slag stub, keep stye
     |=  {a/@ b/stub}
     ^-  stub
-    =+  c=(lnts b)
+    =+  c=(lnts-char b)
     =+  i=(brek a c)
     ?~  i  b
     =+  r=(^slag +(p.u.i) b)
@@ -964,7 +980,7 @@
   ++  scag                                            ::  scag stub, keep stye
     |=  {a/@ b/stub}
     ^-  stub
-    =+  c=(lnts b)
+    =+  c=(lnts-char b)
     =+  i=(brek a c)
     ?~  i  b
     ?:  =(a q.u.i)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -408,53 +408,7 @@
   |=  lin/(pair @ud stub)
   ^+  +>
   =.  off  ?:((lth p.lin edg) 0 (sub p.lin edg))
-  (se-show (sub p.lin off) (scag-stub edg (slag-stub off q.lin)))
-::
-++  lents-stub
-  |=  a/stub
-  %+  turn  a
-  |=  a/(pair styd (list @c))
-  %+  add
-    (lent (tail a))
-  =+  d=~(wyt in p.p.a)
-  (mul 4 ?:(=(0 d) 0 +(d)))
-::
-++  break-stub
-  |=  {a/(list @) b/@}
-  =|  {c/@ i/@}
-  |-  ^-  (unit (pair @ @))
-  ?~  a  ~
-  =.  c  (add i.a c)
-  ?:  (gte c b)
-    `[i c]
-  $(i +(i), a t.a)
-::
-++  slag-stub
-  |=  {a/@ b/stub}
-  ^-  stub
-  =+  c=(lents-stub b)
-  =+  i=(break-stub c a)
-  ?~  i  b
-  =+  r=(slag +(p.u.i) b)
-  ?:  =(a q.u.i)
-    r
-  =+  n=(snag p.u.i b)
-  :_  r  :-  p.n
-  (slag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
-::
-++  scag-stub
-  |=  {a/@ b/stub}
-  ^-  stub
-  =+  c=(lents-stub b)
-  =+  i=(break-stub c a)
-  ?~  i  b
-  ?:  =(a q.u.i)
-    (scag +(p.u.i) b)
-  %+  welp
-    (scag p.u.i b)
-  =+  n=(snag p.u.i b)
-  :_  ~  :-  p.n
-  (scag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
+  (se-show (sub p.lin off) (scag:klr edg (slag:klr off q.lin)))
 ::
 ++  se-view                                           ::  flush buffer
   ^+  .
@@ -479,10 +433,6 @@
   ^+  +>
   ?.  se-ably  (se-talk [%leaf txt]~)
   (se-blit %out (tuba txt))
-::
-++  se-klr                                            ::  return styled text
-  |=  a/stub
-  ^+(+> (se-blit %klr a))
 ::
 ++  se-poke                                           ::  send a poke
   |=  {gyl/gill par/pear}
@@ -635,35 +585,6 @@
     |=  pos/@ud
     (ta-erl (~(transpose sole say.inp) pos))
   ::
-  ++  flatten-styx
-    |=  a/styx
-    =|  b/styd
-    %+  reel
-    |-  ^-  stub
-    %-  zing
-    %+  turn  a
-    |=  a/$@(@t (pair styl styx))
-    ?@  a
-      [b (tuba (trip a))]~
-    %=  ^$
-      a  q.a
-      b  :+  ?~  p.p.a  p.b
-               ?~(u.p.p.a ~ (~(put in p.b) u.p.p.a))
-             ?~(p.q.p.a p.q.b u.p.q.p.a)
-             ?~(q.q.p.a q.q.b u.q.q.p.a)
-    ==
-    ::
-    |=  {a/(pair styd (list @c)) b/stub}
-    ?~  b
-      [a]~
-    ?.  =(p.a p.i.b)
-      [a b]
-    [[p.a (weld q.a q.i.b)] t.b]
-  ::
-  ++  ta-klr                                          ::  render styled text
-    |=  a/styx
-    +>(..ta (se-klr (flatten-styx a)))
-  ::
   ++  ta-fec                                          ::  apply effect
     |=  fec/sole-effect
     ^+  +>
@@ -673,7 +594,7 @@
       {$clr *}  +>(..ta (se-blit fec))
       {$det *}  (ta-got +.fec)
       {$err *}  (ta-err p.fec)
-      {$klr *}  (ta-klr p.fec)
+      {$klr *}  +>(..ta (se-blit %klr (make:klr p.fec)))
       {$mor *}  |-  ^+  +>.^$
                 ?~  p.fec  +>.^$
                 $(p.fec t.p.fec, +>.^$ ^$(fec i.p.fec))
@@ -901,10 +822,9 @@
   ++  ta-vew                                          ::  computed prompt
     ^-  (pair @ud stub)
     =;  vew/(pair (list @c) styx)
-      =/  lin/stub
-        (flatten-styx p.vew)
-      =+  len=((curr roll add) (lents-stub lin))
-      [(add pos.inp len) (welp lin [*styd p.vew]~)]
+      =+  lin=(make:klr q.vew)
+      :_  (welp lin [*styd p.vew]~)
+      (add pos.inp (roll (lnts:klr lin) add))
     ?:  vis.pom
       :-  buf.say.inp                                 ::  default prompt
       ?~  ris
@@ -980,5 +900,79 @@
     |-  ^-  @ud
     ?:  |(?=($~ a) (alnm i.a))  i
     $(i +(i), a t.a)
+  --
+::
+++  klr                                               ::  styx/stub engine
+  |%
+  ++  make                                            ::  stub from styx
+    |=  a/styx
+    =|  b/styd
+    %+  reel
+    |-  ^-  stub
+    %-  zing
+    %+  turn  a
+    |=  a/$@(@t (pair styl styx))
+    ?@  a
+      [b (tuba (trip a))]~
+    %=  ^$
+      a  q.a
+      b  :+  ?~  p.p.a  p.b
+               ?~(u.p.p.a ~ (~(put in p.b) u.p.p.a))
+             ?~(p.q.p.a p.q.b u.p.q.p.a)
+             ?~(q.q.p.a q.q.b u.q.q.p.a)
+    ==
+    ::
+    |=  {a/(pair styd (list @c)) b/stub}
+    ?~  b
+      [a]~
+    ?.  =(p.a p.i.b)
+      [a b]
+    [[p.a (weld q.a q.i.b)] t.b]
+  ::
+  ++  lnts                                            ::  stub pair lengths
+    |=  a/stub
+    %+  turn  a
+    |=  a/(pair styd (list @c))
+    %+  add
+      (lent q.a)
+    =+  d=~(wyt in p.p.a)
+    (mul 4 ?:(=(0 d) 0 +(d)))
+  ::
+  ++  brek                                            ::  index + incl-len of
+    |=  {a/@ b/(list @)}                              ::  stub pair w/ idx a
+    =|  {c/@ i/@}
+    |-  ^-  (unit (pair @ @))
+    ?~  b  ~
+    =.  c  (add c i.b)
+    ?:  (gte c a)
+      `[i c]
+    $(i +(i), b t.b)
+  ::
+  ++  slag                                            ::  slag stub, keep styd
+    |=  {a/@ b/stub}
+    ^-  stub
+    =+  c=(lnts b)
+    =+  i=(brek a c)
+    ?~  i  b
+    =+  r=(^slag +(p.u.i) b)
+    ?:  =(a q.u.i)
+      r
+    =+  n=(snag p.u.i b)
+    :_  r  :-  p.n
+    (^slag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
+  ::
+  ++  scag                                            ::  scag stub, keep styd
+    |=  {a/@ b/stub}
+    ^-  stub
+    =+  c=(lnts b)
+    =+  i=(brek a c)
+    ?~  i  b
+    ?:  =(a q.u.i)
+      (^scag +(p.u.i) b)
+    %+  welp
+      (^scag p.u.i b)
+    =+  n=(snag p.u.i b)
+    :_  ~  :-  p.n
+    (^scag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
   --
 --

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -823,7 +823,7 @@
     ^-  (pair @ud stub)
     =;  vew/(pair (list @c) styx)
       =+  lin=(make:klr q.vew)
-      :_  (welp lin [*styd p.vew]~)
+      :_  (welp lin [*stye p.vew]~)
       (add pos.inp (roll (lnts:klr lin) add))
     ?:  vis.pom
       :-  buf.say.inp                                 ::  default prompt
@@ -906,7 +906,7 @@
   |%
   ++  make                                            ::  stub from styx
     |=  a/styx
-    =|  b/styd
+    =|  b/stye
     %+  reel
     |-  ^-  stub
     %-  zing
@@ -922,7 +922,7 @@
              ?~(q.q.p.a q.q.b u.q.q.p.a)
     ==
     ::
-    |=  {a/(pair styd (list @c)) b/stub}
+    |=  {a/(pair stye (list @c)) b/stub}
     ?~  b
       [a]~
     ?.  =(p.a p.i.b)
@@ -932,7 +932,7 @@
   ++  lnts                                            ::  stub pair lengths
     |=  a/stub
     %+  turn  a
-    |=  a/(pair styd (list @c))
+    |=  a/(pair stye (list @c))
     %+  add
       (lent q.a)
     =+  d=~(wyt in p.p.a)
@@ -948,7 +948,7 @@
       `[i c]
     $(i +(i), b t.b)
   ::
-  ++  slag                                            ::  slag stub, keep styd
+  ++  slag                                            ::  slag stub, keep stye
     |=  {a/@ b/stub}
     ^-  stub
     =+  c=(lnts b)
@@ -961,7 +961,7 @@
     :_  r  :-  p.n
     (^slag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
   ::
-  ++  scag                                            ::  scag stub, keep styd
+  ++  scag                                            ::  scag stub, keep stye
     |=  {a/@ b/stub}
     ^-  stub
     =+  c=(lnts b)

--- a/sur/sole.hoon
+++ b/sur/sole.hoon
@@ -46,7 +46,7 @@
 ++  sole-prompt                                         ::  prompt definition
   $:  vis/?                                             ::  command visible
       tag/term                                          ::  history mode
-      cad/tape                                          ::  caption
+      cad/styx                                          ::  caption
   ==                                                    ::
 ++  sole-share                                          ::  symmetric state
   $:  ven/sole-clock                                    ::  our vector clock

--- a/sur/sole.hoon
+++ b/sur/sole.hoon
@@ -28,6 +28,7 @@
       {$clr $~}                                         ::  clear screen
       {$det sole-change}                                ::  edit command
       {$err p/@ud}                                      ::  error point
+      {$klr p/styx}                                     ::  styled text line
       {$mor p/(list sole-effect)}                       ::  multiple effects
       {$nex $~}                                         ::  save clear command
       {$pro sole-prompt}                                ::  set prompt


### PR DESCRIPTION
This PR implements the molds and transformations discussed in #212...

It's not ready to be merged -- right now it styled dill-blits are slogged, and then output with the styles stripped. I opened it now so the molds and overall approach could be reviewed early. 

questions:

- should the core in `drum:ta-klr` be moved somewhere else? A "klr-engine" in zuse?
- right now, lines are hard-wrapped at the terminal width -- should I be wrapping at the previous word boundary? (I haven't taken the time to deconstruct `++re` yet ...)

I'll get started on the actual color printing in `term.c` now ...

Examples:

```
=/  klr/styx  ~[[```%r "foo"] [```%g "bar"] [```%b "baz"]]
[[ost %diff %sole-effect %klr klr]~ +>.$]
```

`dill` slogs

```
[[p={} q=[p=~ q=%r]] "foo"]
[[p={} q=[p=~ q=%g]] "bar"]
[[p={} q=[p=~ q=%b]] "baz"]
```

and then outputs `foobarbaz`.

And, with inheritance:

```
=/  klr/styx
      :~  'foo bar baz bud boogity '
          [```%r "woogity "]
          [```%g ~['doogity ' [[~ `%k ~] "foogity "]]]
          [[`%un ~ ~] "zooooooooooooooooooooooooooogity dobity-dap "]
          [[`%br `%w `%m] ~['beepbopboop']]
      ==
```

slogs:

```
[[p={} q=[p=~ q=~]] "foo bar baz bud boogity "]
[[p={} q=[p=~ q=%r]] "woogity "]
[[p={} q=[p=~ q=%g]] "doogity "]
[[p={} q=[p=%k q=%g]] "foogity "]
[[p={%un} q=[p=~ q=~]] "zooooooooooooooooooooooooooogity dobity-dap "]
[[p={%br} q=[p=%w q=%m]] "beepbopboop"]
```

and outputs

```
foo bar baz bud boogity woogity doogity foogity zooooooooooooooooooooooooooogity dobity-dap beepbopboop
```