### PR TITLE
Fixed issue with automatic newline-@ for long @-messages.

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -840,14 +840,14 @@
             ?.  =(64 len)  advance
             :-  (fix(inx brk) (turf '•'))
             ?:  isa
-              [[%ins +(inx) (turf '@')] newline(new &)]
+              [[%ins +(brk) (turf '@')] newline(new &)]
             newline(new &)
           ?:  =(64 len)
             =+  dif=(sub inx brk)
             ?:  (lth dif 64)
               :-  (fix(inx brk) (turf '•'))
               ?:  isa
-                [[%ins (sub inx 3) (turf '@')] $(len dif, new &)]
+                [[%ins +(brk) (turf '@')] $(len dif, new &)]
               $(len dif, new &)
             [[%ins inx (turf '•')] $(len 0, inx +(inx), new &)]
           ?:  |((lth cur 32) (gth cur 126))


### PR DESCRIPTION
Turns out I didn't test #211 thoroughly enough, and that the code was doing something dumb. It should now work correctly 100% of the time.