### PR TITLE
reject :talk ++command pokes from foreign ships

### DIFF
--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -1098,10 +1098,8 @@
   he-abet:(he-arm +<)
 ::
 ++  peer-sole
-  ~?  !=(src.hid our.hid)  [%dojo-peer-stranger ost.hid src.hid]
-  ?>  ?|  =(src.hid our.hid) 
-          &(=(%earl (clan src.hid)) =(our.hid (sein src.hid)))
-      ==
+  ~?  !=(our.hid src.hid)  [%dojo-peer-stranger ost.hid src.hid]
+  ?>  (team our.hid src.hid)
   =^  moz  .
     ?.  (~(has by hoc) ost.hid)  [~ .]
     ~&  [%dojo-peer-replaced ost.hid]

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -2157,6 +2157,7 @@
   |=  cod/command
   ^+  [*(list move) +>]
   ::  ~&  [%talk-poke-command src.hid cod]
+  ?>  (team our.hid src.hid)
   =^  mos  +>.$
       ra-abet:(ra-apply:ra src.hid cod)
   =^  mow  +>.$  log-all-to-file

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2180,6 +2180,12 @@
     $earl  (end 5 1 who)
     $pawn  `@p`0
   ==
+::
+++  team                                                ::  our / our moon
+  |=  {our/@p him/@p}
+  ?|  =(our him)
+      &(?=($earl (clan him)) =(our (sein him)))
+  ==
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::                section 3bI, Arvo structures          ::
 ::


### PR DESCRIPTION
closes #208 

Crashing rejects the poke, right? (As opposed to producing `[~ +>.$]`, which would accept and acknowledge?)