### PR TITLE
adds ++key:by and ++val:by

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2823,6 +2823,17 @@
   +-  wyt                                               ::  depth of map
     |-  ^-  @
     ?~(a 0 +((add $(a l.a) $(a r.a))))
+  ::
+  +-  key                                               ::  set of keys
+    |-  ^-  (set _?>(?=(^ a) p.n.a))
+    ?~  a  ~
+    [n=p.n.a l=$(a l.a) r=$(a r.a)]
+  ::
+  +-  val                                               ::  list of vals
+    =|  b/(list _?>(?=(^ a) q.n.a))
+    |-  ^+  b
+    ?~  a   b
+    $(a r.a, b [q.n.a $(a l.a)])
   --
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::                section 2dC, queues                   ::


### PR DESCRIPTION
before:

```
> =m (malt (limo ~[[1 2] [3 4] [5 6]]))
{[p=5 q=6] [p=1 q=2] [p=3 q=4]}
> (~(gas in *(set @)) (turn (~(tap by m)) |=({a/@ b/@} a)))
{5 1 3}
> (turn (~(tap by m)) |=({a/@ b/@} b))
~[4 2 6]
```

after:

```
> =m (malt (limo ~[[1 2] [3 4] [5 6]]))
{[p=5 q=6] [p=1 q=2] [p=3 q=4]}
> ~(key by m)
{5 1 3}
> ~(val by m)
~[4 2 6]
```

The names are overly-normal by urbit standards, but they're three letters, meaningful, and I couldn't think of urbity variants ... ;)