### PR TITLE
adds +-gaf:by (non-colliding gas)

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2695,6 +2695,15 @@
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
+  +-  gaf                                               ::  concat, fail on dupe
+    ~/  %gaf
+    |=  b/(list _?>(?=(^ a) n.a))
+    |-  ^+  a
+    ?~  b
+      a
+    ?<  (has p.i.b)
+    $(b t.b, a (put p.i.b q.i.b))
+  ::
   +-  get                                               ::  grab value by key
     ~/  %get
     |=  b/*

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2701,6 +2701,7 @@
     |-  ^+  a
     ?~  b
       a
+    ~|  duplicate-key+p.i.b
     ?<  (has p.i.b)
     $(b t.b, a (put p.i.b q.i.b))
   ::


### PR DESCRIPTION
"gas, fail on dupe" -- as suggested in #199 ...

```
> =m (malt (limo ~[[1 2] [3 4] [5 6]]))
{[p=5 q=6] [p=1 q=2] [p=3 q=4]}
> (~(gas by m) (limo ~[[5 7]]))
{[p=5 q=7] [p=1 q=2] [p=3 q=4]}
> (~(gaf by m) (limo ~[[5 7]]))
ford: build failed ~[/g/~zod/use/dojo/~zod/inn/hand /g/~zod/use/hood/~zod/out/dojo/drum/phat/~zod/dojo /d //term/1]
```
