### PR TITLE
fixes meta-. to capture to whitespace instead of by word

### DIFF
--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -848,9 +848,9 @@
       $dot  ?.  &(?=(^ old.hit) ?=(^ -.old.hit))
               ta-bel
             =+  old=`(list @c)`-.old.hit
-            =+  b=(bwrd (lent old) old nedg)
+            =+  b=(bwrd (lent old) old nace)
             %-  ta-hom(ris ~)
-            (ta-cat pos.inp (slag b old))
+            (ta-cat pos.inp (slag (add b =(0 b)) old))
             ::
       $bac  ?:  =(0 pos.inp)
               ta-bel


### PR DESCRIPTION
I used the wrong capture semantics for the `meta-.` keyboard shortcut ...