### PR TITLE
Fix ++peg discrepancy with jet.

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -553,6 +553,7 @@
 ++  peg                                                 ::  tree connect
   ~/  %peg
   |=  {a/@ b/@}
+  ?<  =(0 a)
   ^-  @
   ?-  b
     $1  a


### PR DESCRIPTION
++peg's jet fails when `a` is 0, but the Hoon version returns nonsense. Failing seems like the right thing to do here.