### PR TITLE
Change "backspace at start of line" to "backspace on empty line" for clear

### DIFF
--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -617,8 +617,10 @@
         ta-bel
       .(str.u.ris (scag (dec (lent str.u.ris)) str.u.ris))
     ?:  =(0 pos.inp)
-      (ta-act %clr ~)
-      :: .(+> (se-blit %bel ~))
+      ?:  =(0 (lent buf.say.inp))
+        (ta-act %clr ~)
+        :: .(+> (se-blit %bel ~))
+      ta-bel
     =+  pre=(dec pos.inp)
     (ta-hom %del pre)
   ::


### PR DESCRIPTION
See #85. Not sure if this change is still desired, but it seemed like an easy fix, so here's a proposal.

Beeps if you backspace at the start of a line and it's not completely empty yet.

(Would it be appropriate to delete that comment (line 622) while I'm touching this part of the code?)