### PR TITLE
updates ++cass and ++cuss to return a tape instead of a cord

### DIFF
--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -173,7 +173,7 @@
   |=  hed/(list {p/@t q/@t})  ^-  math
   %+  roll  hed
   |=  {a/{p/cord q/cord} b/math}
-  =.  p.a  (cass (trip p.a))
+  =.  p.a  (crip (cass (trip p.a)))
   (~(add ja b) p.a q.a)
 ::
 ++  fcgi                                                ::  credential caboose
@@ -1129,7 +1129,7 @@
         ^-  (unit perk)
         =.  mef
           ?.  ?=($post mef)  mef
-          ?+    (skim quy |=({a/@t b/@t} &(=('' b) =(a (cuss (trip a))))))
+          ?+    (skim quy |=({a/@t b/@t} &(=('' b) =(a (crip (cuss (trip a)))))))
               ~|(bad-quy+[req='"?PUT" or "?DELETE"' quy] !!)
             $~   mef
             {{$'DELETE' $~} $~}  %delt

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -3589,13 +3589,12 @@
 ::
 ++  cass                                                ::  lowercase
   |=  vib/tape
-  %+  rap  3
+  ^-  tape
   (turn vib |=(a/@ ?.(&((gte a 'A') (lte a 'Z')) a (add 32 a))))
 ::
 ++  cuss                                                ::  uppercase
   |=  vib/tape
-  ^-  @t
-  %+  rap  3
+  ^-  tape
   (turn vib |=(a/@ ?.(&((gte a 'a') (lte a 'z')) a (sub a 32))))
 ::
 ++  crip  |=(a/tape `@t`(rap 3 a))                      ::  tape to cord

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -1983,7 +1983,7 @@
     %+  sear
       |=  a/@ta
       ?.(=('-' (rsh 3 (dec (met 3 a)) a)) [~ u=a] ~)
-    %+  cook  cass
+    %+  cook  |=(a/tape (crip (cass a)))
     ;~(plug aln (star alp))
   ::
   ++  fque  (cook crip (plus pquo))                     ::  normal query field
@@ -2004,7 +2004,7 @@
               hep  dot  ket  cab  tec  bar  sig
             ==
   ++  scem                                              ::  2396 scheme
-    %+  cook  cass
+    %+  cook  |=(a/tape (crip (cass a)))
     ;~(plug alf (star ;~(pose aln lus hep dot)))
   ::
   ++  smeg  (cook crip (plus pcar))                     ::  2396 segment

--- a/lib/down-jet/parse.hoon
+++ b/lib/down-jet/parse.hoon
@@ -41,11 +41,11 @@
   view-source webcal wtai wyciwyg xfire xri ymsgr
   '''
 ::
-++  uri-skem   (sear (flit |=(a/tape (~(has in skem-set) (cass a)))) skem-symb)
+++  uri-skem   (sear (flit |=(a/tape (~(has in skem-set) (crip (cass a))))) skem-symb)
 --
 ::
 ::::
-  :: 
+  ::
 |%
 ++  nal  (just `@`10)
 ++  end  (full (easy ~))
@@ -273,8 +273,8 @@
         ;~(plug pel (cook welp ;~(plug (star chu) per ^$)))
         (easy ~)
       ==
-    ++  text  
-      =-  (ifix sel^ser (cook cass (star -)))
+    ++  text
+      =-  (ifix sel^ser (cook |=(a/tape (crip (cass a))) (star -)))
       ;~  pose
         (cook |=(a/char (cat 3 '\\' a)) esc)
         (cold ' ' (plus gah))
@@ -494,8 +494,8 @@
         %script  %section  %style    %table   %tbody   %td  %textarea    %tfoot
         %th   %thead  %tr  %ul  %video  
     ==
-  ++  htm-head  =+  blu=(flit ~(has in (silt `wain`blok)))   
-                =+  blo=(sear blu (cook cass (star aln)))
+  ++  htm-head  =+  blu=(flit ~(has in (silt `wain`blok)))
+                =+  blo=(sear blu (cook |=(a/tape (crip (cass a))) (star aln)))
                 %+  stag  %html
                 ;~  plug  gal
                   ;~  pose

--- a/lib/oauth1.hoon
+++ b/lib/oauth1.hoon
@@ -177,7 +177,7 @@
     |=  {med/meth url/purl qen/quay-enc}  ^-  tape
     =.  qen  (sort qen aor)
     %-  join-urle
-    :~  (trip (cuss (trip `@t`med)))
+    :~  (cuss (trip `@t`med))
         (earn url)
         (joint "&" qen)
     ==

--- a/lib/react.hoon
+++ b/lib/react.hoon
@@ -25,7 +25,7 @@
   ~+  ^-  (map term cord)
   %-  molt  ^-  (list (pair term cord))  
   :-  [%class 'className']
-  =-  (rash - (more next (cook |=(a/tape [(cass a) (crip a)]) (star alf))))  
+  =-  (rash - (more next (cook |=(a/tape [(crip (cass a)) (crip a)]) (star alf))))
   '''
   accept acceptCharset accessKey action allowFullScreen allowTransparency alt
   async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet checked


### PR DESCRIPTION
While this isn't much of a win for the existing code, I think it's a big win for end-users. The "automatic `crip`" behavior is pretty counterintuitive, at least to me.

Also, `|=(a/tape (crip (cass a)))` could be `(corl crip cass)`, if not for the onerous "span check" in `++corl`.
