### PR TITLE
refactors drum

### DIFF
--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -516,31 +516,6 @@
     =+  pre=(dec pos.inp)
     (ta-hom %del pre)
   ::
-  ++  ta-kil                                          ::  build kil
-    |=  {a/?($l $r) b/(list @c)}
-    ^-  kill
-    =+  max=|=(a/(list (list @c)) (scag max.kil a))
-    ?.  ?&  ?=(^ p.blt)
-            ?|  ?=({$ctl p/?($k $u $w)} u.p.blt)
-                ?=({$met p/?($d $bac)} u.p.blt)
-        ==  ==
-      %=  kil
-        num  +(num.kil)
-        pos  +(num.kil)
-        old  (max [b old.kil])
-      ==
-    %=  kil
-      pos  num.kil
-      old  ?~  old.kil
-             [b]~
-           %-  max
-           :_  t.old.kil
-           ?-  a
-             $l  (welp b i.old.kil)
-             $r  (welp i.old.kil b)
-           ==
-    ==
-  ::
   ++  ta-ctl                                          ::  hear control
     |=  key/@ud
     ^+  +>
@@ -558,10 +533,7 @@
         $k  =+  len=(lent buf.say.inp)
             ?:  =(pos.inp len)
               ta-bel
-            %-  %=  ta-hom
-                  ris  ~
-                  kil  (ta-kil %r (slag pos.inp buf.say.inp))
-                ==
+            %-  (ta-kil %r (slag pos.inp buf.say.inp))
             (cut:edit pos.inp (sub len pos.inp))
         $l  +>(+> (se-blit %clr ~))
         $n  (ta-aro %d)
@@ -579,19 +551,13 @@
             (rep:edit [sop 2] (flop (swag [sop 2] buf.say.inp)))
         $u  ?:  =(0 pos.inp)
               ta-bel
-            %-  %=  ta-hom
-                  ris  ~
-                  kil  (ta-kil %l (scag pos.inp buf.say.inp))
-                ==
+            %-  (ta-kil %l (scag pos.inp buf.say.inp))
             (cut:edit 0 pos.inp)
         $v  ta-bel
         $w  ?:  =(0 pos.inp)
               ta-bel
             =+  b=(bwrd pos.inp buf.say.inp nace)
-            %-  %=  ta-hom
-                  ris  ~
-                  kil  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
-                ==
+            %-  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
             (cut:edit b (sub pos.inp b))
         $x  +>(+> se-anon)
         $y  ?:  =(0 num.kil)
@@ -670,6 +636,30 @@
     =.  +>  (ta-dog(say.inp (~(commit sole say.inp) ted)) ted)
     +>
   ::
+  ++  ta-kil                                          ::  update kill ring
+    |=  {a/?($l $r) b/(list @c)}
+    ^+  ta-hom
+    =;  lik/(pair @ud (list (list @c)))
+      %=  ta-hom
+        ris  ~
+        kil  %=  kil
+               num  p.lik
+               pos  p.lik
+               old  (scag max.kil q.lik)
+      ==     ==
+    ?.  ?&  ?=(^ old.kil)
+            ?=(^ p.blt)
+            ?|  ?=({$ctl ?($k $u $w)} u.p.blt)
+                ?=({$met ?($d $bac)} u.p.blt)
+        ==  ==
+      [+(num.kil) b old.kil]
+    :+  num.kil
+    ?-  a
+      $l  (welp b i.old.kil)
+      $r  (welp i.old.kil b)
+    ==
+    t.old.kil
+  ::
   ++  lcas                                            ::  lowercase
     |*  a/(list @)
     ^+  a
@@ -744,10 +734,7 @@
       $bac  ?:  =(0 pos.inp)
               ta-bel
             =+  b=(bwrd pos.inp buf.say.inp nedg)
-            %-  %=  ta-hom
-                  ris  ~
-                  kil  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
-                ==
+            %-  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
             (cut:edit b (sub pos.inp b))
             ::
       $b    ?:  =(0 pos.inp)
@@ -763,10 +750,7 @@
       $d    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             =+  f=(fwrd pos.inp buf.say.inp nedg)
-            %-  %=  ta-hom
-                  ris  ~
-                  kil  (ta-kil %r (slag pos.inp (scag f buf.say.inp)))
-                ==
+            %-  (ta-kil %r (slag pos.inp (scag f buf.say.inp)))
             (cut:edit pos.inp (sub f pos.inp))
             ::
       $f    ?:  =(pos.inp (lent buf.say.inp))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -277,9 +277,7 @@
 ::
 ++  se-alas                                           ::  recalculate index
   |=  gyl/gill
-  ^+  +>
   =+  [xin=0 wag=se-amor]
-  ?:  =(~ wag)  +>.$(inx 0)
   |-  ^+  +>.^$
   ?~  wag  +>.^$(inx 0)
   ?:  =(i.wag gyl)  +>.^$(inx xin)
@@ -287,19 +285,20 @@
 ::
 ++  se-amor                                           ::  live targets
   ^-  (list gill)
-  (skim (~(tap in eel)) |=(gill ?=({$~ $~ *} (~(get by fug) +<))))
+  %+  skim  (~(tap in eel))
+  |=(a/gill ?=({$~ $~ *} (~(get by fug) a)))
 ::
 ++  se-anon                                           ::  rotate index
   =+  wag=se-amor
   ?~  wag  +
   ::  ~&  [%se-anon inx+inx wag+wag nex+(mod +(inx) (lent se-amor))]
-  +(inx (mod +(inx) (lent se-amor)))
+  +(inx (mod +(inx) (lent wag)))
 ::
 ++  se-agon                                           ::  current gill
   ^-  (unit gill)
   =+  wag=se-amor
   ?~  wag  ~
-  `(snag inx se-amor)
+  `(snag inx `(list gill)`wag)
 ::
 ++  se-belt                                           ::  handle input
   |=  bet/dill-belt

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -466,20 +466,19 @@
   ++  ta-aro                                          ::  hear arrow
     |=  key/?($d $l $r $u)
     ^+  +>
+    =.  ris  ~
     ?-  key
-      $d  =.  ris  ~
-          ?.  =(num.hit pos.hit)
+      $d  ?.  =(num.hit pos.hit)
             (ta-mov +(pos.hit))
           ?:  =(0 (lent buf.say.inp))
             ta-bel
           (ta-hom:ta-nex %set ~)
       $l  ?:  =(0 pos.inp)  ta-bel
-          +>(pos.inp (dec pos.inp), ris ~)
+          +>(pos.inp (dec pos.inp))
       $r  ?:  =((lent buf.say.inp) pos.inp)
             ta-bel
-          +>(pos.inp +(pos.inp), ris ~)
-      $u  =.  ris  ~
-          ?:(=(0 pos.hit) ta-bel (ta-mov (dec pos.hit)))
+          +>(pos.inp +(pos.inp))
+      $u  ?:(=(0 pos.hit) ta-bel (ta-mov (dec pos.hit)))
     ==
   ::
   ++  ta-bel                                          ::  beep
@@ -520,10 +519,11 @@
   ++  ta-ctl                                          ::  hear control
     |=  key/@ud
     ^+  +>
-    ?+    key  ta-bel
-        $a  +>(pos.inp 0, ris ~)
+    =.  ris  ?.(?=(?($g $r) key) ~ ris)
+    ?+    key    ta-bel
+        $a  +>(pos.inp 0)
         $b  (ta-aro %l)
-        $c  ta-bel(ris ~)
+        $c  ta-bel
         $d  ?:  &(=(0 pos.inp) =(0 (lent buf.say.inp)))
               +>(liv |)
             ta-del
@@ -547,8 +547,7 @@
             ?:  |(=(0 pos.inp) (lth len 2))
               ta-bel
             =+  sop=(sub pos.inp ?:(=(len pos.inp) 2 1))
-            %-  ta-hom(ris ~)
-            (rep:edit [sop 2] (flop (swag [sop 2] buf.say.inp)))
+            (ta-hom (rep:edit [sop 2] (flop (swag [sop 2] buf.say.inp))))
         $u  ?:  =(0 pos.inp)
               ta-bel
             (ta-kil %l [0 pos.inp])
@@ -560,8 +559,7 @@
         $x  +>(+> se-anon)
         $y  ?:  =(0 num.kil)
               ta-bel
-            %-  ta-hom(ris ~)
-            (cat:edit pos.inp (snag (sub num.kil pos.kil) old.kil))
+            (ta-hom (cat:edit pos.inp (snag (sub num.kil pos.kil) old.kil)))
     ==
   ::
   ++  ta-del                                          ::  hear delete
@@ -640,7 +638,6 @@
     =+  buf=(swag sel buf.say.inp)
     %.  (cut:edit sel)
     %=  ta-hom
-        ris  ~
         kil
       ?.  ?&  ?=(^ old.kil)
               ?=(^ p.blt)
@@ -675,13 +672,14 @@
   ::
   ++  ta-met                                          ::  meta key
     |=  key/@ud
+    ^+  +>
+    =.  ris  ~
     ?+    key    ta-bel
       $dot  ?.  &(?=(^ old.hit) ?=(^ i.old.hit))
               ta-bel
             =+  old=`(list @c)`i.old.hit
             =+  sop=(ta-jump(buf.say.inp old) %l %ace (lent old))
-            %-  ta-hom(ris ~)
-            (cat:edit pos.inp (slag sop old))
+            (ta-hom (cat:edit pos.inp (slag sop old)))
             ::
       $bac  ?:  =(0 pos.inp)
               ta-bel
@@ -730,8 +728,7 @@
             =+  case=?:(?=($u key) ucas lcas)
             =+  sop=(ta-jump %r %wrd pos.inp)
             =+  sel=[sop (ta-off %r %edg sop)]
-            %-  ta-hom
-            (rep:edit sel (case (swag sel buf.say.inp)))
+            (ta-hom (rep:edit sel (case (swag sel buf.say.inp))))
             ::
       $y    ?.  ?&  (gth num.kil 0)
                     ?=(^ p.blt)
@@ -741,7 +738,7 @@
               ta-bel
             =+  las=(lent (snag (sub num.kil pos.kil) old.kil))
             =+  pos=?:(=(1 pos.kil) num.kil (dec pos.kil))
-            %-  ta-hom(pos.kil pos, ris ~)
+            %-  ta-hom(pos.kil pos)
             %+  rep:edit
               [(sub pos.inp las) las]
             (snag (sub num.kil pos) old.kil)
@@ -760,15 +757,16 @@
     (bond |.((snag (sub num.hit +(sop)) old.hit)))
   ::
   ++  ta-nex                                          ::  advance history
+    ^+  .
+    =.  ris  ~
+    =.  lay.hit  ~
     ?:  ?|  ?=($~ buf.say.inp)
             &(?=(^ old.hit) =(buf.say.inp i.old.hit))
         ==
-      %_(. pos.hit num.hit, ris ~, lay.hit ~)
+      .(pos.hit num.hit)
     %_  .
       num.hit  +(num.hit)
       pos.hit  +(num.hit)
-      ris  ~
-      lay.hit  ~
       old.hit  [buf.say.inp old.hit]
     ==
   ::

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -793,20 +793,15 @@
   ++  ta-ser                                          ::  reverse search
     |=  ext/(list @c)
     ^+  +>
-    ?:  |(?=($~ ris) =(0 pos.u.ris))  ta-bel
+    ?:  |(?=($~ ris) =(0 pos.u.ris))
+      ta-bel
     =+  sop=?~(ext (dec pos.u.ris) pos.u.ris)
     =+  tot=(weld str.u.ris ext)
     =+  dol=(slag (sub num.hit sop) old.hit)
-    =+  ^=  ser
-        =+  ^=  beg
-            |=  {a/(list @c) b/(list @c)}  ^-  ?
-            ?~(a & ?~(b | &(=(i.a i.b) $(a t.a, b t.b))))
-        |=  {a/(list @c) b/(list @c)}  ^-  ?
-        ?~(a & ?~(b | |((beg a b) $(b t.b))))
-    =+  ^=  sup
+    =/  sup
         |-  ^-  (unit @ud)
         ?~  dol  ~
-        ?:  (ser tot i.dol)
+        ?^  (find tot i.dol)
           `sop
         $(sop (dec sop), dol t.dol)
     ?~  sup  ta-bel

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -345,7 +345,8 @@
   |=  tac/(list tank)
   ^+  +>
   ?.  se-ably  (se-talk tac)
-  =+  wol=`wall`(zing (turn (flop tac) |=(a/tank (~(win re a) [0 edg]))))
+  =/  wol/wall
+    (zing (turn (flop tac) |=(a/tank (~(win re a) [0 edg]))))
   |-  ^+  +>.^$
   ?~  wol  +>.^$
   $(wol t.wol, +>.^$ (se-blit %out (tuba i.wol)))
@@ -565,8 +566,7 @@
   ::
   ++  ta-cru                                          ::  hear crud
     |=  {lab/@tas tac/(list tank)}
-    =.  +>+>  (se-text (trip lab))
-    (ta-tan tac)
+    +>(+> (se-dump:(se-text (trip lab)) tac))
   ::
   ++  ta-del                                          ::  hear delete
     ^+  .
@@ -596,10 +596,10 @@
                 $(p.fec t.p.fec, +>.^$ ^$(fec i.p.fec))
       {$nex *}  ta-nex
       {$pro *}  (ta-pro +.fec)
-      {$tan *}  (ta-tan p.fec)
+      {$tan *}  +>(+> (se-dump p.fec))
       {$sag *}  +>(+> (se-blit fec))
       {$sav *}  +>(+> (se-blit fec))
-      {$txt *}  (ta-tan [[%leaf p.fec] ~])
+      {$txt *}  +>(+> (se-text p.fec))
       {$url *}  +>(+> (se-blit fec))
     ==
   ::
@@ -818,13 +818,6 @@
         $(sop (dec sop), dol t.dol)
     ?~  sup  ta-bel
     (ta-mov(str.u.ris tot, pos.u.ris u.sup) (dec u.sup))
-  ::
-  ++  ta-tan                                          ::  print tanks
-    |=  tac/(list tank)
-    =+  wol=`wall`(zing (turn (flop tac) |=(a/tank (~(win re a) [0 edg]))))
-    |-  ^+  +>.^$
-    ?~  wol  +>.^$
-    $(wol t.wol, +>+>.^$ (se-text i.wol))
   ::
   ++  ta-txt                                          ::  hear text
     |=  txt/(list @c)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -305,29 +305,18 @@
 ++  se-belt                                           ::  handle input
   |=  bet/dill-belt
   ^+  +>
-  ?:  ?=($rez -.bet)
-    +>(edg (dec p.bet))
-  ?:  ?=($yow -.bet)
-    ~&  [%no-yow -.bet]
-    +>
+  ?:  ?=({?($hey $rez $yow) *} bet)                   ::  target-agnostic
+    ?-  bet
+      {$hey *}  +>(mir [0 ~])                         ::  refresh
+      {$rez *}  +>(edg (dec p.bet))                   ::  resize window
+      {$yow *}  ~&([%no-yow -.bet] +>)
+    ==
   =+  gul=se-agon
-  =+  tur=?~(gul ~ (~(get by fug) u.gul))
+  =+  tur=?~(gul ~ (~(get by fug) u.gul))    ::  XX se-aint
   ?:  |(?=($~ gul) ?=($~ tur) ?=($~ u.tur))
     (se-blit %bel ~)
-  =+  taz=~(. ta [& u.gul] u.u.tur)
-  =.  blt.taz  [q.blt.taz `bet]
   =<  ta-abet
-  ?-  -.bet
-    $aro  (ta-aro:taz p.bet)
-    $bac  ta-bac:taz
-    $cru  (ta-cru:taz p.bet q.bet)
-    $ctl  (ta-ctl:taz p.bet)
-    $del  ta-del:taz
-    $hey  taz(mir [0 ~])
-    $met  (ta-met:taz p.bet)
-    $ret  ta-ret:taz
-    $txt  (ta-txt:taz p.bet)
-  ==
+  (ta-belt:(se-tame u.gul) bet)
 ::
 ++  se-born                                           ::  new server
   |=  wel/well
@@ -496,7 +485,24 @@
     ==
   ::
   ++  ta-bel                                          ::  beep
-    .(+> (se-blit %bel ~), q.blt ~)
+    .(+> (se-blit %bel ~), q.blt ~)                   ::  forget belt
+  ::
+  ++  ta-belt                                         ::  handle input
+    |=  bet/dill-belt
+    ^+  +>
+    ?<  ?=({?($hey $rez $yow) *} bet)                 ::  target-specific
+    =.  blt  [q.blt `bet]                             ::  remember belt
+    ?-  bet
+      {$aro *}  (ta-aro p.bet)
+      {$bac *}  ta-bac
+      {$cru *}  (ta-cru p.bet q.bet)
+      {$ctl *}  (ta-ctl p.bet)
+      {$del *}  ta-del
+      {$met *}  (ta-met p.bet)
+      {$ret *}  ta-ret
+      {$txt *}  (ta-txt p.bet)
+    ==
+  ::
   ++  ta-cat                                          ::  mass insert
     |=  {pos/@ud txt/(list @c)}
     ^-  sole-edit

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -437,7 +437,7 @@
 ++  se-tame                                           ::  switch connection
   |=  gyl/gill
   ^+  ta
-  ~(. ta [& gyl] (need (~(got by fug) gyl)))
+  ~(. ta gyl (need (~(got by fug) gyl)))
 ::
 ++  se-diff                                           ::  receive results
   |=  {gyl/gill fec/sole-effect}
@@ -445,17 +445,9 @@
   ta-abet:(ta-fec:(se-tame gyl) fec)
 ::
 ++  ta                                                ::  per target
-  |_  $:  $:  liv/?                                   ::  don't delete
-              gyl/gill                                ::  target app
-          ==                                          ::
-          target                                      ::  target state
-      ==                                              ::
+  |_  {gyl/gill target}                               ::  app and state
   ++  ta-abet                                         ::  resolve
     ^+  ..ta
-    ?.  liv
-      ?:   (~(has in (deft-fish our.hid)) gyl)
-        (se-blit qit+~)
-      (se-nuke gyl)
     ..ta(fug (~(put by fug) gyl ``target`+<+))
   ::
   ++  ta-poke  |=(a/pear +>(..ta (se-poke gyl a)))    ::  poke gyl
@@ -526,9 +518,11 @@
         $a  +>(pos.inp 0)
         $b  (ta-aro %l)
         $c  ta-bel
-        $d  ?:  &(=(0 pos.inp) =(0 (lent buf.say.inp)))
-              +>(liv |)
-            ta-del
+        $d  ?^  buf.say.inp
+              ta-del
+            ?:  (~(has in (deft-fish our.hid)) gyl)
+              +>(..ta (se-blit qit+~))                ::  quit pier
+            +>(..ta (se-klin gyl))                    ::  unlink app
         $e  +>(pos.inp (lent buf.say.inp))
         $f  (ta-aro %r)
         $g  ?~  ris  ta-bel
@@ -567,7 +561,7 @@
   ++  ta-del                                          ::  hear delete
     ^+  .
     ?:  =((lent buf.say.inp) pos.inp)
-      .(..ta (se-blit %bel ~))
+      ta-bel
     (ta-hom %del pos.inp)
   ::
   ++  ta-erl                                          ::  hear local error

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -305,8 +305,9 @@
 ++  se-belt                                           ::  handle input
   |=  bet/dill-belt
   ^+  +>
-  ?:  ?=({?($hey $rez $yow) *} bet)                   ::  target-agnostic
+  ?:  ?=({?($cru $hey $rez $yow) *} bet)              ::  target-agnostic
     ?-  bet
+      {$cru *}  (se-dump:(se-text (trip p.bet)) q.bet)
       {$hey *}  +>(mir [0 ~])                         ::  refresh
       {$rez *}  +>(edg (dec p.bet))                   ::  resize window
       {$yow *}  ~&([%no-yow -.bet] +>)
@@ -487,12 +488,11 @@
   ++  ta-belt                                         ::  handle input
     |=  bet/dill-belt
     ^+  +>
-    ?<  ?=({?($hey $rez $yow) *} bet)                 ::  target-specific
+    ?<  ?=({?($cru $hey $rez $yow) *} bet)            ::  target-specific
     =.  blt  [q.blt `bet]                             ::  remember belt
     ?-  bet
       {$aro *}  (ta-aro p.bet)
       {$bac *}  ta-bac
-      {$cru *}  (ta-cru p.bet q.bet)
       {$ctl *}  (ta-ctl p.bet)
       {$del *}  ta-del
       {$met *}  (ta-met p.bet)
@@ -563,10 +563,6 @@
             %-  ta-hom(ris ~)
             (cat:edit pos.inp (snag (sub num.kil pos.kil) old.kil))
     ==
-  ::
-  ++  ta-cru                                          ::  hear crud
-    |=  {lab/@tas tac/(list tank)}
-    +>(+> (se-dump:(se-text (trip lab)) tac))
   ::
   ++  ta-del                                          ::  hear delete
     ^+  .

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -533,8 +533,7 @@
         $k  =+  len=(lent buf.say.inp)
             ?:  =(pos.inp len)
               ta-bel
-            %-  (ta-kil %r (slag pos.inp buf.say.inp))
-            (cut:edit pos.inp (sub len pos.inp))
+            (ta-kil %r [pos.inp (sub len pos.inp)])
         $l  +>(+> (se-blit %clr ~))
         $n  (ta-aro %d)
         $p  (ta-aro %u)
@@ -551,15 +550,12 @@
             (rep:edit [sop 2] (flop (swag [sop 2] buf.say.inp)))
         $u  ?:  =(0 pos.inp)
               ta-bel
-            %-  (ta-kil %l (scag pos.inp buf.say.inp))
-            (cut:edit 0 pos.inp)
+            (ta-kil %l [0 pos.inp])
         $v  ta-bel
         $w  ?:  =(0 pos.inp)
               ta-bel
-            =+  b=(ta-jump %l %ace pos.inp)
-            =+  sel=[(sub pos.inp b) b]
-            %-  (ta-kil %l (swag sel buf.say.inp))
-            (cut:edit sel)
+            =+  sop=(ta-off %l %ace pos.inp)
+            (ta-kil %l [(sub pos.inp sop) sop])
         $x  +>(+> se-anon)
         $y  ?:  =(0 num.kil)
               ta-bel
@@ -643,29 +639,32 @@
     %-  ?:(?=($l dir) sub add)
     [pos (ta-off dir til pos)]
   ::
-  ++  ta-kil                                          ::  update kill ring
-    |=  {a/?($l $r) b/(list @c)}
-    ^+  ta-hom
-    =;  lik/(pair @ud (list (list @c)))
-      %=  ta-hom
+  ++  ta-kil                                          ::  kill selection
+    |=  {dir/?($l $r) sel/{@ @}}
+    ^+  +>
+    =+  buf=(swag sel buf.say.inp)
+    %.  (cut:edit sel)
+    %=  ta-hom
         ris  ~
-        kil  %=  kil
-               num  p.lik
-               pos  p.lik
-               old  (scag max.kil q.lik)
+        kil
+      ?.  ?&  ?=(^ old.kil)
+              ?=(^ p.blt)
+              ?|  ?=({$ctl ?($k $u $w)} u.p.blt)
+                  ?=({$met ?($d $bac)} u.p.blt)
+          ==  ==
+        %=  kil                                       ::  prepend
+          num  +(num.kil)
+          pos  +(num.kil)
+          old  (scag max.kil `(list (list @c))`[buf old.kil])
+        ==
+      %=  kil                                         ::  cumulative yanks
+        pos  num.kil
+        old  :_  t.old.kil
+             ?-  dir
+               $l  (welp buf i.old.kil)
+               $r  (welp i.old.kil buf)
       ==     ==
-    ?.  ?&  ?=(^ old.kil)
-            ?=(^ p.blt)
-            ?|  ?=({$ctl ?($k $u $w)} u.p.blt)
-                ?=({$met ?($d $bac)} u.p.blt)
-        ==  ==
-      [+(num.kil) b old.kil]
-    :+  num.kil
-    ?-  a
-      $l  (welp b i.old.kil)
-      $r  (welp i.old.kil b)
     ==
-    t.old.kil
   ::
   ++  lcas                                            ::  lowercase
     |*  a/(list @)
@@ -691,10 +690,8 @@
             ::
       $bac  ?:  =(0 pos.inp)
               ta-bel
-            =+  b=(ta-off %l %edg pos.inp)
-            =+  sel=[(sub pos.inp b) b]
-            %-  (ta-kil %l (swag sel buf.say.inp))
-            (cut:edit sel)
+            =+  sop=(ta-off %l %edg pos.inp)
+            (ta-kil %l [(sub pos.inp sop) sop])
             ::
       $b    ?:  =(0 pos.inp)
               ta-bel
@@ -708,9 +705,7 @@
             ::
       $d    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            =+  sel=[pos.inp (ta-off %r %edg pos.inp)]
-            %-  (ta-kil %r (swag sel buf.say.inp))
-            (cut:edit sel)
+            (ta-kil %r [pos.inp (ta-off %r %edg pos.inp)])
             ::
       $f    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -139,11 +139,11 @@
   (se-diff gyl fec)
 ::
 ++  peer                                              ::
-  |=   pax/path  =<  se-abet
-  ^+  +>
+  |=  pax/path
   ~|  [%drum-unauthorized our+our src+src]            ::  ourself
   ?>  (team our src)                                  ::  or our own moon
-  se-view:(se-text "[{<src>}, driving {<our>}]")
+  =<  se-abet  =<  se-view
+  (se-text "[{<src>}, driving {<our>}]")
 ::
 ++  poke-dill-belt                                    ::
   |=  bet/dill-belt
@@ -186,8 +186,9 @@
   ?~  saw  +>
   =+  gyl=(drum-phat way)
   ?:  (se-aint gyl)  +>.$
-  =.  u.saw  :_(u.saw >[%drum-coup-fail src ost gyl]<)
-  (se-dump:(se-drop & gyl) u.saw)
+  %-  se-dump:(se-drop & gyl)
+  :_  u.saw
+  >[%drum-coup-fail src ost gyl]<
 ::
 ++  take-onto                                         ::
   |=  {way/wire saw/(each suss tang)}

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -484,7 +484,7 @@
     ==
   ::
   ++  ta-bel                                          ::  beep
-    .(+> (se-blit %bel ~), q.blt ~)                   ::  forget belt
+    .(..ta (se-blit %bel ~), q.blt ~)                 ::  forget belt
   ::
   ++  ta-belt                                         ::  handle input
     |=  bet/dill-belt
@@ -537,7 +537,7 @@
             ?:  =(pos.inp len)
               ta-bel
             (ta-kil %r [pos.inp (sub len pos.inp)])
-        $l  +>(+> (se-blit %clr ~))
+        $l  +>(..ta (se-blit %clr ~))
         $n  (ta-aro %d)
         $p  (ta-aro %u)
         $r  ?~  ris
@@ -558,7 +558,7 @@
               ta-bel
             =+  sop=(ta-off %l %ace pos.inp)
             (ta-kil %l [(sub pos.inp sop) sop])
-        $x  +>(+> se-anon)
+        $x  +>(..ta se-anon)
         $y  ?:  =(0 num.kil)
               ta-bel
             (ta-hom (cat:edit pos.inp (snag (sub num.kil pos.kil) old.kil)))
@@ -567,7 +567,7 @@
   ++  ta-del                                          ::  hear delete
     ^+  .
     ?:  =((lent buf.say.inp) pos.inp)
-      .(+> (se-blit %bel ~))
+      .(..ta (se-blit %bel ~))
     (ta-hom %del pos.inp)
   ::
   ++  ta-erl                                          ::  hear local error
@@ -584,7 +584,7 @@
     ?-  fec
       {$bel *}  ta-bel
       {$blk *}  +>
-      {$clr *}  +>(+> (se-blit fec))
+      {$clr *}  +>(..ta (se-blit fec))
       {$det *}  (ta-got +.fec)
       {$err *}  (ta-err p.fec)
       {$mor *}  |-  ^+  +>.^$
@@ -592,11 +592,11 @@
                 $(p.fec t.p.fec, +>.^$ ^$(fec i.p.fec))
       {$nex *}  ta-nex
       {$pro *}  (ta-pro +.fec)
-      {$tan *}  +>(+> (se-dump p.fec))
-      {$sag *}  +>(+> (se-blit fec))
-      {$sav *}  +>(+> (se-blit fec))
-      {$txt *}  +>(+> (se-text p.fec))
-      {$url *}  +>(+> (se-blit fec))
+      {$tan *}  +>(..ta (se-dump p.fec))
+      {$sag *}  +>(..ta (se-blit fec))
+      {$sav *}  +>(..ta (se-blit fec))
+      {$txt *}  +>(..ta (se-text p.fec))
+      {$url *}  +>(..ta (se-blit fec))
     ==
   ::
   ++  ta-dog                                          ::  change cursor

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -195,12 +195,12 @@
   =<  se-abet  =<  se-view
   ?>  ?=({@ @ $~} way)
   ?>  (~(has by fur) i.t.way)
-  =+  wel=`well`[i.way i.t.way]
-  ?-  -.saw
-    $|  (se-dump p.saw)
-    $&  ?>  =(q.wel p.p.saw)
-        ::  =.  +>.$  (se-text "live {<p.saw>}")
-        +>.$(fur (~(put by fur) q.wel `[p.wel %da r.p.saw]))
+  =/  wel/well  [i.way i.t.way]
+  ?-  saw
+    {$| *}  (se-dump p.saw)
+    {$& *}  ?>  =(q.wel p.p.saw)
+            ::  =.  +>.$  (se-text "live {<p.saw>}")
+            +>.$(fur (~(put by fur) q.wel `[p.wel %da r.p.saw]))
   ==
 ::
 ++  quit-phat                                         ::
@@ -641,22 +641,22 @@
   ++  ta-fec                                          ::  apply effect
     |=  fec/sole-effect
     ^+  +>
-    ?-    -.fec
-      $bel  ta-bel
-      $blk  +>
-      $clr  +>(+> (se-blit fec))
-      $det  (ta-got +.fec)
-      $err  (ta-err +.fec)
-      $mor  |-  ^+  +>.^$
-            ?~  p.fec  +>.^$
-            $(p.fec t.p.fec, +>.^$ ^$(fec i.p.fec))
-      $nex  ta-nex
-      $pro  (ta-pro +.fec)
-      $tan  (ta-tan p.fec)
-      $sag  +>(+> (se-blit fec))
-      $sav  +>(+> (se-blit fec))
-      $txt  $(fec [%tan [%leaf p.fec]~])
-      $url  +>(+> (se-blit fec))
+    ?-  fec
+      {$bel *}  ta-bel
+      {$blk *}  +>
+      {$clr *}  +>(+> (se-blit fec))
+      {$det *}  (ta-got +.fec)
+      {$err *}  (ta-err p.fec)
+      {$mor *}  |-  ^+  +>.^$
+                ?~  p.fec  +>.^$
+                $(p.fec t.p.fec, +>.^$ ^$(fec i.p.fec))
+      {$nex *}  ta-nex
+      {$pro *}  (ta-pro +.fec)
+      {$tan *}  (ta-tan p.fec)
+      {$sag *}  +>(+> (se-blit fec))
+      {$sav *}  +>(+> (se-blit fec))
+      {$txt *}  (ta-tan [[%leaf p.fec] ~])
+      {$url *}  +>(+> (se-blit fec))
     ==
   ::
   ++  ta-dog                                          ::  change cursor
@@ -666,14 +666,14 @@
       =+  len=(lent buf.say.inp)
       %+  min  len
       |-  ^-  @ud
-      ?-  -.ted
-        $del  ?:((gth pos.inp p.ted) (dec pos.inp) pos.inp)
-        $ins  ?:((gte pos.inp p.ted) +(pos.inp) pos.inp)
-        $mor  |-  ^-  @ud
-              ?~  p.ted  pos.inp
-              $(p.ted t.p.ted, pos.inp ^$(ted i.p.ted))
-        $nop  pos.inp
-        $set  len
+      ?-  ted
+        {$del *}  ?:((gth pos.inp p.ted) (dec pos.inp) pos.inp)
+        {$ins *}  ?:((gte pos.inp p.ted) +(pos.inp) pos.inp)
+        {$mor *}  |-  ^-  @ud
+                  ?~  p.ted  pos.inp
+                  $(p.ted t.p.ted, pos.inp ^$(ted i.p.ted))
+        {$nop *}  pos.inp
+        {$set *}  len
       ==
     ==
   ::
@@ -753,9 +753,9 @@
   ++  ta-met                                          ::  meta key
     |=  key/@ud
     ?+    key    ta-bel
-      $dot  ?.  &(?=(^ old.hit) ?=(^ -.old.hit))
+      $dot  ?.  &(?=(^ old.hit) ?=(^ i.old.hit))
               ta-bel
-            =+  old=`(list @c)`-.old.hit
+            =+  old=`(list @c)`i.old.hit
             =+  b=(bwrd (lent old) old nedg)
             %-  ta-hom(ris ~)
             (ta-cat pos.inp (slag b old))
@@ -862,8 +862,8 @@
     (~(get by lay.hit) sop)
   ::
   ++  ta-nex                                          ::  advance history
-    ?:  ?|  =(0 (lent buf.say.inp))
-            &(?=(^ old.hit) =(-.old.hit buf.say.inp))
+    ?:  ?|  ?=($~ buf.say.inp)
+            &(?=(^ old.hit) =(buf.say.inp i.old.hit))
         ==
       %_(. pos.hit num.hit, ris ~, lay.hit ~)
     %_  .

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -386,14 +386,6 @@
   ?~  wol  +>.^$
   $(wol t.wol, +>.^$ (se-blit %out (tuba i.wol)))
 ::
-++  se-joke                                           ::  prepare connection
-  |=  gyl/gill
-  ^+  +>
-  =+  lag=se-agon
-  ?~  lag  +>.$
-  ?:  =(~ fug)  +>.$
-  (se-alas(fug (~(put by fug) gyl ~)) u.lag)
-::
 ++  se-join                                           ::  confirm connection
   |=  gyl/gill
   ^+  +>

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -511,10 +511,10 @@
         ta-bel
       .(str.u.ris (scag (dec (lent str.u.ris)) str.u.ris))
     ?:  =(0 pos.inp)
-      (ta-act %clr ~)
-      :: .(+> (se-blit %bel ~))
-    =+  pre=(dec pos.inp)
-    (ta-hom %del pre)
+      ?~  buf.say.inp
+        (ta-act %clr ~)
+      ta-bel
+    (ta-hom %del (dec pos.inp))
   ::
   ++  ta-ctl                                          ::  hear control
     |=  key/@ud

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -82,18 +82,6 @@
     [[(sein our) %talk] [our %dojo] ~]
   [[our %talk] [our %dojo] ~]
 ::
-++  deft-pipe                                           ::  default source
-  |=  our/ship                                          ::
-  ^-  source                                            ::
-  :*  80                                                ::  edg
-      0                                                 ::  off
-      [0 0 60 ~]                                        ::  kil
-      0                                                 ::  inx
-      ~                                                 ::  fug
-      [0 ~]                                             ::  mir
-  ==
-::
-++  deft-tart  *target                                  ::  default target
 ++  drum-make                                           ::  initial part
   |=  our/ship
   ^-  drum-part
@@ -124,7 +112,7 @@
 ::::
   ::
 |=  {bowl drum-part}                                  ::  main drum work
-=+  (fall (~(get by bin) ost) (deft-pipe our))
+=+  (fall (~(get by bin) ost) *source)
 =*  dev  -
 =>  |%                                                ::  arvo structures
     ++  pear                                          ::  request

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -62,11 +62,6 @@
       pom/sole-prompt                                   ::  static prompt
       inp/sole-command                                  ::  input state
   ==                                                    ::
-++  ukase                                               ::  master command
-  $%  {$add p/(list gill)}                              ::  attach to
-      {$del p/(list gill)}                              ::  detach from
-      {$new p/(list well)}                              ::  create
-  ==                                                    ::
 --
 ::                                                      ::  ::
 ::::                                                    ::  ::
@@ -410,25 +405,6 @@
   |=  gyl/gill
   ^+  +>
   (se-drop:(se-pull gyl) & gyl)
-::
-++  se-like                                           ::  act in master
-  |=  kus/ukase
-  ?-    -.kus
-      $add
-    |-  ^+  +>.^$
-    ?~  p.kus  +>.^$
-    $(p.kus t.p.kus, +>.^$ (se-link i.p.kus))
-  ::
-      $del
-    |-  ^+  +>.^$
-    ?~  p.kus  +>.^$
-    $(p.kus t.p.kus, +>.^$ (se-nuke i.p.kus))
-  ::
-      $new
-    |-  ^+  +>.^$
-    ?~  p.kus  +>.^$
-    $(p.kus t.p.kus, +>.^$ (se-born i.p.kus))
-  ==
 ::
 ++  se-plot                                           ::  status line
   ^-  tape

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -41,10 +41,6 @@
       fug/(map gill (unit target))                      ::  connections
       mir/(pair @ud (list @c))                          ::  mirrored terminal
   ==                                                    ::
-++  master                                              ::  master buffer
-  $:  liv/?                                             ::  master is live
-      tar/target                                        ::  master target
-  ==                                                    ::
 ++  history                                             ::  past input
   $:  pos/@ud                                           ::  input position
       num/@ud                                           ::  number of entries
@@ -85,17 +81,6 @@
   ?:  =(%earl myr)
     [[(sein our) %talk] [our %dojo] ~]
   [[our %talk] [our %dojo] ~]
-::
-++  deft-mast                                           ::  default master
-  |=  our/ship
-  ^-  master
-  :*  %&
-      [~ ~]
-      *(unit search)
-      *history
-      [%& %sole "{(scow %p our)}/ "]
-      *sole-command
-  ==
 ::
 ++  deft-pipe                                           ::  default source
   |=  our/ship                                          ::

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -626,8 +626,7 @@
     |=  ted/sole-edit
     ^+  +>
     =.  +>  (ta-det ted)
-    =.  +>  (ta-dog(say.inp (~(commit sole say.inp) ted)) ted)
-    +>
+    (ta-dog(say.inp (~(commit sole say.inp) ted)) ted)
   ::
   ++  ta-jump                                         ::  buffer pos
     |=  {dir/?($l $r) til/?($ace $edg $wrd) pos/@ud}

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -406,30 +406,6 @@
   ^+  +>
   (se-drop:(se-pull gyl) & gyl)
 ::
-++  se-plot                                           ::  status line
-  ^-  tape
-  =+  lag=se-agon
-  =+  ^=  pry
-      |=  gill  ^-  tape
-      =+((trip q.+<) ?:(=(our p.+>-) - :(welp (scow %p p.+>-) "/" -)))
-  =+  ^=  yey
-      |=  gill  ^-  tape
-      =+((pry +<) ?:(=(lag `+>-) ['*' -] -))
-  =+  ^=  yal  ^-  (list tape)
-      %+  weld
-        ^-  (list tape)
-        %+  turn  (~(tap by fug))
-        |=  {a/gill b/(unit target)}
-        =+  c=(yey a)
-        ?~(b ['?' c] c)
-      ^-  (list tape)
-      %+  turn  (skip (~(tap by fur)) |=({term *} (~(has by fug) [our +<-])))
-      |=({term *} ['-' (pry our +<-)])
-  |-  ^-  tape
-  ?~  yal  ~
-  ?~  t.yal  i.yal
-  :(welp i.yal ", " $(yal t.yal))
-::
 ++  se-klin                                           ::  disconnect app
   |=  gyl/gill
   +>(eel (~(del in eel) gyl))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -111,8 +111,8 @@
 !:
 ::::
   ::
-|=  {bowl drum-part}                                  ::  main drum work
-=+  (fall (~(get by bin) ost) *source)
+|=  {hid/bowl drum-part}                              ::  main drum work
+=+  (fall (~(get by bin) ost.hid) *source)
 =*  dev  -
 =>  |%                                                ::  arvo structures
     ++  pear                                          ::  request
@@ -141,10 +141,10 @@
 ::
 ++  peer                                              ::
   |=  pax/path
-  ~|  [%drum-unauthorized our+our src+src]            ::  ourself
-  ?>  (team our src)                                  ::  or our own moon
+  ~|  [%drum-unauthorized our+our.hid src+src.hid]    ::  ourself
+  ?>  (team our.hid src.hid)                          ::  or our own moon
   =<  se-abet  =<  se-view
-  (se-text "[{<src>}, driving {<our>}]")
+  (se-text "[{<src.hid>}, driving {<our.hid>}]")
 ::
 ++  poke-dill-belt                                    ::  terminal event
   |=  bet/dill-belt
@@ -189,7 +189,7 @@
   ?:  (se-aint gyl)  +>.$
   %-  se-dump:(se-drop & gyl)
   :_  u.saw
-  >[%drum-coup-fail src ost gyl]<
+  >[%drum-coup-fail src.hid ost.hid gyl]<
 ::
 ++  take-onto                                         ::  ack start
   |=  {way/wire saw/(each suss tang)}
@@ -208,7 +208,7 @@
   |=  way/wire
   =<  se-abet  =<  se-view
   =+  gyl=(drum-phat way)
-  ~&  [%drum-quit src ost gyl]
+  ~&  [%drum-quit src.hid ost.hid gyl]
   (se-drop %| gyl)
 ::                                                    ::  ::
 ::::                                                  ::  ::
@@ -219,16 +219,16 @@
   ?.  se-ably
     =.  .  se-adit
     [(flop moz) pith]
-  =.  sys  ?^(sys sys `ost)
+  =.  sys  ?^(sys sys `ost.hid)
   =.  .  se-subze:se-adze:se-adit
-  :_  pith(bin (~(put by bin) ost dev))
+  :_  pith(bin (~(put by bin) ost.hid dev))
   %-  flop
   ^-  (list move)
   ?~  biz  moz
   :_  moz
-  [ost %diff %dill-blit ?~(t.biz i.biz [%mor (flop biz)])]
+  [ost.hid %diff %dill-blit ?~(t.biz i.biz [%mor (flop biz)])]
 ::
-++  se-ably  (~(has by sup) ost)                      ::  caused by console
+++  se-ably  (~(has by sup.hid) ost.hid)              ::  caused by console
 ::
 ++  se-adit                                           ::  update servers
   ^+  .
@@ -240,7 +240,7 @@
   ?:  &(?=(^ hig) |(?=($~ u.hig) =(p.wel syd.u.u.hig)))  +>.$
   =.  +>.$  (se-text "activated app {(trip p.wel)}/{(trip q.wel)}")
   %-  se-emit(fur (~(put by fur) q.wel ~))
-  [ost %conf [%drum p.wel q.wel ~] [our q.wel] %load our p.wel]
+  [ost.hid %conf [%drum p.wel q.wel ~] [our.hid q.wel] %load our.hid p.wel]
 ::
 ++  se-adze                                           ::  update connections
   ^+  .
@@ -253,14 +253,14 @@
   (se-peer gil)
 ::
 ++  se-subze                                          ::  downdate connections
-  =<  .(dev (~(got by bin) ost))
-  =.  bin  (~(put by bin) ost dev)
+  =<  .(dev (~(got by bin) ost.hid))
+  =.  bin  (~(put by bin) ost.hid dev)
   ^+  .
   %-  ~(rep by bin)
   =<  .(con +>)
   |=  {{ost/bone dev/source} con/_.}  ^+  con
-  =+  xeno=se-subze-local:%_(con ost ost, dev dev)
-  xeno(ost ost.con, dev dev.con, bin (~(put by bin) ost dev.xeno))
+  =+  xeno=se-subze-local:%_(con ost.hid ost, dev dev)
+  xeno(ost.hid ost.hid.con, dev dev.con, bin (~(put by bin) ost dev.xeno))
 ::
 ++  se-subze-local
   ^+  .
@@ -275,7 +275,7 @@
 ++  se-aint                                           ::  ignore result
   |=  gyl/gill
   ^-  ?
-  ?.  (~(has by bin) ost)  &
+  ?.  (~(has by bin) ost.hid)  &
   =+  gyr=(~(get by fug) gyl)
   |(?=($~ gyr) ?=($~ u.gyr))
 ::
@@ -326,7 +326,7 @@
     (se-text "[already running {<p.wel>}/{<q.wel>}]")
   %=  +>
     ray  (~(put in ray) wel)
-    eel  (~(put in eel) [our q.wel])
+    eel  (~(put in eel) [our.hid q.wel])
   ==
 ::
 ++  se-drop                                           ::  disconnect
@@ -340,7 +340,7 @@
               +>.$(inx 0)
             (se-alas u.lag)
   =.  +>.$  (se-text "[unlinked from {<gyl>}]")
-  ?:  =(gyl [our %dojo])                              ::  undead dojo
+  ?:  =(gyl [our.hid %dojo])                          ::  undead dojo
     (se-link gyl)
   +>.$
 ::
@@ -413,7 +413,7 @@
   :: XX talk should be usable for stack traces, see urbit#584 which this change
   :: closed for the problems there
   ((slog (flop tac)) +>)
-  ::(se-emit 0 %poke /drum/talk [our %talk] (said:talk our %drum now eny tac))
+  ::(se-emit 0 %poke /drum/talk [our.hid %talk] (said:talk our.hid %drum now.hid eny.hid tac))
 ::
 ++  se-text                                           ::  return text
   |=  txt/tape
@@ -423,16 +423,16 @@
 ::
 ++  se-poke                                           ::  send a poke
   |=  {gyl/gill par/pear}
-  (se-emit [ost %poke (drum-path gyl) gyl par])
+  (se-emit [ost.hid %poke (drum-path gyl) gyl par])
 ::
 ++  se-peer                                           ::  send a peer
   |=  gyl/gill
   %-  se-emit(fug (~(put by fug) gyl ~))
-  [ost %peer (drum-path gyl) gyl /sole]
+  [ost.hid %peer (drum-path gyl) gyl /sole]
 ::
 ++  se-pull                                           ::  cancel subscription
   |=  gyl/gill
-  (se-emit [ost %pull (drum-path gyl) gyl ~])
+  (se-emit [ost.hid %pull (drum-path gyl) gyl ~])
 ::
 ++  se-tame                                           ::  switch connection
   |=  gyl/gill
@@ -453,7 +453,7 @@
   ++  ta-abet                                         ::  resolve
     ^+  ..ta
     ?.  liv
-      ?:   (~(has in (deft-fish our)) gyl)
+      ?:   (~(has in (deft-fish our.hid)) gyl)
         (se-blit qit+~)
       (se-nuke gyl)
     ..ta(fug (~(put by fug) gyl ``target`+<+))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -92,6 +92,7 @@
       ~                                                 ::  fur
       ~                                                 ::  bin
   ==                                                    ::
+::
 ++  drum-port
   |=  old/?(drum-part drum-part-old)  ^-  drum-part
   ?-  &2.old
@@ -131,7 +132,7 @@
     ++  move  (pair bone card)                        ::  user-level move
     --
 |_  {moz/(list move) biz/(list dill-blit)}
-++  diff-sole-effect-phat                             ::
+++  diff-sole-effect-phat                             ::  app event
   |=  {way/wire fec/sole-effect}
   =<  se-abet  =<  se-view
   =+  gyl=(drum-phat way)
@@ -145,34 +146,34 @@
   =<  se-abet  =<  se-view
   (se-text "[{<src>}, driving {<our>}]")
 ::
-++  poke-dill-belt                                    ::
+++  poke-dill-belt                                    ::  terminal event
   |=  bet/dill-belt
   =<  se-abet  =<  se-view
   (se-belt bet)
 ::
-++  poke-start                                        ::
+++  poke-start                                        ::  start app
   |=  wel/well
   =<  se-abet  =<  se-view
   (se-born wel)
 ::
-++  poke-link                                         ::
+++  poke-link                                         ::  connect app
   |=  gyl/gill
   =<  se-abet  =<  se-view
   (se-link gyl)
 ::
-++  poke-unlink                                       ::
+++  poke-unlink                                       ::  disconnect app
   |=  gyl/gill
   =<  se-abet  =<  se-view
   (se-klin gyl)
 ::
-++  poke-exit                                         ::
+++  poke-exit                                         ::  shutdown
   |=($~ se-abet:(se-blit-sys `dill-blit`[%qit ~]))    ::
 ::
-++  poke-put                                          ::
+++  poke-put                                          ::  write file
   |=  {pax/path txt/@}
   se-abet:(se-blit-sys [%sav pax txt])                ::
 ::
-++  reap-phat                                         ::
+++  reap-phat                                         ::  ack connect
   |=  {way/wire saw/(unit tang)}
   =<  se-abet  =<  se-view
   =+  gyl=(drum-phat way)
@@ -180,7 +181,7 @@
     (se-join gyl)
   (se-dump:(se-drop & gyl) u.saw)
 ::
-++  take-coup-phat                                    ::
+++  take-coup-phat                                    ::  ack poke
   |=  {way/wire saw/(unit tang)}
   =<  se-abet  =<  se-view
   ?~  saw  +>
@@ -190,7 +191,7 @@
   :_  u.saw
   >[%drum-coup-fail src ost gyl]<
 ::
-++  take-onto                                         ::
+++  take-onto                                         ::  ack start
   |=  {way/wire saw/(each suss tang)}
   =<  se-abet  =<  se-view
   ?>  ?=({@ @ $~} way)
@@ -228,6 +229,7 @@
   [ost %diff %dill-blit ?~(t.biz i.biz [%mor (flop biz)])]
 ::
 ++  se-ably  (~(has by sup) ost)                      ::  caused by console
+::
 ++  se-adit                                           ::  update servers
   ^+  .
   %+  roll  (~(tap in ray))
@@ -359,7 +361,7 @@
   ?>  ?=($~ (~(got by fug) gyl))
   (se-alas(fug (~(put by fug) gyl `*target)) gyl)
 ::
-++  se-nuke                                           ::  teardown
+++  se-nuke                                           ::  teardown connection
   |=  gyl/gill
   ^+  +>
   (se-drop:(se-pull gyl) & gyl)
@@ -675,41 +677,41 @@
     ^+  +>
     =.  ris  ~
     ?+    key    ta-bel
-      $dot  ?.  &(?=(^ old.hit) ?=(^ i.old.hit))
+      $dot  ?.  &(?=(^ old.hit) ?=(^ i.old.hit))      ::  last "arg" from hist
               ta-bel
             =+  old=`(list @c)`i.old.hit
             =+  sop=(ta-jump(buf.say.inp old) %l %ace (lent old))
             (ta-hom (cat:edit pos.inp (slag sop old)))
             ::
-      $bac  ?:  =(0 pos.inp)
+      $bac  ?:  =(0 pos.inp)                          ::  kill left-word
               ta-bel
             =+  sop=(ta-off %l %edg pos.inp)
             (ta-kil %l [(sub pos.inp sop) sop])
             ::
-      $b    ?:  =(0 pos.inp)
+      $b    ?:  =(0 pos.inp)                          ::  jump left-word
               ta-bel
             +>(pos.inp (ta-jump %l %edg pos.inp))
             ::
-      $c    ?:  =(pos.inp (lent buf.say.inp))
+      $c    ?:  =(pos.inp (lent buf.say.inp))         ::  capitalize
               ta-bel
             =+  sop=(ta-jump %r %wrd pos.inp)
             %-  ta-hom(pos.inp (ta-jump %r %edg sop))
             (rep:edit [sop 1] (ucas (swag [sop 1] buf.say.inp)))
             ::
-      $d    ?:  =(pos.inp (lent buf.say.inp))
+      $d    ?:  =(pos.inp (lent buf.say.inp))         ::  kill right-word
               ta-bel
             (ta-kil %r [pos.inp (ta-off %r %edg pos.inp)])
             ::
-      $f    ?:  =(pos.inp (lent buf.say.inp))
+      $f    ?:  =(pos.inp (lent buf.say.inp))         ::  jump right-word
               ta-bel
             +>(pos.inp (ta-jump %r %edg pos.inp))
             ::
       $r    %-  ta-hom(lay.hit (~(put by lay.hit) pos.hit ~))
-            :-  %set
+            :-  %set                                  ::  revert hist edit
             ?:  =(pos.hit num.hit)  ~
             (snag (sub num.hit +(pos.hit)) old.hit)
             ::
-      $t    =+  a=(ta-jump %r %edg pos.inp)
+      $t    =+  a=(ta-jump %r %edg pos.inp)           ::  transpose words
             =+  b=(ta-jump %l %edg a)
             =+  c=(ta-jump %l %edg b)
             ?:  =(b c)
@@ -722,7 +724,7 @@
                 (rep:edit prev (swag next buf.say.inp))
             ==
             ::
-      ?($u $l)
+      ?($u $l)                                        ::  upper/lower case
             ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             =+  case=?:(?=($u key) ucas lcas)
@@ -730,7 +732,7 @@
             =+  sel=[sop (ta-off %r %edg sop)]
             (ta-hom (rep:edit sel (case (swag sel buf.say.inp))))
             ::
-      $y    ?.  ?&  (gth num.kil 0)
+      $y    ?.  ?&  (gth num.kil 0)                   ::  rotate & yank
                     ?=(^ p.blt)
                     ?|  ?=({$ctl $y} u.p.blt)
                         ?=({$met $y} u.p.blt)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -213,17 +213,18 @@
   ::                                                  ::  ::
 ++  se-abet                                           ::  resolve
   ^-  (quip move *drum-part)
+  =*  pith  +>+>+<+
   ?.  se-ably
     =.  .  se-adit
-    [(flop moz) +>+>+<+]
+    [(flop moz) pith]
   =.  sys  ?^(sys sys `ost)
   =.  .  se-subze:se-adze:se-adit
-  :_  %_(+>+>+<+ bin (~(put by bin) ost `source`+>+<))
+  :_  pith(bin (~(put by bin) ost dev))
+  %-  flop
   ^-  (list move)
-  %+  welp  (flop moz)
-  ^-  (list move)
-  ?~  biz  ~
-  [ost %diff %dill-blit ?~(t.biz i.biz [%mor (flop biz)])]~
+  ?~  biz  moz
+  :_  moz
+  [ost %diff %dill-blit ?~(t.biz i.biz [%mor (flop biz)])]
 ::
 ++  se-ably  (~(has by sup) ost)                      ::  caused by console
 ++  se-adit                                           ::  update servers

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -14,8 +14,8 @@
 ++  drum-pith-0  _!!                                    ::  forgotten
 ++  drum-pith-1                                         ::
   $:  sys/(unit bone)                                   ::  local console
-      eel/(set gill)                                    ::  connect to 
-      ray/(set well)                                    ::  
+      eel/(set gill)                                    ::  connect to
+      ray/(set well)                                    ::
       fur/(map dude (unit server))                      ::  servers
       bin/(map bone source)                             ::  terminals
   ==                                                    ::
@@ -414,12 +414,7 @@
   |=  mov/move
   %_(+> moz [mov moz])
 ::
-++  se-emil                                           ::  emit moves
-  |=  mov/(list move)
-  ?~  mov  +>
-  $(mov t.mov, +> (se-emit i.mov))
-::
-++  se-talk  
+++  se-talk
   |=  tac/(list tank)
   ^+  +>
   :: XX talk should be usable for stack traces, see urbit#584 which this change

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -312,11 +312,9 @@
       {$yow *}  ~&([%no-yow -.bet] +>)
     ==
   =+  gul=se-agon
-  =+  tur=?~(gul ~ (~(get by fug) u.gul))    ::  XX se-aint
-  ?:  |(?=($~ gul) ?=($~ tur) ?=($~ u.tur))
+  ?:  |(?=($~ gul) (se-aint u.gul))
     (se-blit %bel ~)
-  =<  ta-abet
-  (ta-belt:(se-tame u.gul) bet)
+  ta-abet:(ta-belt:(se-tame u.gul) bet)
 ::
 ++  se-born                                           ::  new server
   |=  wel/well
@@ -398,9 +396,7 @@
 ++  se-view                                           ::  flush buffer
   ^+  .
   =+  gul=se-agon
-  =+  tur=?~(gul ~ (~(get by fug) u.gul))    ::  XX se-aint
-  ?:  |(?=($~ gul) ?=($~ tur) ?=($~ u.tur))
-    +>
+  ?:  |(?=($~ gul) (se-aint u.gul))  +
   (se-just ta-vew:(se-tame u.gul))
 ::
 ++  se-emit                                           ::  emit move

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -556,9 +556,10 @@
         $v  ta-bel
         $w  ?:  =(0 pos.inp)
               ta-bel
-            =+  b=(bwrd pos.inp buf.say.inp nace)
-            %-  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
-            (cut:edit b (sub pos.inp b))
+            =+  b=(ta-jump %l %ace pos.inp)
+            =+  sel=[(sub pos.inp b) b]
+            %-  (ta-kil %l (swag sel buf.say.inp))
+            (cut:edit sel)
         $x  +>(+> se-anon)
         $y  ?:  =(0 num.kil)
               ta-bel
@@ -636,6 +637,12 @@
     =.  +>  (ta-dog(say.inp (~(commit sole say.inp) ted)) ted)
     +>
   ::
+  ++  ta-jump                                         ::  buffer pos
+    |=  {dir/?($l $r) til/?($ace $edg $wrd) pos/@ud}
+    ^-  @ud
+    %-  ?:(?=($l dir) sub add)
+    [pos (ta-off dir til pos)]
+  ::
   ++  ta-kil                                          ::  update kill ring
     |=  {a/?($l $r) b/(list @c)}
     ^+  ta-hom
@@ -672,103 +679,55 @@
     %+  turn  a
     |=(a/@ ?.(&((gte a 'a') (lte a 'z')) a (sub a 32)))
   ::
-  ++  alnm                                            ::  alpha-numeric
-    |=  a/@  ^-  ?
-    ?|  &((gte a '0') (lte a '9'))
-        &((gte a 'A') (lte a 'Z'))
-        &((gte a 'a') (lte a 'z'))
-    ==
-  ::
-  ++  nace                                            ::  next ace offset
-    |=  a/(list @)
-    =|  i/@ud
-    =+  b=|
-    |-  ^+  i
-    ?~  a  i
-    =+  c=.=(32 i.a)
-    =.  b  |(b c)
-    ?:  &(b !|(=(0 i) c))
-      i
-    $(i +(i), a t.a)
-  ::
-  ++  nedg                                            ::  next boundary offset
-    |=  a/(list @)
-    =|  i/@ud
-    =+  b=|
-    |-  ^+  i
-    ?~  a  i
-    =+  c=(alnm i.a)
-    =.  b  |(b c)
-    ?:  &(b !|(=(0 i) c))
-      i
-    $(i +(i), a t.a)
-  ::
-  ++  nwrd                                            ::  word-offset
-    |=  a/(list @)
-    =|  i/@ud
-    |-  ^+  i
-    ?:  |(?=($~ a) (alnm i.a))
-      i
-    $(i +(i), a t.a)
-  ::
-  ++  bwrd                                            :: prev pos by offset
-    |=  {a/@ud b/(list @) c/$-((list @) @)}
-    ^-  @ud
-    (sub a (c (flop (scag a b))))
-  ::
-  ++  fwrd                                            :: next pos by offset
-    |=  {a/@ud b/(list @) c/$-((list @) @)}
-    ^-  @ud
-    (add a (c (slag a b)))
-  ::
   ++  ta-met                                          ::  meta key
     |=  key/@ud
     ?+    key    ta-bel
       $dot  ?.  &(?=(^ old.hit) ?=(^ i.old.hit))
               ta-bel
             =+  old=`(list @c)`i.old.hit
-            =+  b=(bwrd (lent old) old nedg)
+            =+  b=(ta-jump(buf.say.inp old) %l %edg (lent old))
             %-  ta-hom(ris ~)
             (cat:edit pos.inp (slag b old))
             ::
       $bac  ?:  =(0 pos.inp)
               ta-bel
-            =+  b=(bwrd pos.inp buf.say.inp nedg)
-            %-  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
-            (cut:edit b (sub pos.inp b))
+            =+  b=(ta-off %l %edg pos.inp)
+            =+  sel=[(sub pos.inp b) b]
+            %-  (ta-kil %l (swag sel buf.say.inp))
+            (cut:edit sel)
             ::
       $b    ?:  =(0 pos.inp)
               ta-bel
-            +>(pos.inp (bwrd pos.inp buf.say.inp nedg))
+            +>(pos.inp (ta-jump %l %edg pos.inp))
             ::
       $c    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            =+  sop=(fwrd pos.inp buf.say.inp nwrd)
-            %-  ta-hom(pos.inp (fwrd sop buf.say.inp nedg))
+            =+  sop=(ta-jump %r %wrd pos.inp)
+            %-  ta-hom(pos.inp (ta-jump %r %edg sop))
             (rep:edit [sop 1] (ucas (swag [sop 1] buf.say.inp)))
             ::
       $d    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            =+  f=(fwrd pos.inp buf.say.inp nedg)
-            %-  (ta-kil %r (slag pos.inp (scag f buf.say.inp)))
-            (cut:edit pos.inp (sub f pos.inp))
+            =+  sel=[pos.inp (ta-off %r %edg pos.inp)]
+            %-  (ta-kil %r (swag sel buf.say.inp))
+            (cut:edit sel)
             ::
       $f    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
-            +>(pos.inp (fwrd pos.inp buf.say.inp nedg))
+            +>(pos.inp (ta-jump %r %edg pos.inp))
             ::
       $r    %-  ta-hom(lay.hit (~(put by lay.hit) pos.hit ~))
             :-  %set
             ?:  =(pos.hit num.hit)  ~
             (snag (sub num.hit +(pos.hit)) old.hit)
             ::
-      $t    =+  a=(fwrd pos.inp buf.say.inp nedg)
-            =+  b=(bwrd a buf.say.inp nedg)
-            =+  c=(bwrd b buf.say.inp nedg)
+      $t    =+  a=(ta-jump %r %edg pos.inp)
+            =+  b=(ta-jump %l %edg a)
+            =+  c=(ta-jump %l %edg b)
             ?:  =(b c)
               ta-bel
-            =/  prev/(pair @ud @ud)  [c (sub (fwrd c buf.say.inp nedg) c)]
-            =/  next/(pair @ud @ud)  [b (sub a b)]
+            =+  next=[b (sub a b)]
+            =+  prev=[c (ta-off %r %edg c)]
             %-  ta-hom(pos.inp a)
             :~  %mor
                 (rep:edit next (swag prev buf.say.inp))
@@ -779,12 +738,10 @@
             ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             =+  case=?:(?=($u key) ucas lcas)
-            =+  sop=(fwrd pos.inp buf.say.inp nwrd)
-            =+  f=(fwrd sop buf.say.inp nedg)
+            =+  sop=(ta-jump %r %wrd pos.inp)
+            =+  sel=[sop (ta-off %r %edg sop)]
             %-  ta-hom
-            %+  rep:edit
-              [sop (sub f pos.inp)]
-            (case (slag sop (scag f buf.say.inp)))
+            (rep:edit sel (case (swag sel buf.say.inp)))
             ::
       $y    ?.  ?&  (gth num.kil 0)
                     ?=(^ p.blt)
@@ -825,6 +782,17 @@
       ris  ~
       lay.hit  ~
       old.hit  [buf.say.inp old.hit]
+    ==
+  ::
+  ++  ta-off                                          ::  buffer pos offset
+    |=  {dir/?($l $r) til/?($ace $edg $wrd) pos/@ud}
+    ^-  @ud
+    %-  ?-  til  $ace  ace:offset
+                 $edg  edg:offset
+                 $wrd  wrd:offset
+        ==
+    ?-  dir  $l  (flop (scag pos buf.say.inp))
+             $r  (slag pos buf.say.inp)
     ==
   ::
   ++  ta-pro                                          ::  set prompt
@@ -919,5 +887,41 @@
         (cut pos num)
         (cat pos txt)
     ==
+  --
+++  offset                                            ::  calculate offsets
+  |%
+  ++  alnm                                            ::  alpha-numeric
+    |=  a/@  ^-  ?
+    ?|  &((gte a '0') (lte a '9'))
+        &((gte a 'A') (lte a 'Z'))
+        &((gte a 'a') (lte a 'z'))
+    ==
+  ::
+  ++  ace                                             ::  next whitespace
+    |=  a/(list @)
+    =|  {b/_| i/@ud}
+    |-  ^-  @ud
+    ?~  a  i
+    =/  c  =(32 i.a)
+    =.  b  |(b c)
+    ?:  &(b !|(=(0 i) c))  i
+    $(i +(i), a t.a)
+  ::
+  ++  edg                                             ::  next word boundary
+    |=  a/(list @)
+    =|  {b/_| i/@ud}
+    |-  ^-  @ud
+    ?~  a  i
+    =/  c  (alnm i.a)
+    =.  b  |(b c)
+    ?:  &(b !|(=(0 i) c))  i
+    $(i +(i), a t.a)
+  ::
+  ++  wrd                                             ::  next or current word
+    |=  a/(list @)
+    =|  i/@ud
+    |-  ^-  @ud
+    ?:  |(?=($~ a) (alnm i.a))  i
+    $(i +(i), a t.a)
   --
 --

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -824,27 +824,18 @@
   ::
   ++  ta-vew                                          ::  computed prompt
     |-  ^-  (pair @ud (list @c))
-    ?^  ris
-      %=    $
-          ris  ~
-          cad.pom
-        :(welp "(reverse-i-search)'" (tufa str.u.ris) "': ")
-      ==
-    =-  [(add pos.inp (lent p.vew)) (weld (tuba p.vew) q.vew)]
-    ^=  vew  ^-  (pair tape (list @c))
-    ?:  vis.pom  [cad.pom buf.say.inp]
-    :-  ;:  welp
-          cad.pom
-          ?~  buf.say.inp  ~
-          ;:  welp
-            "<"
-            (scow %p (end 4 1 (sham buf.say.inp)))
-            "> "
-          ==
-        ==
-    =+  len=(lent buf.say.inp)
-    |-  ^-  (list @c)
-    ?:(=(0 len) ~ [`@c`'*' $(len (dec len))])
+    =;  vew/(pair (list @c) tape)
+      [(add pos.inp (lent q.vew)) (weld (tuba q.vew) p.vew)]
+    ?:  vis.pom
+      :-  buf.say.inp                                 ::  default prompt
+      ?~  ris
+        cad.pom
+      :(welp "(reverse-i-search)'" (tufa str.u.ris) "': ")
+    :-  (reap (lent buf.say.inp) `@c`'*')             ::  hidden input
+    %+  welp
+      cad.pom
+    ?~  buf.say.inp  ~
+    :(welp "<" (scow %p (end 4 1 (sham buf.say.inp))) "> ")
   --
 ++  edit                                              ::  produce sole-edits
   |%

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -684,9 +684,9 @@
       $dot  ?.  &(?=(^ old.hit) ?=(^ i.old.hit))
               ta-bel
             =+  old=`(list @c)`i.old.hit
-            =+  b=(ta-jump(buf.say.inp old) %l %edg (lent old))
+            =+  sop=(ta-jump(buf.say.inp old) %l %ace (lent old))
             %-  ta-hom(ris ~)
-            (cat:edit pos.inp (slag b old))
+            (cat:edit pos.inp (slag sop old))
             ::
       $bac  ?:  =(0 pos.inp)
               ta-bel
@@ -897,7 +897,7 @@
     =|  {b/_| i/@ud}
     |-  ^-  @ud
     ?~  a  i
-    =/  c  =(32 i.a)
+    =/  c  !=(32 i.a)
     =.  b  |(b c)
     ?:  &(b !|(=(0 i) c))  i
     $(i +(i), a t.a)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -334,7 +334,10 @@
   ^+  +>
   ?:  (~(has in ray) wel)
     (se-text "[already running {<p.wel>}/{<q.wel>}]")
-  +>(ray (~(put in ray) wel), eel (~(put in eel) [our q.wel]))
+  %=  +>
+    ray  (~(put in ray) wel)
+    eel  (~(put in eel) [our q.wel])
+  ==
 ::
 ++  se-drop                                           ::  disconnect
   |=  {pej/? gyl/gill}

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -19,7 +19,6 @@
       fur/(map dude (unit server))                      ::  servers
       bin/(map bone source)                             ::  terminals
   ==                                                    ::
-++  drum-start  well                                    ::  start (local) server
 ::                                                      ::  ::
 ::::                                                    ::  ::
   ::                                                    ::  ::

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -751,15 +751,13 @@
     |=  sop/@ud
     ^+  +>
     ?:  =(sop pos.hit)  +>
-    %+  %=  ta-hom
+    %-  %=  ta-hom
           pos.hit  sop
-          lay.hit  %+  ~(put by lay.hit)
-                     pos.hit
-                   buf.say.inp
+          lay.hit  (~(put by lay.hit) pos.hit buf.say.inp)
         ==
-      %set
-    %-  (bond |.((snag (sub num.hit +(sop)) old.hit)))
-    (~(get by lay.hit) sop)
+    :-  %set
+    %.  (~(get by lay.hit) sop)
+    (bond |.((snag (sub num.hit +(sop)) old.hit)))
   ::
   ++  ta-nex                                          ::  advance history
     ?:  ?|  ?=($~ buf.say.inp)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -407,13 +407,12 @@
   (se-show (sub p.lin off) (scag edg (slag off q.lin)))
 ::
 ++  se-view                                           ::  flush buffer
+  ^+  .
   =+  gul=se-agon
-  ?~  gul  +
-  =+  gyr=(~(get by fug) u.gul)
-  ?~  gyr  +>
-  ?~  u.gyr  +>
-  %-  se-just
-  ~(ta-vew ta [& u.gul] u.u.gyr)
+  =+  tur=?~(gul ~ (~(get by fug) u.gul))    ::  XX se-aint
+  ?:  |(?=($~ gul) ?=($~ tur) ?=($~ u.tur))
+    +>
+  (se-just ta-vew:(se-tame u.gul))
 ::
 ++  se-emit                                           ::  emit move
   |=  mov/move

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -499,20 +499,6 @@
       {$txt *}  (ta-txt p.bet)
     ==
   ::
-  ++  ta-cat                                          ::  mass insert
-    |=  {pos/@ud txt/(list @c)}
-    ^-  sole-edit
-    :-  %mor
-    |-  ^-  (list sole-edit)
-    ?~  txt  ~
-    [[%ins pos i.txt] $(pos +(pos), txt t.txt)]
-  ::
-  ++  ta-cut                                          ::  mass delete
-    |=  {pos/@ud num/@ud}
-    ^-  sole-edit
-    :-  %mor
-    |-(?:(=(0 num) ~ [[%del pos] $(num (dec num))]))
-  ::
   ++  ta-det                                          ::  send edit
     |=  ted/sole-edit
     ^+  +>
@@ -576,7 +562,7 @@
                   ris  ~
                   kil  (ta-kil %r (slag pos.inp buf.say.inp))
                 ==
-            (ta-cut pos.inp (sub len pos.inp))
+            (cut:edit pos.inp (sub len pos.inp))
         $l  +>(+> (se-blit %clr ~))
         $n  (ta-aro %d)
         $p  (ta-aro %u)
@@ -588,21 +574,16 @@
         $t  =+  len=(lent buf.say.inp)
             ?:  |(=(0 pos.inp) (lth len 2))
               ta-bel
-            =+  sop=?:(=(len pos.inp) (dec pos.inp) pos.inp)
-            =.  pos.inp  +(sop)
-            =.  ris  ~
-            %-  ta-hom
-            :~  %mor
-                [%del sop]
-                [%ins (dec sop) (snag sop buf.say.inp)]
-            ==
+            =+  sop=(sub pos.inp ?:(=(len pos.inp) 2 1))
+            %-  ta-hom(ris ~)
+            (rep:edit [sop 2] (flop (swag [sop 2] buf.say.inp)))
         $u  ?:  =(0 pos.inp)
               ta-bel
             %-  %=  ta-hom
                   ris  ~
                   kil  (ta-kil %l (scag pos.inp buf.say.inp))
                 ==
-            (ta-cut 0 pos.inp)
+            (cut:edit 0 pos.inp)
         $v  ta-bel
         $w  ?:  =(0 pos.inp)
               ta-bel
@@ -611,12 +592,12 @@
                   ris  ~
                   kil  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
                 ==
-            (ta-cut b (sub pos.inp b))
+            (cut:edit b (sub pos.inp b))
         $x  +>(+> se-anon)
         $y  ?:  =(0 num.kil)
               ta-bel
             %-  ta-hom(ris ~)
-            (ta-cat pos.inp (snag (sub num.kil pos.kil) old.kil))
+            (cat:edit pos.inp (snag (sub num.kil pos.kil) old.kil))
     ==
   ::
   ++  ta-cru                                          ::  hear crud
@@ -758,7 +739,7 @@
             =+  old=`(list @c)`i.old.hit
             =+  b=(bwrd (lent old) old nedg)
             %-  ta-hom(ris ~)
-            (ta-cat pos.inp (slag b old))
+            (cat:edit pos.inp (slag b old))
             ::
       $bac  ?:  =(0 pos.inp)
               ta-bel
@@ -767,7 +748,7 @@
                   ris  ~
                   kil  (ta-kil %l (slag b (scag pos.inp buf.say.inp)))
                 ==
-            (ta-cut b (sub pos.inp b))
+            (cut:edit b (sub pos.inp b))
             ::
       $b    ?:  =(0 pos.inp)
               ta-bel
@@ -777,11 +758,7 @@
               ta-bel
             =+  sop=(fwrd pos.inp buf.say.inp nwrd)
             %-  ta-hom(pos.inp (fwrd sop buf.say.inp nedg))
-            :~  %mor
-              [%del sop]
-              :+  %ins  sop
-              (head (ucas (limo [(snag sop buf.say.inp)]~)))
-            ==
+            (rep:edit [sop 1] (ucas (swag [sop 1] buf.say.inp)))
             ::
       $d    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
@@ -790,33 +767,28 @@
                   ris  ~
                   kil  (ta-kil %r (slag pos.inp (scag f buf.say.inp)))
                 ==
-            (ta-cut pos.inp (sub f pos.inp))
+            (cut:edit pos.inp (sub f pos.inp))
             ::
       $f    ?:  =(pos.inp (lent buf.say.inp))
               ta-bel
             +>(pos.inp (fwrd pos.inp buf.say.inp nedg))
             ::
       $r    %-  ta-hom(lay.hit (~(put by lay.hit) pos.hit ~))
-            :~  %mor
-              (ta-cut 0 (lent buf.say.inp))
-              %+  ta-cat  0
-              ?:  =(pos.hit num.hit)  ~
-              (snag (sub num.hit +(pos.hit)) old.hit)
-            ==
+            :-  %set
+            ?:  =(pos.hit num.hit)  ~
+            (snag (sub num.hit +(pos.hit)) old.hit)
             ::
       $t    =+  a=(fwrd pos.inp buf.say.inp nedg)
             =+  b=(bwrd a buf.say.inp nedg)
             =+  c=(bwrd b buf.say.inp nedg)
             ?:  =(b c)
               ta-bel
-            =+  prev=`(pair @ud @ud)`[c (fwrd c buf.say.inp nedg)]
-            =+  next=`(pair @ud @ud)`[b a]
-            %-  ta-hom(pos.inp q.next)
+            =/  prev/(pair @ud @ud)  [c (sub (fwrd c buf.say.inp nedg) c)]
+            =/  next/(pair @ud @ud)  [b (sub a b)]
+            %-  ta-hom(pos.inp a)
             :~  %mor
-              (ta-cut p.next (sub q.next p.next))
-              (ta-cat p.next (slag p.prev (scag q.prev buf.say.inp)))
-              (ta-cut p.prev (sub q.prev p.prev))
-              (ta-cat p.prev (slag p.next (scag q.next buf.say.inp)))
+                (rep:edit next (swag prev buf.say.inp))
+                (rep:edit prev (swag next buf.say.inp))
             ==
             ::
       ?($u $l)
@@ -826,25 +798,22 @@
             =+  sop=(fwrd pos.inp buf.say.inp nwrd)
             =+  f=(fwrd sop buf.say.inp nedg)
             %-  ta-hom
-            :~  %mor
-              (ta-cut sop (sub f pos.inp))
-              (ta-cat sop (case (slag sop (scag f buf.say.inp))))
-            ==
+            %+  rep:edit
+              [sop (sub f pos.inp)]
+            (case (slag sop (scag f buf.say.inp)))
             ::
       $y    ?.  ?&  (gth num.kil 0)
                     ?=(^ p.blt)
-                    ?|  ?=({$ctl p/$y} u.p.blt)
-                        ?=({$met p/$y} u.p.blt)
+                    ?|  ?=({$ctl $y} u.p.blt)
+                        ?=({$met $y} u.p.blt)
                 ==  ==
               ta-bel
             =+  las=(lent (snag (sub num.kil pos.kil) old.kil))
-            =+  sop=(sub pos.inp las)
             =+  pos=?:(=(1 pos.kil) num.kil (dec pos.kil))
             %-  ta-hom(pos.kil pos, ris ~)
-            :~  %mor
-              (ta-cut sop las)
-              (ta-cat sop (snag (sub num.kil pos) old.kil))
-            ==
+            %+  rep:edit
+              [(sub pos.inp las) las]
+            (snag (sub num.kil pos) old.kil)
     ==
   ::
   ++  ta-mov                                          ::  move in history
@@ -915,11 +884,7 @@
     ^+  +>
     ?^  ris
       (ta-ser txt)
-    %-  ta-hom
-    :-  %mor
-    |-  ^-  (list sole-edit)
-    ?~  txt  ~
-    [[%ins pos.inp i.txt] $(pos.inp +(pos.inp), txt t.txt)]
+    (ta-hom (cat:edit pos.inp txt))
   ::
   ++  ta-vew                                          ::  computed prompt
     |-  ^-  (pair @ud (list @c))
@@ -944,5 +909,31 @@
     =+  len=(lent buf.say.inp)
     |-  ^-  (list @c)
     ?:(=(0 len) ~ [`@c`'*' $(len (dec len))])
+  --
+++  edit                                              ::  produce sole-edits
+  |%
+  ++  cat                                             ::  mass insert
+    |=  {pos/@ud txt/(list @c)}
+    ^-  sole-edit
+    :-  %mor
+    |-  ^-  (list sole-edit)
+    ?~  txt  ~
+    [[%ins pos i.txt] $(pos +(pos), txt t.txt)]
+  ::
+  ++  cut                                             ::  mass delete
+    |=  {pos/@ud num/@ud}
+    ^-  sole-edit
+    :-  %mor
+    |-  ^-  (list sole-edit)
+    ?:  =(0 num)  ~
+    [[%del pos] $(num (dec num))]
+  ::
+  ++  rep                                             ::  mass replace
+    |=  {{pos/@ud num/@ud} txt/(list @c)}
+    ^-  sole-edit
+    :~  %mor
+        (cut pos num)
+        (cat pos txt)
+    ==
   --
 --

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -65,10 +65,11 @@
 ++  deft-apes                                           ::  default servers
   |=  our/ship
   %-  ~(gas in *(set well))
+  ^-  (list well)
   =+  myr=(clan our)
-  ?:  =(%pawn myr)
+  ?:  ?=($pawn myr)
     [[%base %talk] [%base %dojo] ~]
-  ?:  =(%earl myr)
+  ?:  ?=($earl myr)
     [[%home %dojo] ~]
   [[%home %talk] [%home %dojo] ~]
 ::
@@ -76,8 +77,7 @@
   |=  our/ship
   %-  ~(gas in *(set gill))
   ^-  (list gill)
-  =+  myr=(clan our)
-  ?:  =(%earl myr)
+  ?:  ?=($earl (clan our))
     [[(sein our) %talk] [our %dojo] ~]
   [[our %talk] [our %dojo] ~]
 ::
@@ -100,7 +100,7 @@
   ==
 ::
 ++  drum-path                                           ::  encode path
-  |=  gyl/gill
+  |=  gyl/gill  ^-  wire
   [%drum %phat (scot %p p.gyl) q.gyl ~]
 ::
 ++  drum-phat                                           ::  decode path
@@ -273,7 +273,7 @@
   ^-  ?
   ?.  (~(has by bin) ost)  &
   =+  gyr=(~(get by fug) gyl)
-  |(?=($~ gyr) ?=({$~ $~} gyr))
+  |(?=($~ gyr) ?=($~ u.gyr))
 ::
 ++  se-alas                                           ::  recalculate index
   |=  gyl/gill
@@ -309,9 +309,10 @@
     ~&  [%no-yow -.bet]
     +>
   =+  gul=se-agon
-  =+  tur=`(unit (unit target))`?~(gul ~ (~(get by fug) u.gul))
-  ?:  |(=(~ gul) =(~ tur) =([~ ~] tur))  (se-blit %bel ~)
-  =+  taz=~(. ta [& (need gul)] `target`(need (need tur)))
+  =+  tur=?~(gul ~ (~(get by fug) u.gul))
+  ?:  |(?=($~ gul) ?=($~ tur) ?=($~ u.tur))
+    (se-blit %bel ~)
+  =+  taz=~(. ta [& u.gul] u.u.tur)
   =.  blt.taz  [q.blt.taz `bet]
   =<  ta-abet
   ?-  -.bet
@@ -361,7 +362,7 @@
   |=  gyl/gill
   ^+  +>
   =.  +>  (se-text "[linked to {<gyl>}]")
-  ?>  =(~ (~(got by fug) gyl))
+  ?>  ?=($~ (~(got by fug) gyl))
   (se-alas(fug (~(put by fug) gyl `*target)) gyl)
 ::
 ++  se-nuke                                           ::  teardown

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -435,15 +435,16 @@
 ::
 ++  se-poke                                           ::  send a poke
   |=  {gyl/gill par/pear}
-  (se-emit ost %poke (drum-path gyl) gyl par)
+  (se-emit [ost %poke (drum-path gyl) gyl par])
 ::
 ++  se-peer                                           ::  send a peer
   |=  gyl/gill
-  (se-emit(fug (~(put by fug) gyl ~)) ost %peer (drum-path gyl) gyl /sole)
+  %-  se-emit(fug (~(put by fug) gyl ~))
+  [ost %peer (drum-path gyl) gyl /sole]
 ::
 ++  se-pull                                           ::  cancel subscription
   |=  gyl/gill
-  (se-emit ost %pull (drum-path gyl) gyl ~)
+  (se-emit [ost %pull (drum-path gyl) gyl ~])
 ::
 ++  se-tame                                           ::  switch connection
   |=  gyl/gill

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -561,7 +561,7 @@
         $x  +>(..ta se-anon)
         $y  ?:  =(0 num.kil)
               ta-bel
-            (ta-hom (cat:edit pos.inp (snag (sub num.kil pos.kil) old.kil)))
+            (ta-hom (cat:edit pos.inp ta-yan))
     ==
   ::
   ++  ta-del                                          ::  hear delete
@@ -732,18 +732,15 @@
             =+  sel=[sop (ta-off %r %edg sop)]
             (ta-hom (rep:edit sel (case (swag sel buf.say.inp))))
             ::
-      $y    ?.  ?&  (gth num.kil 0)                   ::  rotate & yank
+      $y    ?.  ?&  ?=(^ old.kil)                     ::  rotate & yank
                     ?=(^ p.blt)
                     ?|  ?=({$ctl $y} u.p.blt)
                         ?=({$met $y} u.p.blt)
                 ==  ==
               ta-bel
-            =+  las=(lent (snag (sub num.kil pos.kil) old.kil))
-            =+  pos=?:(=(1 pos.kil) num.kil (dec pos.kil))
-            %-  ta-hom(pos.kil pos)
-            %+  rep:edit
-              [(sub pos.inp las) las]
-            (snag (sub num.kil pos) old.kil)
+            =+  las=(lent ta-yan)
+            =.  pos.kil  ?:(=(1 pos.kil) num.kil (dec pos.kil))
+            (ta-hom (rep:edit [(sub pos.inp las) las] ta-yan))
     ==
   ::
   ++  ta-mov                                          ::  move in history
@@ -828,6 +825,9 @@
       cad.pom
     ?~  buf.say.inp  ~
     :(welp "<" (scow %p (end 4 1 (sham buf.say.inp))) "> ")
+  ::
+  ++  ta-yan                                          ::  yank
+    (snag (sub num.kil pos.kil) old.kil)
   --
 ++  edit                                              ::  produce sole-edits
   |%


### PR DESCRIPTION
advance apologies for the opening this massive PR without warning ...

I started refactoring as I looked into #255. I ended up blocked there, but some of my changes seemed generally useful. I kept them, and started on a long-overdue cleanup of `++ta-met` and related gates. I've tried to keep my commits separate, but I'm happy to cherry-pick across multiple branches if that'd be easier to review.

This PR covers several areas:

- restoring lost PRs

restores the fixes from #226 and #235 (although not their exact implementations), which were inadvertently removed in 786bce0

- dead code removal

everything related to `++master`, `++ukase`, and several `++se-*` arms were completely unused

- type safety

favoring `?=` over `.=`, avoiding `-.limb`, especially when pattern-matching a kelp, casting judiciously, etc.

- readability

a face for `++bowl`, bracketed moves, whitespace, etc.

- a long overdue refactoring of `++ta-met`

many cases were overly complex or contained redundancies

- comments

