### PR TITLE
fixes +-key:by (produce a valid set by using +-put:in)

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2871,9 +2871,10 @@
     ?~(a 0 +((add $(a l.a) $(a r.a))))
   ::
   +-  key                                               ::  set of keys
-    |-  ^-  (set _?>(?=(^ a) p.n.a))
-    ?~  a  ~
-    [n=p.n.a l=$(a l.a) r=$(a r.a)]
+    =|  b/(set _?>(?=(^ a) p.n.a))
+    |-  ^+  b
+    ?~  a   b
+    $(a r.a, b $(a l.a, b (~(put in b) p.n.a)))
   ::
   +-  val                                               ::  list of vals
     =|  b/(list _?>(?=(^ a) q.n.a))


### PR DESCRIPTION
*apologizes for this and all future attempted cleverness*

I thought `++by` and `++in` used the same hashes, but I only checked atoms ...

closes #266