### PR TITLE
urbit/talk@c83aedc Don't prepend extra ~ to audi

### DIFF
--- a/web/talk/main.js
+++ b/web/talk/main.js
@@ -338,7 +338,7 @@ module.exports = recl({
   _handleAudi: function(e) {
     var audi;
     audi = _.map($(e.target).closest('.path').find('div'), function(div) {
-      return "~" + $(div).text();
+      return $(div).text();
     });
     return this.props._handleAudi(audi);
   },


### PR DESCRIPTION
Selecting previous messages' audiences would result in ~~him/foo messages, which would promptly be rejected by the server.