### PR TITLE
remove duplicate arms within kernel cores

### DIFF
--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -76,9 +76,6 @@
   $%  {$nice $~}                                        ::
       {$init p/ship}                                    ::
   ==                                                    ::
-++  sign-gall                                           ::  see %gall
-  $%  {$onto p/(unit tang)}                             ::
-  ==                                                    ::
 ++  sign-clay                                           ::
   $%  {$mere p/(each (set path) (pair term tang))}      ::
       {$note p/@tD q/tank}                              ::

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -5009,7 +5009,7 @@
     $d  [%d q.q.don p.q.don]
   ==
 ::
-++  hump                                                ::  general prepatch
+++  hemp                                                ::  general prepatch
   |=  {pum/umph src/*}  ^-  *
   ?+  pum  ~|(%unsupported !!)
     $a  src

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2290,13 +2290,6 @@
               heg/(map hand code)                       ::  proposed
               qim/(map hand code)                       ::  inbound
           ==                                            ::
-++  coal  *                                             ::  untyped vase
-++  code  @uvI                                          ::  symmetric key
-++  cone                                                ::  reconfiguration
-          $%  {$& p/twig}                               ::  transform
-              {$| p/(list @tas)}                        ::  alter
-          ==                                            ::
-++  chum  @uvI                                          ::  hashed passcode
 ++  claw                                                ::  startup chain
           $:  joy/(unit coal)                           ::  local context
               ran/(unit coal)                           ::  arguments
@@ -2309,7 +2302,7 @@
 ++  coal  *                                             ::  untyped vase
 ++  code  @uvI                                          ::  symmetric key
 ++  cone                                                ::  reconfiguration
-          $%  {$& p/twig}                                ::  transform
+          $%  {$& p/twig}                               ::  transform
               {$| p/(list @tas)}                        ::  alter
           ==                                            ::
 ++  coop  (unit ares)                                   ::  e2e ack


### PR DESCRIPTION
as reported in #199 and urbit/urbit#622

This PR doesn't disallow duplicate arms, but simply removes those that already exist (since the disallowing has to be released separately).

Note: I renamed `++hump` to `++hemp` instead of removing it. It's unused, but so is much of the surrounding code in Section 2eP...