### PR TITLE
removes +-gaf:by

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2731,16 +2731,6 @@
       a
     $(b t.b, a (put p.i.b q.i.b))
   ::
-  +-  gaf                                               ::  concat, fail on dupe
-    ~/  %gaf
-    |=  b/(list _?>(?=(^ a) n.a))
-    |-  ^+  a
-    ?~  b
-      a
-    ~|  duplicate-key+p.i.b
-    ?<  (has p.i.b)
-    $(b t.b, a (put p.i.b q.i.b))
-  ::
   +-  get                                               ::  grab value by key
     ~/  %get
     |=  b/*


### PR DESCRIPTION
The current `+-gaf:by` implementation prints `%duplicate-key` for every recursive invocation prior to detecting a duplicate.

There's still a bigger problem, which is that wet arms can't `++slog` in a type-aware manner (see urbit/urbit#700). Given that, and the inapplicability of `+-gaf:by` to #199, is it worth keeping around? Should I instead just remove the arm?