### PR TITLE
add support for tree head js "extras"

### DIFF
--- a/ren/tree/head.hoon
+++ b/ren/tree/head.hoon
@@ -15,6 +15,8 @@
       |=  gas/epic  ^-  {? ?}                           :: check if the query
       :-  (~(has by qix.gas) 'dbg.nopack')              :: dictates separate files
       (~(has by qix.gas) 'dbg.nomin')                   :: and/or unminified assets
+/=    extras    /:  /===/ren/tree/head/extras           :: additional scripts
+                /^  (map knot cord)    /_  /js/
 ::
 |%
 ++  cdnjs
@@ -45,6 +47,7 @@
     ;script(type "text/javascript", src "{(cdnjs "react/0.14.6/react")}");
     ;script(type "text/javascript", src "{(cdnjs "react/0.14.6/react-dom")}");
     ;script(type "text/javascript", src "{(cdnjs "flux/2.1.1/Flux")}");
+    ;*  (turn (~(tap by extras)) |=({@ a/@t} ;script(type "text/javascript"):"{(trip a)}"))
 ::     ;script(type "text/javascript", src "//cdnjs.cloudflare.com/ajax/libs/codemirror/4.3.0/codemirror.js");
 ::     ;script(type "text/javascript", src "//cdnjs.cloudflare.com/ajax/libs/".
 ::       "codemirror/4.3.0/mode/markdown/markdown.min.js");


### PR DESCRIPTION
Usage: e.g. ren/tree/head/extras/analytics.js containing

```
  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

  ga('create', 'UA-47054188-3', 'auto');
  ga('send', 'pageview');
```