### PR TITLE
updates ++apt to transitively verify set constraints

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2388,10 +2388,13 @@
 ::
 ++  apt                                                 ::  set invariant
   |=  a/(tree)
-  ?~  a
-    &
-  ?&  ?~(l.a & ?&((vor n.a n.l.a) (hor n.l.a n.a) $(a l.a)))
-      ?~(r.a & ?&((vor n.a n.r.a) (hor n.a n.r.a) $(a r.a)))
+  =|  {l/(unit) r/(unit)}
+  |-  ^-  ?
+  ?~  a   &
+  ?&  ?~(l & (hor n.a u.l))
+      ?~(r & (hor u.r n.a))
+      ?~(l.a & ?&((vor n.a n.l.a) $(a l.a, l `n.a)))
+      ?~(r.a & ?&((vor n.a n.r.a) $(a r.a, r `n.a)))
   ==
 ::
 ++  in                                                  ::  set engine

--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -2586,11 +2586,14 @@
 ::                section 2dB, maps                     ::
 ::
 ++  ept                                                 ::  map invariant
-  |=  a/(tree {p/* q/*})
-  ?~  a
-    &
-  ?&  ?~(l.a & ?&((vor p.n.a p.n.l.a) (gor p.n.l.a p.n.a) $(a l.a)))
-      ?~(r.a & ?&((vor p.n.a p.n.r.a) (gor p.n.a p.n.r.a) $(a l.a)))
+  |=  a/(tree (pair))
+  =|  {l/(unit) r/(unit)}
+  |-  ^-  ?
+  ?~  a   &
+  ?&  ?~(l & (gor p.n.a u.l))
+      ?~(r & (gor u.r p.n.a))
+      ?~(l.a & ?&((vor p.n.a p.n.l.a) $(a l.a, l `p.n.a)))
+      ?~(r.a & ?&((vor p.n.a p.n.r.a) $(a r.a, r `p.n.a)))
   ==
 ::
 ++  ja                                                  ::  jar engine


### PR DESCRIPTION
I'm not sure that this is the most efficient approach. It maintains lists of ancestor nodes: `l` for ancestors whose left branch we descended, `r` for right. (there's a case to be made for reversing those names ...)

In any case, using the broken `+-key:by` implementation:

```
:+  (apt (sy /a /b /c ~))
    (apt ~(key by (my [/a 1] [/b 2] [/c 3] ~)))
    (apt (sy /a /b /c /d /e /f ~))
```

produces `[%.y %.n %.y]`

re #266 