### PR TITLE
updates ++snag to cast the product

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -798,7 +798,7 @@
 ++  snag                                                ::  index
   ~/  %snag
   |*  {a/@ b/(list)}
-  |-
+  |-  ^+  ?>(?=(^ b) i.b)
   ?~  b
     ~|('snag-fail' !!)
   ?:  =(0 a)  i.b


### PR DESCRIPTION
as pointed out by @ohAitch on `urbit-meta` ...