### PR TITLE
Talk no longer displays @ as the glyph for your own @-messages.

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -2183,8 +2183,6 @@
         =.  pal  ?:  =(who our.hid)  pal
                  (~(del in pal) [%& who (main who)])
         (weld ~(te-pref te man pal) txt)
-      ?:  oug
-        (weld "@ " txt)
       (weld " " txt)
     ::
         $app


### PR DESCRIPTION
Does what it says on the box.