### PR TITLE
reapplies ++cass change too lib/elem-to-react (unbreak the web)

### DIFF
--- a/lib/elem-to-react-json.hoon
+++ b/lib/elem-to-react-json.hoon
@@ -8,7 +8,7 @@
   ~+  ^-  (map term cord)
   %-  molt  ^-  (list (pair term cord))  
   :-  [%class 'className']
-  =-  (rash - (more next (cook |=(a/tape [(cass a) (crip a)]) (star alf))))  
+  =-  (rash - (more next (cook |=(a/tape [(crip (cass a)) (crip a)]) (star alf))))
   '''
   accept acceptCharset accessKey action allowFullScreen allowTransparency alt
   async autoComplete autoFocus autoPlay cellPadding cellSpacing charSet checked


### PR DESCRIPTION
this change from #262 that was lost in the merge of #287