### PR TITLE
disallows duplicate arms in ++wisp

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -10183,8 +10183,14 @@
     ::
     ++  wisp                                            ::  core tail
       %-  ulva
-      %+  cook
-        |=(a/(list {p/term q/foot}) (~(gas by *(map term foot)) a))
+      %+  sear
+        |=  a/(list (pair term foot))
+        =|  b/(map term foot)
+        |-  ^-  (unit _b)
+        ?~  a  `b
+        ?:  (~(has by b) p.i.a)
+          ~&(duplicate-arm+p.i.a ~)
+        $(a t.a, b (~(put by b) p.i.a q.i.a))
       (most muck boog)
     ::
     ++  toad                                            ::  untrap parser exp


### PR DESCRIPTION
added this now that #270 has been merged -- see #199 for discussion.

closes #199
