### PR TITLE
remove [press enter to compute] +pope prompt

### DIFF
--- a/gen/pope.hoon
+++ b/gen/pope.hoon
@@ -17,11 +17,7 @@
 %+  sole-lo  [%| %pope-pass "passphrase: "]
 %+  sole-go  (boss 256 (star prn))
 |=  fra/@t
-%+  sole-lo  [%| %pope-none "[press enter to compute]"]  :: XX oy
-%+  sole-go  (easy ~)
-|=  $~
 =+  bur=(shaz (add who (shaz fra)))
-~&  %computing-fingerprint
 =+  arc=(pit:nu:cryp 512 bur)
 %+  sole-so  %tang
 :~  leaf+"generator: {(scow %uw bur)}"


### PR DESCRIPTION
Curve key generation is fast enough that computing all the partial-passphrase keys is not prohibitively expensive.