### PR TITLE
Added a %mutegroup setting to talk. Suppresses presence output when set.

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -288,7 +288,7 @@
       ++  setting
         %-  perk  :~
           %noob
-          %mutegroup
+          %quiet
         ==
       ++  work
         %+  knee  *^work  |.  ~+
@@ -770,7 +770,7 @@
                 cha/(list (pair ship status))
             ==
           ==
-      ?:  (~(has in settings.she) %mutegroup)
+      ?:  (~(has in settings.she) %quiet)
         +>.$
       =.  +>.$
           |-  ^+  +>.^$
@@ -802,7 +802,7 @@
       =+  day=(sh-repo-rogue-diff q.owners.she yid)
       =+  dun=q.owners.she
       =.  q.owners.she  yid
-      ?:  (~(has in settings.she) %mutegroup)
+      ?:  (~(has in settings.she) %quiet)
         +>.$
       =.  +>.$
           |-  ^+  +>.^$

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -288,6 +288,7 @@
       ++  setting
         %-  perk  :~
           %noob
+          %mutegroup
         ==
       ++  work
         %+  knee  *^work  |.  ~+
@@ -769,6 +770,8 @@
                 cha/(list (pair ship status))
             ==
           ==
+      ?:  (~(has in settings.she) %mutegroup)
+        +>.$
       =.  +>.$
           |-  ^+  +>.^$
           ?~  old.cul  +>.^$
@@ -799,6 +802,8 @@
       =+  day=(sh-repo-rogue-diff q.owners.she yid)
       =+  dun=q.owners.she
       =.  q.owners.she  yid
+      ?:  (~(has in settings.she) %mutegroup)
+        +>.$
       =.  +>.$
           |-  ^+  +>.^$
           ?~  old.day  +>.^$


### PR DESCRIPTION
`;set mutegroup` suppresses group notifications (ie `for station --met ship %hear`).

I'm fairly sure this doesn't break anything. `;who`'s output still updates correctly at least. Please do verify.

Also, I'm taking suggestions for a better setting name than `mutegroup`. `mutepresence` seems a bit long, `quiet` too ambiguous. What do you think?