### PR TITLE
Change .rss-xml to use correct urls, metadata

### DIFF
--- a/arvo/ford.hoon
+++ b/arvo/ford.hoon
@@ -1136,6 +1136,7 @@
           &((slob %grow p.pro) (slob too p:(slap pro [%limb %grow])))
         :: ~$  link-grow
         :: =<  $  ~%  %grow  link-jet  ~  |.
+        %+  cool  |.(leaf+"ford: grow {<for>} to {<too>}")
         %+  cope  (keel cof pro [[%& 6]~ vax]~)
         |=  {cof/cafe pox/vase}
         (maim cof pox [%per [%limb %grow] [%limb too]])

--- a/mar/json.hoon
+++ b/mar/json.hoon
@@ -9,8 +9,8 @@
 ::
 ++  grow                                                ::  convert to
   |%
-  ++  mime  [/application/json (taco txt)]                     ::  convert to %mime
-  ++  txt   (crip (pojo jon))
+  ++  mime  [/application/json (tact (pojo jon))]       ::  convert to %mime
+  ++  txt   (lore (crip (pojo jon)))
   --
 ++  grab
   |%                                                    ::  convert from

--- a/ren/rss-xml.hoon
+++ b/ren/rss-xml.hoon
@@ -5,7 +5,7 @@
 /?    310
 /=  our  /$  |=({bem/beam *} p.bem)
 /=  top
-  /.  /=  pax  /$  |=({bem/beam *} (slag 1 (flop s.bem)))
+  /.  /=  pax  /$  |=({bem/beam *} (slag (lent /web) (flop s.bem)))
       /=  inf  /%  /&front&/|(/front/ /~[~])
   ==
 /=  kid  /^  :(map knot knot cord)

--- a/ren/rss-xml.hoon
+++ b/ren/rss-xml.hoon
@@ -3,9 +3,9 @@
 ::::  /hoon/rss-xml/ren
   ::
 /?    310
-/=  sum  /%  /&snip&elem&/|(/elem/ /~[;div;])
-/=  kid  /^  (map knot {marl marl})
-         /%  /_  /&snip&/elem/
+/=  sum  /%  /&front&/|(/front/ /~[~])
+/=  kid  /^  :(map knot knot cord)
+         /%  /_  /front/
 /$    |=({bem/beam *} [our=p.bem tub=(slag 1 (flop s.bem))])
 !:
 ::::  ~fyr, ~tasfyn-partyv
@@ -14,21 +14,36 @@
 ::  Link from relative path
 =+  hok=.^(hart %e /(scot %p our)/host/real)
 =+  ref=|=(a/path (earn hok `(weld tub a) ~))
-::  urb:front attrs confuse RSS validators, readers
-=+  no-meta=|=(a/marl ^+(a ?~(a ~ ?.(?=($meta n.g.i.a) a $(a t.a)))))
+=/  atrs
+  |=  a/(map cord cord)
+  :*  title=(fall (~(get by a) %title) '')
+      preview=(fall (~(get by a) %preview) '')
+      author=(fall (~(get by a) %author) '')
+      date=(fall (~(get by a) %date) '')
+  ==
 ::
 %-  crip  %-  poxo
 ;rss(version "2.0")
+::   ;raw: *{(turn (wash 0^80 >% .<) |=(a/tape ;l:"{a}"))}
   ;channel
-    ;title: *{hed.sum}
-    ;link: {(ref /)}
-    ;description: *{(no-meta tal.sum)}
+    ;*  =/  a  (atrs sum)
+        ;=
+          ;title: {(trip title.a)}
+          ;link: {(ref /)}
+          ;description: {(trip preview.a)}
+        ==
     ;*  %+  turn  (~(tap by kid))
-        |=  {nom/@t hed/marl tal/marl}
+        |=  {nom/@t som/(map knot cord)}
+        =/  a  (atrs som)
         ;item
-          ;title: *{hed}
-          ;description: *{(no-meta tal)}
           ;link: {(ref /[nom])}
+          ;title: {(trip title.a)}
+          ;author: {(trip author.a)}
+          ;description: {(trip preview.a)}
+          ;*  %-  drop
+              %+  bind  (slaw %da date.a)
+              |=  b/@da  ^-  manx
+              ;date:"{(dust (yore b))}"
         ==
   ==
 ==

--- a/ren/rss-xml.hoon
+++ b/ren/rss-xml.hoon
@@ -51,7 +51,7 @@
           ;*  %-  drop
               %+  bind  (slaw %da date.a)
               |=  b/@da  ^-  manx
-              ;date:"{(dust (yore b))}"
+              [/'pubDate' ;/((dust (yore b))) ~]
         ==
   ==
 ==

--- a/ren/rss-xml.hoon
+++ b/ren/rss-xml.hoon
@@ -3,9 +3,9 @@
 ::::  /hoon/rss-xml/ren
   ::
 /?    310
-/=  sum  /&snip&elem&/|(/elem/ /~[;div;])
+/=  sum  /%  /&snip&elem&/|(/elem/ /~[;div;])
 /=  kid  /^  (map knot {marl marl})
-         /_  /&snip&/elem/
+         /%  /_  /&snip&/elem/
 /$    |=({bem/beam *} [our=p.bem tub=(slag 1 (flop s.bem))])
 !:
 ::::  ~fyr, ~tasfyn-partyv

--- a/ren/rss-xml.hoon
+++ b/ren/rss-xml.hoon
@@ -3,40 +3,48 @@
 ::::  /hoon/rss-xml/ren
   ::
 /?    310
-/=  sum  /%  /&front&/|(/front/ /~[~])
+/=  our  /$  |=({bem/beam *} p.bem)
+/=  top
+  /.  /=  pax  /$  |=({bem/beam *} (slag 1 (flop s.bem)))
+      /=  inf  /%  /&front&/|(/front/ /~[~])
+  ==
 /=  kid  /^  :(map knot knot cord)
          /%  /_  /front/
-/$    |=({bem/beam *} [our=p.bem tub=(slag 1 (flop s.bem))])
 !:
 ::::  ~fyr, ~tasfyn-partyv
   ::
-::~&  [sum=sum kid=kid]
-::  Link from relative path
-=+  hok=.^(hart %e /(scot %p our)/host/real)
-=+  ref=|=(a/path (earn hok `(weld tub a) ~))
-=/  atrs
+|%
+++  relative-link
+  =/  external-host
+    ~+(.^(hart %e /(scot %p our)/host/real))
+  |=  a/path  ^-  tape
+  (earn external-host `(weld pax.top a) ~)
+::
+++  parse-front
   |=  a/(map cord cord)
   :*  title=(fall (~(get by a) %title) '')
       preview=(fall (~(get by a) %preview) '')
       author=(fall (~(get by a) %author) '')
       date=(fall (~(get by a) %date) '')
   ==
+--
 ::
+::::
+  ::
 %-  crip  %-  poxo
 ;rss(version "2.0")
-::   ;raw: *{(turn (wash 0^80 >% .<) |=(a/tape ;l:"{a}"))}
   ;channel
-    ;*  =/  a  (atrs sum)
+    ;*  =/  a  (parse-front inf.top)
         ;=
           ;title: {(trip title.a)}
-          ;link: {(ref /)}
+          ;link: {(relative-link /)}
           ;description: {(trip preview.a)}
         ==
     ;*  %+  turn  (~(tap by kid))
-        |=  {nom/@t som/(map knot cord)}
-        =/  a  (atrs som)
+        |=  {fyl/@t inf/(map knot cord)}
+        =/  a  (parse-front inf)
         ;item
-          ;link: {(ref /[nom])}
+          ;link: {(relative-link /[fyl])}
           ;title: {(trip title.a)}
           ;author: {(trip author.a)}
           ;description: {(trip preview.a)}

--- a/ren/tree/head.hoon
+++ b/ren/tree/head.hoon
@@ -3,7 +3,7 @@
   ::
 ::
 /?    310
-/=    tub    /$  |=({bem/beam *} (flop s.bem))
+/=    tub    /$  |=({bem/beam *} (slag (lent /web) (flop s.bem)))
 /=    aut
   /$  %+  cork  fuel                                    :: after parsing params,
       |=  gas/epic  ^-  ?                               :: check that the fcgi

--- a/ren/urb/tree.hoon
+++ b/ren/urb/tree.hoon
@@ -3,7 +3,7 @@
 ::::  /hoon/tree/urb/ren
   ::
 /?    310
-/=   hed    /#    /%   /:  /===/ren   /tree-head/  :: XX static
+/=   hed    /#    /%   /tree-head/
 /=   bod    /#    /%   /tree-body/
 ^-  {hed/{@uvH marl} bod/{@uvH marl}}
 [hed bod]


### PR DESCRIPTION
All rss source items must now have title: and description: markdown frontmatter to display properly in readers.