### PR TITLE
Fixed talk's parsing of ;who

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -300,7 +300,7 @@
             qut
           ==
         ::
-          ;~(plug (perk %who ~) ;~(pose para (easy ~)))
+          ;~(plug (perk %who ~) ;~(pose ;~(pfix ace para) (easy ~)))
           ;~(plug (perk %bind ~) ;~(pfix ace glyph) (punt ;~(pfix ace para)))
           ;~((glue ace) (perk %join ~) para)
           ;~((glue ace) (perk %leave ~) para)


### PR DESCRIPTION
Now properly parses `;who station` and denies `;whostation`.

This fixes urbit/talk#29.