### PR TITLE
Talk setting: message timestamps

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -289,6 +289,7 @@
         %-  perk  :~
           %noob
           %quiet
+          %showtime
         ==
       ++  work
         %+  knee  *^work  |.  ~+
@@ -2109,6 +2110,15 @@
         ?.  (~(has in sef) %noob)
           (~(sn-curt sn man [who (main who)]) |)
         (~(sn-nick sn man [who (main who)]))
+    ?:  (~(has in sef) %showtime)
+      =+  dat=(yore now.hid)
+      =+  ^=  t
+        |=  a/@  ^-  tape
+        %+  weld
+          ?:  (lth a 10)  "0"  ~
+          (scow %ud a)
+      =+  ^=  time  :(weld "~" (t h.t.dat) "." (t m.t.dat) "." (t s.t.dat))
+      :(weld baw txt (reap (sub 67 (lent txt)) ' ') time)
     (weld baw txt)
   ::
   ++  tr-meta  ^-  tang

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -436,8 +436,8 @@
     ::
     ++  sh-rend                                         ::  print on one line
       |=  gam/telegram
-      =+  lin=~(tr-line tr man.she (~(has in settings.she) %noob) gam)
-      (sh-pass:(sh-fact %txt lin) q.q.gam) 
+      =+  lin=~(tr-line tr man.she settings.she gam)
+      (sh-pass:(sh-fact %txt lin) q.q.gam)
     ::
     ++  sh-numb                                         ::  print msg number
       |=  num/@ud
@@ -1003,7 +1003,7 @@
       ++  activate                                      ::  from %number
         |=  gam/telegram
         ^+  ..sh-work
-        =+  tay=~(. tr man.she (~(has in settings.she) %noob) gam)
+        =+  tay=~(. tr man.she settings.she gam)
         =.  ..sh-work  (sh-fact tr-fact:tay)
         sh-prod(active.she `tr-pals:tay)
       ::
@@ -2089,7 +2089,7 @@
 ::
 ++  tr                                                  ::  telegram renderer
   |_  $:  man/knot
-          nob/?
+          sef/(set knot)
           who/ship
           sen/serial
           aud/audience
@@ -2106,7 +2106,7 @@
     =+  ^=  baw
         ::  ?:  oug 
         ::  ~(te-whom te man tr-pals)
-        ?.  nob
+        ?.  (~(has in sef) %noob)
           (~(sn-curt sn man [who (main who)]) |)
         (~(sn-nick sn man [who (main who)]))
     (weld baw txt)


### PR DESCRIPTION
Added the `%showtime` flag. After calling `;set showtime`, timestamps appear to the far right of messages, much like in webtalk. Unlike webtalk, this can't correct for the user's timezone.  
Requires a terminal of at least 90 characters wide for comfy displaying.

Modified the telegram renderer core `tr` a little bit. Instead of passing the `%noob` flag, we now pass the entire list of flags. `sef` for **se**ttings **f**lags.

I felt like giving `:talk` a little loving. Personally like seeing timestamps in my chats, and webtalk already has them, so why not. It's opt-in too, so talk remains 80 lines wide by default.