### PR TITLE
applies map/set invariants inside the molds

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1206,7 +1206,7 @@
       $(a l.a, c (peg c 6))
     $(a r.a, c (peg c 7))
   ::
-  +-  ept                                               ::  check correctness
+  +-  apt                                               ::  check correctness
     =|  {l/(unit) r/(unit)}
     |-  ^-  ?
     ?~  a   &
@@ -1600,7 +1600,7 @@
 ++  map  |*  {a/mold b/mold}                            ::  table
          %+  cork  (tree (pair a b))                    ::
          |=  c/(tree (pair a b))  ^+  c                 ::
-         ?.(~(ept by c) ~ c)                            ::
+         ?.(~(apt by c) ~ c)                            ::
 ++  qeu  |*  a/mold                                     ::  queue
          $@($~ {n/a l/(qeu a) r/(qeu a)})               ::
 ++  set  |*  a/mold                                     ::  set

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1601,8 +1601,7 @@
          %+  cork  (tree (pair a b))                    ::
          |=  c/(tree (pair a b))  ^+  c                 ::
          ?.(~(apt by c) ~ c)                            ::
-++  qeu  |*  a/mold                                     ::  queue
-         $@($~ {n/a l/(qeu a) r/(qeu a)})               ::
+++  qeu  |*(a/mold (tree a))                            ::  queue
 ++  set  |*  a/mold                                     ::  set
          %+  cork  (tree a)                             ::
          |=  b/(tree a)  ^+  b                          ::

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1598,7 +1598,9 @@
 ++  jar  |*({a/mold b/mold} (map a (list b)))           ::  map of lists
 ++  jug  |*({a/mold b/mold} (map a (set b)))            ::  map of sets
 ++  map  |*  {a/mold b/mold}                            ::  table
-         $@($~ {n/{p/a q/b} l/(map a b) r/(map a b)})   ::
+         %+  cork  (tree (pair a b))                    ::
+         |=  c/(tree (pair a b))  ^+  c                 ::
+         ?.(~(ept by c) ~ c)                            ::
 ++  qeu  |*  a/mold                                     ::  queue
          $@($~ {n/a l/(qeu a) r/(qeu a)})               ::
 ++  set  |*  a/mold                                     ::  set

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1602,7 +1602,9 @@
 ++  qeu  |*  a/mold                                     ::  queue
          $@($~ {n/a l/(qeu a) r/(qeu a)})               ::
 ++  set  |*  a/mold                                     ::  set
-         $@($~ {n/a l/(set a) r/(set a)})               ::
+         %+  cork  (tree a)                             ::
+         |=  b/(tree a)  ^+  b                          ::
+         ?.(~(apt in b) ~ b)                            ::
 ::
 ::::  2p: serialization                                 ::
   ::                                                    ::


### PR DESCRIPTION
also renames `+-ept:by` to `+-apt:by`, and simplifies `++qeu`.

my branch was created on top of cgyarvin/cc-merge. Should I reparent these commits somewhere else?