### PR TITLE
Talk setting: notify on mention

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -436,8 +436,8 @@
     ::
     ++  sh-rend                                         ::  print on one line
       |=  gam/telegram
-      =+  lin=~(tr-line tr man.she (~(has in settings.she) %noob) gam)
-      (sh-pass:(sh-fact %txt lin) q.q.gam) 
+      =+  lin=~(tr-line tr man.she settings.she gam)
+      (sh-pass:(sh-fact %txt lin) q.q.gam)
     ::
     ++  sh-numb                                         ::  print msg number
       |=  num/@ud
@@ -1003,7 +1003,7 @@
       ++  activate                                      ::  from %number
         |=  gam/telegram
         ^+  ..sh-work
-        =+  tay=~(. tr man.she (~(has in settings.she) %noob) gam)
+        =+  tay=~(. tr man.she settings.she gam)
         =.  ..sh-work  (sh-fact tr-fact:tay)
         sh-prod(active.she `tr-pals:tay)
       ::
@@ -2089,7 +2089,7 @@
 ::
 ++  tr                                                  ::  telegram renderer
   |_  $:  man/knot
-          nob/?
+          sef/(set knot)
           who/ship
           sen/serial
           aud/audience
@@ -2106,7 +2106,7 @@
     =+  ^=  baw
         ::  ?:  oug 
         ::  ~(te-whom te man tr-pals)
-        ?.  nob
+        ?.  (~(has in sef) %noob)
           (~(sn-curt sn man [who (main who)]) |)
         (~(sn-nick sn man [who (main who)]))
     (weld baw txt)

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -289,6 +289,7 @@
         %-  perk  :~
           %noob
           %quiet
+          %notify
         ==
       ++  work
         %+  knee  *^work  |.  ~+
@@ -437,7 +438,15 @@
     ++  sh-rend                                         ::  print on one line
       |=  gam/telegram
       =+  lin=~(tr-line tr man.she settings.she gam)
-      (sh-pass:(sh-fact %txt lin) q.q.gam)
+      =+  nom=(scag 7 (cite our.hid))
+      %.  q.q.gam
+      =<  sh-pass
+      %.  [%txt lin]
+      ?:  ?&  (~(has in settings.she) %notify)
+              (gth (fall (find nom lin) 0) 15)
+          ==
+        sh-fact:(sh-fact %bel ~)
+      sh-fact
     ::
     ++  sh-numb                                         ::  print msg number
       |=  num/@ud


### PR DESCRIPTION
Added the `%notify` flag. Having called `;set notify`, the terminal beeps whenever a message contains the first part (`~palfun`) of your ship name.  
Magically, it doesn't beep for your own messages.

Contains the telegram renderer core modification that's also included in #308.

Would love a code review on this (lines 440-449). I saw vaguely similar constructions in the rest of the code, but I'm still unsure if this is "good" Hoon or over-engineering. Let me know!