### PR TITLE
updates path-with-placeholder parsing for more consistent namespace dereferences

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -8440,10 +8440,19 @@
     |=  {pre/(unit tyke) pof/(unit {p/@ud q/tyke})}
     ^-  (unit (list twig))
     =-  ?^(- - ~&(%posh-fail -))
-    =/  wom/(list twig)  (turn wer |=(a/@ta [%sand %ta a]))
     %+  biff
-      ?~  pre  `u=wom
-      %+  bind  (poon wom u.pre)
+      =/  wom/(list twig)
+        (turn wer |=(a/@ta [%sand %ta a]))
+      ?~  pre
+        `u=wom
+      %+  bind
+        ?.  ?&  ?=(^ u.pre)            ::  XX handle initial {vane}{care}
+                ?=(^ i.u.pre)
+                ?=({$sand ?($ta $tas) @} u.i.u.pre)
+                =(2 (met 3 q.u.i.u.pre))
+            ==
+          (poon wom u.pre)
+        (both i.u.pre (poon wom t.u.pre))
       |=  moz/(list twig)
       ?~(pof moz (weld moz (slag (lent u.pre) wom)))
     |=  yez/(list twig)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -8440,7 +8440,7 @@
     |=  {pre/(unit tyke) pof/(unit {p/@ud q/tyke})}
     ^-  (unit (list twig))
     =-  ?^(- - ~&(%posh-fail -))
-    =+  wom=(poof wer)
+    =/  wom/(list twig)  (turn wer |=(a/@ta [%sand %ta a]))
     %+  biff
       ?~  pre  `u=wom
       %+  bind  (poon wom u.pre)
@@ -8453,7 +8453,6 @@
     =+  zom=(poon (flop moz) q.u.pof)
     ?~(zom ~ `(weld (flop gul) u.zom))
   ::
-  ++  poof  |=(pax/path ^-((list twig) (turn pax |=(a/@ta [%sand %ta a]))))
   ++  poon
     |=  {pag/(list twig) goo/tyke}
     ^-  (unit (list twig))

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -8399,8 +8399,8 @@
   ++  mota  %+  cook
               |=({a/tape b/tape} (rap 3 (weld a b)))
             ;~(plug (star low) (star hig))
-  ::
-  ++  plex
+  ::                                                    ::  ++plex:vast
+  ++  plex                                              ::  path from $conl twig
     |=  gen/twig  ^-  (unit path)
     ?:  ?=({$dbug *} gen)
       $(gen q.gen)
@@ -8435,8 +8435,8 @@
     ?@  i.i.ruw
       $(i.ruw t.i.ruw, cah [i.i.ruw cah])
     $(i.ruw t.i.ruw, cah ~, yun [p.i.i.ruw (wod cah yun)])
-  ::
-  ++  posh
+  ::                                                    :: ++posh:vast
+  ++  posh                                              :: path placeholders
     |=  {pre/(unit tyke) pof/(unit {p/@ud q/tyke})}
     ^-  (unit (list twig))
     =-  ?^(- - ~&(%posh-fail -))
@@ -8461,23 +8461,23 @@
     =+  [moz=(scag p.u.pof zey) gul=(slag p.u.pof zey)]
     =+  zom=(poon (flop moz) q.u.pof)
     ?~(zom ~ `(weld (flop gul) u.zom))
-  ::
-  ++  poon
+  ::                                                    :: ++poon:vast
+  ++  poon                                              :: unify path & context
     |=  {pag/(list twig) goo/tyke}
     ^-  (unit (list twig))
     ?~  goo  `~
     %+  both
       ?^(i.goo i.goo ?~(pag ~ `u=i.pag))
     $(goo t.goo, pag ?~(pag ~ t.pag))
-  ::
-  ++  poor
+  ::                                                    :: ++poor:vast
+  ++  poor                                              :: %-prefixed path
     %+  sear  posh
     ;~  plug
       (stag ~ gash)
       ;~(pose (stag ~ ;~(pfix cen porc)) (easy ~))
     ==
-  ::
-  ++  porc
+  ::                                                    :: ++porc:vast
+  ++  porc                                              :: % prefix count
     ;~  plug
       (cook |=(a/(list) (lent a)) (star cen))
       ;~(pfix fas gash)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -8377,15 +8377,18 @@
               |=  a/(list tyke)  ^-  tyke
               ?~(a ~ (weld i.a $(a t.a)))
             (more fas gasp)
-  ++  gasp  ;~  pose
+  ::                                                    :: ++gasp:vast
+  ++  gasp  =/  nils                                    :: parse /= placeholder
+              |=(a/(list) (reap (lent a) ~))
+            ;~  pose
               %+  cook
                 |=({a/tyke b/tyke c/tyke} :(weld a b c))
               ;~  plug
-                (cook |=(a/(list) (turn a |=(b/* ~))) (star tis))
+                (cook nils (star tis))
                 (cook |=(a/twig [[~ a] ~]) hasp)
-                (cook |=(a/(list) (turn a |=(b/* ~))) (star tis))
+                (cook nils (star tis))
               ==
-              (cook |=(a/(list) (turn a |=(b/* ~))) (plus tis))
+              (cook nils (plus tis))
             ==
   ++  glam  ~+((glue ace))
   ++  hasp  ;~  pose


### PR DESCRIPTION
It's common to write `:wish` / `.^` twigs with 3 sub-twigs: mold, vane/care, path. But they're actually just two twigs. The vane/care is the first segment of an Urbit-namespace path. This works fine for "fully-qualified" paths, but errors with `=` placeholders in the path, which is a little confusing. So I've updated `++posh:vast` to support both uses:

```
> .^(@ %cw /===)
1
```

```
> .^(@ /cw/===)
1
```

Previously, that second example would fail to parse, and log `%posh-fail`.

My solution is kind-of a hack: I'm just checking if the first path segment is a `%sand` atom with `%ta` or `%tas` as the aura, and a width of 2 bytes. I'm not sure if there's a better solution, but it seems worthwhile to remove the confusion.