### PR TITLE
Fixed urb.util.isURL to allow multiple successive hyphens in URLs.

### DIFF
--- a/web/lib/js/urb.js
+++ b/web/lib/js/urb.js
@@ -284,7 +284,7 @@ window.urb.unsubscribe = function(params,cb) { //  legacy intreface
 
 window.urb.util = {
   isURL: function(s) {
-     r = new RegExp('^(?!mailto:)(?:(?:http|https|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$', 'i');
+     r = new RegExp('^(?!mailto:)(?:(?:http|https|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?:(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[0-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]+-*)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]+-*)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))|localhost)(?::\\d{2,5})?(?:(/|\\?|#)[^\\s]*)?$', 'i');
      return s.length < 2083 && r.test(s);
   },
   numDot: function(n) {


### PR DESCRIPTION
Posting links to `comet--name.urbit.org` via webtalk causes it to post as a regular line, possibly breaking up. Turns out this is because of the `--`, which urb.util.isURL doesn't recognize as valid.

This change allows any number of successive hyphens. I couldn't find any evidence this isn't allowed in either subdomains or domain names (but maybe I'm looking in the wrong places?).