### PR TITLE
remove tap arg

### DIFF
--- a/app/ask.hoon
+++ b/app/ask.hoon
@@ -44,7 +44,7 @@
 ::
 ++  adrs
   =-  (sort - lor)
-  %+  turn  (~(tap by adr))
+  %+  turn  ~(tap by adr)
   |=({a/email b/time c/invited} [tym=b ask=a inv=c])
 ::
 ++  new-adrs  (skim adrs |=({@ @ inv/invited} =(%new inv)))

--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -553,7 +553,7 @@
       ?+  a  a
         {?($cube $face) ^}  a(q $(a q.a))
         {$cell ^}  a(p $(a p.a), q $(a q.a))
-        {$fork *}  a(p (silt (turn (~(tap in p.a)) |=(b/span ^$(a b)))))
+        {$fork *}  a(p (silt (turn ~(tap in p.a) |=(b/span ^$(a b)))))
         {$core ^}  `wain`/core
         {$hold *}  a(p $(a p.a))
       ==

--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -644,7 +644,7 @@
       :+  (dy-silk-vase !>([now=now.hid eny=eny.hid bec=he-beak]))
         (dy-silk-sources p.cig)
       :+  %mute  (dy-silk-vase (fall (slew 27 gat) !>(~)))
-      %+  turn  (~(tap by q.cig))
+      %+  turn  ~(tap by q.cig)
       |=  {a/term b/(unit dojo-source)}
       ^-  (pair wing silk:ford)
       :-  [a ~]

--- a/app/gh.hoon
+++ b/app/gh.hoon
@@ -322,7 +322,7 @@
     [~ +>.$]
   ::  ~&  response=response
   :_  +>.$
-  %+  turn  (~(tap in listeners.u.hook-data))
+  %+  turn  ~(tap in listeners.u.hook-data)
   |=  ost/bone
   [ost %diff response]
 --

--- a/app/mark-dashboard.hoon
+++ b/app/mark-dashboard.hoon
@@ -58,7 +58,7 @@
   =,  space:userlib
   =,  format
   =+  .^(arch %cy (en-beam now-beak /mar))
-  %+  skim  (~(tap by dir))
+  %+  skim  ~(tap by dir)
   |=  {a/mark $~}
   ?=(^ (file (en-beam now-beak /hoon/[a]/mar)))
 ::
@@ -68,10 +68,10 @@
   ^-  (list {mark $~})
   %-  zing  ^-  (list (list {mark $~}))
   =/  top  .^(arch %cy (en-beam now-beak /mar))
-  %+  turn  (~(tap by dir.top))
+  %+  turn  ~(tap by dir.top)
   |=  {sub/knot $~}
   =+  .^(arch %cy (en-beam now-beak /[sub]/mar))
-  %+  murn  (~(tap by dir))
+  %+  murn  ~(tap by dir)
   |=  {a/mark $~}  ^-  (unit {mark $~})
   ?~  (file (en-beam now-beak /hoon/[a]/[sub]/mar))  ~
   `[(rap 3 sub '-' a ~) ~]

--- a/app/pipe.hoon
+++ b/app/pipe.hoon
@@ -25,7 +25,7 @@
   |=  $~
   ^-  {(list move) _+>.$}
   %-  %-  slog
-      %+  turn  (~(tap in connections))
+      %+  turn  ~(tap in connections)
       |=  {app/term source/path station/knot}
       leaf+"{(trip app)}{<`path`source>} ---> {(trip station)}"
   [~ +>.$]

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -696,7 +696,7 @@
         %^    sh-repo-config-exceptions
             (weld (trip man.she) ": ")
           p.cordon.loc
-        [~ (~(tap in q.cordon.loc))]
+        [~ ~(tap in q.cordon.loc)]
       %^    sh-repo-config-exceptions
           (weld (trip man.she) ": ")
         p.cordon.loc
@@ -974,7 +974,7 @@
     ++  sh-whom                                         ::  current audience
       ^-  audience
       %-  ~(gas by *audience)
-      %+  turn  (~(tap in ?~(active.she passive.she u.active.she)))
+      %+  turn  ~(tap in ?~(active.she passive.she u.active.she))
       |=(a/partner [a *envelope %pending])
     ::
     ++  sh-tell                                         ::  add command
@@ -1070,7 +1070,7 @@
         ?^  qur
           =+  cha=(~(get by nik) qur)
           (sh-fact %txt ?~(cha "none" [u.cha]~))
-        =+  pan=(~(tap in (~(get ju nak) qur)))
+        =+  pan=~(tap in (~(get ju nak) qur))
         ?:  =(~ pan)  (sh-fact %txt "~")
         =<  (sh-fact %mor (turn pan .))
         |=(a/(set partner) [%txt <a>]) ::  XX ~(te-whom te man.she a)
@@ -1172,7 +1172,7 @@
         ^+  ..sh-work
         ?~  seg
           %+  sh-fact  %mor
-          %+  turn  (~(tap in settings.she))
+          %+  turn  ~(tap in settings.she)
           |=  s/knot
           [%txt (trip s)]
         %=  ..sh-work
@@ -1795,8 +1795,8 @@
     ++  pa-reform                                       ::  reconfigure, ugly
       |=  cof/config
       =+  ^=  dif  ^-  (pair (list partner) (list partner))
-          =+  old=`(list partner)`(~(tap in sources.shape) ~)
-          =+  new=`(list partner)`(~(tap in sources.cof) ~)
+          =+  old=`(list partner)`~(tap in sources.shape)
+          =+  new=`(list partner)`~(tap in sources.cof)
           :-  (skip new |=(a/partner (~(has in sources.shape) a)))
           (skip old |=(a/partner (~(has in sources.cof) a)))
       =.  +>.$  (pa-acquire p.dif)
@@ -2069,7 +2069,7 @@
   ++  te-prom  ^-  tape                                 ::  render targets
     =.  .  te-deaf
     =+  ^=  all
-        %+  sort  `(list partner)`(~(tap in lix))
+        %+  sort  `(list partner)`~(tap in lix)
         |=  {a/partner b/partner}
         (~(ta-beat ta man a) b)
     =+  fir=&
@@ -2143,7 +2143,7 @@
     =+  hed=leaf+"{(scow %uv sen)} at {(scow %da wen)}"
     =+  =<  paz=(turn (~(tap by aud)) .)
         |=({a/partner *} leaf+~(ta-full ta man a))
-    =+  bok=(turn (sort (~(tap in bou)) aor) smyt)
+    =+  bok=(turn (sort ~(tap in bou) aor) smyt)
     [%rose [" " ~ ~] [hed >who< [%rose [", " "to " ~] paz] bok]]~
   ::
   ++  tr-body

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -420,7 +420,7 @@
       |=  aud/audience
       %-  sh-poss
       %-  ~(gas in *(set partner))
-      (turn (~(tap by aud)) |=({a/partner *} a))
+      (turn ~(tap by aud) |=({a/partner *} a))
     ::
     ++  sh-poss                                         ::  passive update
       |=  lix/(set partner)
@@ -468,7 +468,7 @@
       =+  grams=grams:(~(got by stories) man.she)
       |-  ^-  (unit (set partner))
       ?~  grams  ~
-      =+  pan=(silt (turn (~(tap by q.q.i.grams)) head))
+      =+  pan=(silt (turn ~(tap by q.q.i.grams) head))
       ?:  (~(has in lax) pan)  `pan
       $(grams t.grams)
       ::
@@ -481,7 +481,7 @@
           ==
       ^+  ret
       =.  ret
-        =+  eno=(~(tap by one))
+        =+  eno=~(tap by one)
         |-  ^+  ret
         ?~  eno  ret
         =.  ret  $(eno t.eno)
@@ -491,7 +491,7 @@
         ?:  =(q.i.eno u.unt)  ret
         ret(cha [[p.i.eno u.unt] cha.ret])
       =.  ret
-        =+  owt=(~(tap by two))
+        =+  owt=~(tap by two)
         |-  ^+  ret
         ?~  owt  ret
         =.  ret  $(owt t.owt)
@@ -509,7 +509,7 @@
           ==
       ^+  ret
       =.  ret
-        =+  eno=(~(tap by one))
+        =+  eno=~(tap by one)
         |-  ^+  ret
         ?~  eno  ret
         =.  ret  $(eno t.eno)
@@ -522,7 +522,7 @@
         ?:  =(q.i.eno u.unt)  ret
         ret(cha [[p.i.eno u.unt] cha.ret])
       =.  ret
-        =+  owt=(~(tap by two))
+        =+  owt=~(tap by two)
         |-  ^+  ret
         ?~  owt  ret
         =.  ret  $(owt t.owt)
@@ -543,7 +543,7 @@
           ==
       ^+  ret
       =.  ret
-        =+  eno=(~(tap by one))
+        =+  eno=~(tap by one)
         |-  ^+  ret
         ?~  eno  ret
         =.  ret  $(eno t.eno)
@@ -553,7 +553,7 @@
         ?:  =(q.i.eno u.unt)  ret
         ret(cha [[p.i.eno u.unt] cha.ret])
       =.  ret
-        =+  owt=(~(tap by two))
+        =+  owt=~(tap by two)
         |-  ^+  ret
         ?~  owt  ret
         =.  ret  $(owt t.owt)
@@ -573,7 +573,7 @@
       =.  two  ~(strip timed two)
       ^+  ret
       =.  ret
-        =+  eno=(~(tap by one))
+        =+  eno=~(tap by one)
         |-  ^+  ret
         ?~  eno  ret
         =.  ret  $(eno t.eno)
@@ -583,7 +583,7 @@
         ?:  =(q.i.eno u.unt)  ret
         ret(cha [[p.i.eno u.unt] cha.ret])
       =.  ret
-        =+  owt=(~(tap by two))
+        =+  owt=~(tap by two)
         |-  ^+  ret
         ?~  owt  ret
         =.  ret  $(owt t.owt)
@@ -600,7 +600,7 @@
           ==
       ^+  ret
       =.  ret
-        =+  eno=(~(tap by one))
+        =+  eno=~(tap by one)
         |-  ^+  ret
         ?~  eno  ret
         =.  ret  $(eno t.eno)
@@ -608,7 +608,7 @@
           ret
         ret(old [i.eno old.ret])
       =.  ret
-        =+  owt=(~(tap by two))
+        =+  owt=~(tap by two)
         |-  ^+  ret
         ?~  owt  ret
         =.  ret  $(owt t.owt)
@@ -625,7 +625,7 @@
           ==
       ^+  ret
       =.  ret
-        =+  eno=(~(tap by one))
+        =+  eno=~(tap by one)
         |-  ^+  ret
         ?~  eno  ret
         =.  ret  $(eno t.eno)
@@ -633,7 +633,7 @@
           ret
         ret(old [i.eno old.ret])
       =.  ret
-        =+  owt=(~(tap by two))
+        =+  owt=~(tap by two)
         |-  ^+  ret
         ?~  owt  ret
         =.  ret  $(owt t.owt)
@@ -828,7 +828,7 @@
           =.  +>.^$  $(new.day t.new.day)
           =.  +>.^$
               (sh-note (weld "new " (~(ta-show ta man.she p.i.new.day) ~)))
-          (sh-repo-group-diff-here "--" ~ (~(tap by q.i.new.day)) ~)
+          (sh-repo-group-diff-here "--" ~ ~(tap by q.i.new.day) ~)
       =.  +>.$
           |-  ^+  +>.^$
           ?~  cha.day  +>.^$
@@ -871,9 +871,9 @@
         nak  nac
         nik  %-  ~(gas by *(map (set partner) char))
              =-  (zing `(list (list {(set partner) char}))`-)
-             %+  turn  (~(tap by nac))
+             %+  turn  ~(tap by nac)
              |=  {a/char b/(set (set partner))}
-             (turn (~(tap by b)) |=(c/(set partner) [c a]))
+             (turn ~(tap by b) |=(c/(set partner) [c a]))
       ==
     ::
     ++  sh-repo                                         ::  apply report
@@ -1077,11 +1077,11 @@
       ::
       ++  who                                          ::  %who
         |=  pan/(set partner)  ^+  ..sh-work
-        =<  (sh-fact %mor (murn (sort (~(tap by q.owners.she) ~) aor) .))
+        =<  (sh-fact %mor (murn (sort ~(tap by q.owners.she) aor) .))
         |=  {pon/partner alt/atlas}  ^-  (unit sole-effect)
         ?.  |(=(~ pan) (~(has in pan) pon))  ~
         =-  `[%tan rose+[", " `~]^- leaf+~(ta-full ta man.she pon) ~]
-        =<  (murn (sort (~(tap by alt)) aor) .)
+        =<  (murn (sort ~(tap by alt) aor) .)
         |=  {a/ship b/presence c/human}  ^-  (unit tank) :: XX names
         ?-  b
           $gone  ~
@@ -1132,7 +1132,7 @@
       ++  reverse-folks
         |=  nym/knot
         ^-  (list ship)
-        %+  murn  (~(tap by folks))
+        %+  murn  ~(tap by folks)
         |=  {p/ship q/human}
         ?~  hand.q  ~
         ?.  =(u.hand.q nym)  ~
@@ -1143,7 +1143,7 @@
         ^+  ..sh-work
         ?:  ?=({$~ $~} +<)
           %+  sh-fact  %mor
-          %+  turn  (~(tap by folks))
+          %+  turn  ~(tap by folks)
           |=  {p/ship q/human}
           :-  %txt
           ?~  hand.q
@@ -1347,7 +1347,7 @@
     :+  %diff  %talk-report
     :-  %house
     %-  ~(gas in *(map knot (pair posture cord)))
-    %+  turn  (~(tap by stories))
+    %+  turn  ~(tap by stories)
     |=({a/knot b/story} [a p.cordon.shape.b caption.shape.b])
   ::
   ++  ra-homes                                          ::  update partners
@@ -1601,7 +1601,7 @@
   ++  ra-consume                                        ::  consume thought
     |=  {pub/? her/ship tip/thought}
     =.  tip  (ra-normal tip)
-    =+  aud=(~(tap by q.tip) ~)
+    =+  aud=~(tap by q.tip)
     |-  ^+  +>.^$
     ?~  aud  +>.^$
     $(aud t.aud, +>.^$ (ra-conduct pub her p.i.aud tip))
@@ -2097,7 +2097,7 @@
     ^-  tape
     =+  cha=(~(get by nik) lix)
     ?^  cha  ~[u.cha ' ']
-    ?.  (lien (~(tap by lix)) ta-dire)
+    ?.  (lien ~(tap by lix) ta-dire)
       "* "
     ?:  ?=({{$& ^} $~ $~} lix)
       ": "
@@ -2141,7 +2141,7 @@
   ++  tr-meta  ^-  tang
     =.  wen  (sub wen (mod wen (div wen ~s0..0001)))     :: round
     =+  hed=leaf+"{(scow %uv sen)} at {(scow %da wen)}"
-    =+  =<  paz=(turn (~(tap by aud)) .)
+    =+  =<  paz=(turn ~(tap by aud) .)
         |=({a/partner *} leaf+~(ta-full ta man a))
     =+  bok=(turn (sort ~(tap in bou) aor) smyt)
     [%rose [" " ~ ~] [hed >who< [%rose [", " "to " ~] paz] bok]]~
@@ -2178,7 +2178,7 @@
   ++  tr-pals
     ^-  (set partner)
     %-  ~(gas in *(set partner))
-    (turn (~(tap by aud)) |=({a/partner *} a))
+    (turn ~(tap by aud) |=({a/partner *} a))
   ::
   ++  tr-chow
     |=  {len/@u txt/tape}  ^-  tape
@@ -2331,7 +2331,7 @@
         log   %-  ~(urn by log)
               |=({man/knot len/@ud} count:(~(got by stories) man))
       ==
-  %+  murn  (~(tap by log))
+  %+  murn  ~(tap by log)
   |=  {man/knot len/@ud}
   ^-  (unit move)
   ?:  (gte len count:(~(got by stories) man))

--- a/app/twit.hoon
+++ b/app/twit.hoon
@@ -121,7 +121,7 @@
   ?.  (~(has by ran) peer+pax)                           ::  ignore if retracted
     ~
   =+  =>  |=({a/bone @ b/path} [b a])
-      pus=(~(gas ju *(jug path bone)) (turn (~(tap by sup)) .))
+      pus=(~(gas ju *(jug path bone)) (turn ~(tap by sup) .))
   ?~  (~(get ju pus) pax)
     ~
   ~&  peer-again+[pax ran]  
@@ -308,7 +308,7 @@
 ++  spam                                                ::  send by path
   |=  {a/path b/(list gift)}  ^-  (list move)
   %-  zing  ^-  (list (list move))
-  %+  turn  (~(tap by sup))
+  %+  turn  ~(tap by sup)
   |=  {ost/bone @ pax/path}
   ?.  =(pax a)  ~
   (turn b |=(c/gift [ost c]))

--- a/gen/help.hoon
+++ b/gen/help.hoon
@@ -52,7 +52,7 @@
   =/  red  ((read-at len (scag len pax)) p.typ ark) :: XX ugly
   (drop (bind red rend))
 |-  ^-  tang
-=+  =<  arl=(~(tap by (~(urn by dir.ark) .)))
+=+  =<  arl=~(tap by (~(urn by dir.ark) .))
     |=({a/@t $~} .^(arch cy+(welp pax /[a])))
 %+  welp
   =/  dir/(list {@ path})

--- a/gen/ls/subdir.hoon
+++ b/gen/ls/subdir.hoon
@@ -8,7 +8,7 @@
   |=  {vane/?($c $g) pax/path des/(map @t $~)}
   ^-  tank
   :+  %rose  [" " `~]
-  %+  turn  (sort (~(tap by des)) aor)
+  %+  turn  (sort ~(tap by des) aor)
   |=  {kid/@ta $~}
   =+  paf=`path`/[kid]
   =-  :+  %rose  ["/" ~ ?:(dir "/" ~)]

--- a/gen/tree.hoon
+++ b/gen/tree.hoon
@@ -17,6 +17,6 @@
     [(rend pax) -]
 %-  zing
 %+  turn
-  (sort (~(tap by dir.ark)) aor)
+  (sort ~(tap by dir.ark) aor)
 |=  {a/@t $~}
 ^$(pax (welp pax /[a]))

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -238,7 +238,7 @@
 ::
 ++  se-adit                                           ::  update servers
   ^+  .
-  %+  roll  (~(tap in ray))
+  %+  roll  ~(tap in ray)
   =<  .(con +>)
   |=  {wel/well:gall con/_..se-adit}  ^+  con
   =.  +>.$  con
@@ -250,7 +250,7 @@
 ::
 ++  se-adze                                           ::  update connections
   ^+  .
-  %+  roll  (~(tap in eel))
+  %+  roll  ~(tap in eel)
   =<  .(con +>)
   |=  {gil/gill:gall con/_.}  ^+  con
   =.  +>.$  con
@@ -295,7 +295,7 @@
 ::
 ++  se-amor                                           ::  live targets
   ^-  (list gill:gall)
-  %+  skim  (~(tap in eel))
+  %+  skim  ~(tap in eel)
   |=(a/gill:gall ?=({$~ $~ *} (~(get by fug) a)))
 ::
 ++  se-anon                                           ::  rotate index

--- a/lib/frontmatter.hoon
+++ b/lib/frontmatter.hoon
@@ -7,7 +7,7 @@
 |%
 ++  atr-lines
   |=  atr/(map cord cord)
-  %+  turn  (sort (~(tap by atr)) |=({{a/@ @} {b/@ @}} (aor a b)))
+  %+  turn  (sort ~(tap by atr) |=({{a/@ @} {b/@ @}} (aor a b)))
   |=  {k/cord v/cord}
   (rap 3 k ': ' v ~)
 ::

--- a/lib/helm.hoon
+++ b/lib/helm.hoon
@@ -125,7 +125,7 @@
   =+  top=`path`/(scot %p our)/[syd]/(scot %da now)
   =/  van/(list {term $~})
     :-  zus=[%zuse ~]
-    (~(tap by dir:.^(arch %cy (welp top /sys/vane))))
+    ~(tap by dir:.^(arch %cy (welp top /sys/vane)))
   |=  nam/@tas
     =.  nam
     ?.  =(1 (met 3 nam))

--- a/lib/kiln.hoon
+++ b/lib/kiln.hoon
@@ -134,7 +134,7 @@
   =<  abet  %-  spam
   ?:  =(0 ~(wyt by syn))
     [%leaf "no syncs configured"]~
-  %+  turn  (~(tap in ~(key by syn)))
+  %+  turn  ~(tap in ~(key by syn))
   |=(a/kiln-sync (render "sync configured" [sud her syd]:a))
 ::
 ++  poke-init-sync
@@ -506,7 +506,7 @@
             our  ~  [our tic %da now]  %tabl
             ^-  (list (pair silk:ford silk:ford))
             :: ~&  >  kiln-mashing+[p.are syd=syd +<.abet]
-            %+  turn  (~(tap in p.are))
+            %+  turn  ~(tap in p.are)
             |=  pax/path
             ^-  (pair silk:ford silk:ford)
             :-  [%$ %path -:!>(*path) pax]

--- a/lib/map-to-json.hoon
+++ b/lib/map-to-json.hoon
@@ -6,4 +6,4 @@
 =,  format
 |*  {a/_cord b/_json}                 ::  XX {a/$-(* cord) b/$-(* json)}
 |=  c/(map _+<.a _+<.b)
-(pairs:enjs (turn (~(tap by c)) |*(d/^ [(a -.d) (b +.d)])))
+(pairs:enjs (turn ~(tap by c) |*(d/^ [(a -.d) (b +.d)])))

--- a/lib/womb.hoon
+++ b/lib/womb.hoon
@@ -163,7 +163,7 @@
   |*  {a/(map) b/$-(* (unit))}
   ^-  ?~(a !! (map _p.n.a _(need (b q.n.a))))
   %-  malt
-  %+  murn  (~(tap by a))
+  %+  murn  ~(tap by a)
   ?~  a  $~
   |=  _c=n.a  ^-  (unit _[p.n.a (need (b q.n.a))])
   =+  d=(b q.c)

--- a/lib/write.hoon
+++ b/lib/write.hoon
@@ -70,7 +70,7 @@
   ^+  all
   :-  (fall inf.dif -.all)
   =;  neu  (~(uni by neu) put.dif)
-  =+  del=(~(tap by del.dif))                           :: XXX map functions
+  =+  del=~(tap by del.dif)                             :: XXX map functions
   |-  ^+  acc.all
   ?~  del  acc.all
   $(del t.del, acc.all (~(del by acc.all) p.i.del))

--- a/mar/plan.hoon
+++ b/mar/plan.hoon
@@ -18,7 +18,7 @@
     ^-  wain
     :+  (cat 3 'User ' ?~(who 'of Urbit' who))
       (cat 3 'Location ' ?~(loc %unknown loc))
-    %+  turn  (sort (~(tap by acc)) aor)
+    %+  turn  (sort ~(tap by acc) aor)
     |=  {a/knot b/plan-acct}  ^-  cord
     %+  rap  3
     :^  a  ': '  usr.b
@@ -61,10 +61,10 @@
   ++  diff
     |=  neu/_all  ^-  plan-diff                        :: XXX map functions
     :+  ?:(=(-.all -.neu) ~ (some -.neu))
-      =<  (malt `(list {knot $~})`(murn (~(tap by acc.all)) .))
+      =<  (malt `(list {knot $~})`(murn ~(tap by acc.all) .))
       |=  {a/knot *}  ^-  (unit {knot $~})
       ?:((~(has by acc.neu) a) ~ (some [a ~]))
-    =<  (malt (murn (~(tap by acc.neu)) .))
+    =<  (malt (murn ~(tap by acc.neu) .))
     |=  {a/knot b/plan-acct}  ^-  (unit {knot plan-acct})
     ?:  =([~ b] (~(get by acc.all) a))
       ~
@@ -74,7 +74,7 @@
     |=  dif/plan-diff  ^+  all                          :: XXX map functions
     :-  (fall inf.dif -.all)
     =;  neu  (~(uni by neu) put.dif)
-    =+  del=(~(tap by del.dif))
+    =+  del=~(tap by del.dif)
     |-  ^+  acc.all
     ?~  del  acc.all
     $(del t.del, acc.all (~(del by acc.all) p.i.del))

--- a/mar/talk/command.hoon
+++ b/mar/talk/command.hoon
@@ -27,7 +27,7 @@
       %+  ci
         |=  a/(map cord _(need *wit))
         ^-  (unit (list _[(wonk *fel) (need *wit)]))
-        (zl (turn (~(tap by a)) (head-rush fel)))
+        (zl (turn ~(tap by a) (head-rush fel)))
       (om wit)
     ::
     ++  ke                                              ::  callbacks

--- a/mar/talk/report.hoon
+++ b/mar/talk/report.hoon
@@ -53,7 +53,7 @@
       |=(c/_[+<.a +<.b] [(a -.c) (b +.c)])
     ::
     ::
-    ++  nack  |=(a/(set (set partner)) [%a (turn (~(tap in a)) sorc)])
+    ++  nack  |=(a/(set (set partner)) [%a (turn ~(tap in a) sorc)])
     ++  grop  (jome phon stas)                          ::  (map ship status)
     ++  phon  |=(a/ship (scot %p a))
     ++  stas  |=(status (jobe presence+(joce p) human+(huma q) ~))
@@ -65,7 +65,7 @@
     ++  audi  (jome parn jove)
     ++  bouq
       |=  a/bouquet
-      a+(turn (~(tap in a)) |=(b/path a+(turn b |=(c/knot s+c))))
+      a+(turn ~(tap in a) |=(b/path a+(turn b |=(c/knot s+c))))
     ::
     ++  parn
       |=  a/partner  ^-  cord
@@ -136,7 +136,7 @@
     ::
     ++  sorc
       |=  a/(set partner)  ^-  json
-      [%a (turn (~(tap in a)) |=(b/partner s+(parn b)))]
+      [%a (turn ~(tap in a) |=(b/partner s+(parn b)))]
     ::
     ++  conf
       |=  config
@@ -144,7 +144,7 @@
         sources+(sorc sources)
         caption+[%s caption]
         =-  cordon+(jobe posture+[%s -.cordon] list+[%a -] ~)
-        (turn (~(tap in q.cordon)) jope)                ::  XX  jase
+        (turn ~(tap in q.cordon) jope)                ::  XX  jase
       ==
   --
 --  --

--- a/mar/talk/report.hoon
+++ b/mar/talk/report.hoon
@@ -24,7 +24,7 @@
     |^  %+  joba  -.rep
         ?-  -.rep
           $cabal  (cabl +.rep)
-          $house  a+(turn (~(tap by +.rep)) jose)
+          $house  a+(turn ~(tap by +.rep) jose)
           $glyph  ((jome |=(a/char a) nack) +.rep)
           $grams  (jobe num+(jone p.rep) tele+[%a (turn q.rep gram)] ~)
           $group  (jobe local+(grop p.rep) global+%.(q.rep (jome parn grop)) ~)
@@ -46,7 +46,7 @@
     ++  jome                                            ::  stringify keys
       |*  {a/_cord b/_json}
       |=  c/(map _+<.a _+<.b)
-      (jobe (turn (~(tap by c)) (both a b)))
+      (jobe (turn ~(tap by c) (both a b)))
     ::
     ++  both                                            ::  cons two gates
       |*  {a/_* b/_*}

--- a/mar/talk/telegrams.hoon
+++ b/mar/talk/telegrams.hoon
@@ -42,7 +42,7 @@
       %+  ci
         |=  a/(map cord _(need *wit))
         ^-  (unit (list _[(wonk *fel) (need *wit)]))
-        (zl (turn (~(tap by a)) (head-rush fel)))
+        (zl (turn ~(tap by a) (head-rush fel)))
       (om wit)
     ::
     ++  as                                              ::  array as set

--- a/mar/talk/telegrams.hoon
+++ b/mar/talk/telegrams.hoon
@@ -139,7 +139,7 @@
     ++  audi  (map-to-json parn jove)
     ++  bouq
       |=  a/bouquet
-      a+(turn (~(tap in a)) |=(b/path a+(turn b |=(c/knot s+c))))  
+      a+(turn ~(tap in a) |=(b/path a+(turn b |=(c/knot s+c))))
     ::
     ++  parn
       |=  a/partner  ^-  cord

--- a/mar/womb/stat-all.hoon
+++ b/mar/womb/stat-all.hoon
@@ -17,7 +17,7 @@
   |%
   ++  json
     %-  jobe
-    %+  turn  (~(tap by all))
+    %+  turn  ~(tap by all)
     |=  {a/ship b/stat:womb}  ^-  {cord ^json}
     :-  (crip +:<a>)
     (jobe live+[%s p.b] dist+(json-dist q.b) ~)

--- a/ren/rss-xml.hoon
+++ b/ren/rss-xml.hoon
@@ -25,7 +25,7 @@
     ;title: *{hed.sum}
     ;link: {(ref /)}
     ;description: *{(no-meta tal.sum)}
-    ;*  %+  turn  (~(tap by kid))
+    ;*  %+  turn  ~(tap by kid)
         |=  {nom/@t hed/marl tal/marl}
         ;item
           ;title: *{hed}

--- a/ren/tree/head.hoon
+++ b/ren/tree/head.hoon
@@ -8,7 +8,7 @@
   /$  %+  cork  fuel:html                           :: after parsing params,
       =,  title
       |=  gas/epic:eyre  ^-  ?                         :: check that the fcgi
-      %+  lien  (~(tap in (~(get ju aut.ced.gas) %$)))  :: has an identity
+      %+  lien  ~(tap in (~(get ju aut.ced.gas) %$))    :: has an identity
       |=(a/knot !=(%pawn (clan (slav %p a))))           :: which isn't a comet
 /=    dbg
   /^  {nopack/? nomin/?}

--- a/ren/tree/index.hoon
+++ b/ren/tree/index.hoon
@@ -8,7 +8,7 @@
 ::
           /pub/docs/dev/hoon/runes
     /;  |=  {tip/marl sub/(map knot marl) $~}
-        (zing `(list marl)`[tip (turn (~(tap by sub)) tail)])
+        (zing `(list marl)`[tip (turn ~(tap by sub) tail)])
     /.    /;    (getall:tree %h1 ~)    /tree-elem/
           /_    /;    (getall:tree %h1 ~)    /tree-elem/
 ==  ==

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1510,9 +1510,9 @@
     bal(a a(l $(a l.a)))
   ::
   +-  tap                                               ::  adds list to end
-    |=  b/(list _?>(?=(^ a) n.a))
+    =|  b/(list _?>(?=(^ a) n.a))
+    |-  ^+  b
     =+  0                                               ::  hack for jet match
-    ^+  b
     ?~  a
       b
     $(a r.a, b [n.a $(a l.a)])

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1155,7 +1155,7 @@
   +-  dep                                               ::  difference as patch
     |*  b/_a
     ^+  [p=a q=a]
-    =+  c=(~(tap by (def b)))
+    =+  c=~(tap by (def b))
     =+  [d e]=[`_a`~ `_a`~]
     |-  ^+  [d e]
     ?~  c  [d e]
@@ -1326,9 +1326,10 @@
     [n=[p=p.n.a q=(b p.n.a q.n.a)] l=$(a l.a) r=$(a r.a)]
   ::
   +-  tap                                               ::  listify pairs
+    =<  $
     ~/  %tap
-    |=  b/(list _?>(?=(^ a) n.a))
-    ^+  b
+    =|  b/(list _?>(?=(^ a) n.a))
+    |.  ^+  b
     ?~  a
       b
     $(a r.a, b [n.a $(a l.a)])
@@ -8352,7 +8353,7 @@
   ?+    typ  ~
       {$hold *}  $(typ ~(repo ut typ))
       {$core *}
-    (turn (~(tap by q.r.q.typ) ~) |=({a/term *} a))
+    (turn ~(tap by q.r.q.typ) |=({a/term *} a))
   ==
 ::
 ++  slop                                                ::  cons two vases
@@ -8598,7 +8599,7 @@
         |=  hug
         ^-  {twig (list twig)}
         =-  [a (welp - ?~(c d [[[%rock %tas p.c] q.c] d]))]
-        =-  (~(tap by -))
+        =-  ~(tap by -)
         %.  |=(e/(list tank) [%knit ~(ram re %rose [" " `~] e)])
         =<  ~(run by (reel b .))
         |=  {e/{p/term q/term} f/(jar twig tank)}
@@ -9854,7 +9855,7 @@
     [(welp "events: " (pi-mumm mon.day)) ~]
   ::
     %+  turn
-      (~(tap by hit.day) ~)
+      ~(tap by hit.day)
     |=  {nam/term num/@ud}
     :(welp (trip nam) ": " (scow %ud num))
     ["" ~]
@@ -9862,7 +9863,7 @@
     %-  zing
     ^-  (list (list tape))
     %+  turn
-      %+  sort  (~(tap by cut.day))
+      %+  sort  ~(tap by cut.day)
       |=  {one/(pair path hump) two/(pair path hump)}
       (gth (pi-moth mon.q.one) (pi-moth mon.q.two))
     |=  {pax/path hup/hump}
@@ -9875,7 +9876,7 @@
       ?:  =(~ out.hup)  ~
       :-  "into:"
       %+  turn
-        %+  sort  (~(tap by out.hup) ~)
+        %+  sort  ~(tap by out.hup)
         |=({{* a/@ud} {* b/@ud}} (gth a b))
       |=  {pax/path num/@ud}
       ^-  tape
@@ -9884,7 +9885,7 @@
       ?:  =(~ inn.hup)  ~
       :-  "from:"
       %+  turn
-        %+  sort  (~(tap by inn.hup) ~)
+        %+  sort  ~(tap by inn.hup)
         |=({{* a/@ud} {* b/@ud}} (gth a b))
       |=  {pax/path num/@ud}
       ^-  tape

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1067,9 +1067,10 @@
     $(a r.a, c c)
   ::
   +-  tap                                               ::  convert to list
+    =<  $
     ~/  %tap
-    |=  b/(list _?>(?=(^ a) n.a))
-    ^+  b
+    =|  b/(list _?>(?=(^ a) n.a))
+    |.  ^+  b
     ?~  a
       b
     $(a r.a, b [n.a $(a l.a)])
@@ -6512,7 +6513,7 @@
                     |=(* (biff ^$(sut q.sut) |=(* `[+>+< +<])))
         {$core *}   (biff $(sut p.sut) |=(* `[p.r.q.sut +<]))
         {$face *}   $(sut repo)
-        {$fork *}   =+  yed=(~(tap in p.sut))
+        {$fork *}   =+  yed=~(tap in p.sut)
                     |-  ^-  (unit)
                     ?~  yed  ~
                     =+  [dis=^$(sut i.yed) mor=$(yed t.yed)]
@@ -6586,7 +6587,7 @@
       ::
           {$core *}  ?:(?=(?({$atom *} {$cell *}) ref) sut sint)
           {$face *}  (face p.sut dext(sut q.sut))
-          {$fork *}  (fork (turn (~(tap in p.sut)) |=(span dext(sut +<))))
+          {$fork *}  (fork (turn ~(tap in p.sut) |=(span dext(sut +<))))
           {$hold *}  ?<  (~(has in bix) [sut ref])
                      dext(sut repo, bix (~(put in bix) [sut ref]))
           $noun      dext(sut repo)
@@ -6598,7 +6599,7 @@
       ?+    ref    !!
         {$core *}  sut
         {$face *}  dext(ref repo(sut ref))
-        {$fork *}  =+  yed=(~(tap in p.ref))
+        {$fork *}  =+  yed=~(tap in p.ref)
                    |-  ^-  span
                    ?~  yed  sut
                    $(yed t.yed, sut dext(ref i.yed))
@@ -6638,7 +6639,7 @@
         rig      t.rig
         p.q.lop  q.dar
       ==
-    =+  hag=(~(tap in q.q.lop))
+    =+  hag=~(tap in q.q.lop)
     %-  fire
     |-  ^+  hag
     ?~  rig
@@ -6667,7 +6668,7 @@
         p.q.lop  q.dar
         hej      [[p.dar q.zil] hej]
       ==
-    =+  hag=(~(tap in q.q.lop))
+    =+  hag=~(tap in q.q.lop)
     =-  [(fire p.-) [%9 p.q.lop (hike axe q.-)]]
     |-  ^-  (pair (list (pair span foot)) (list (pair axis nock)))
     ?~  rig
@@ -6700,7 +6701,7 @@
       ==
     ?>  ?=($| -.q.q.lop)
     ?>  =(p.q.p.lop p.q.q.lop)
-    =+  hag=[p=(~(tap in q.q.p.lop)) q=(~(tap in q.q.q.lop))]
+    =+  hag=[p=~(tap in q.q.p.lop) q=~(tap in q.q.q.lop)]
     =-  [(fire p.-) (fire(vet |) q.-)]
     |-  ^-  (pair (list (pair span foot)) (list (pair span foot)))
     ?~  rig
@@ -6851,7 +6852,7 @@
       =-  [p.- (hike axe q.-)]
       (echo:cin p.q.lop rig)
     =-  [p.- [%9 p.q.lop (hike axe q.-)]]
-    (ecmo:cin (~(tap in q.q.lop)) rig)
+    (ecmo:cin ~(tap in q.q.lop) rig)
   ::
   ++  et
     |_  {hyp/wing rig/(list (pair wing twig))}
@@ -6907,7 +6908,7 @@
     ?-  -.lap
       $&  p.lap
       $|  %-  fire
-          %+  turn  (~(tap in q.lap))
+          %+  turn  ~(tap in q.lap)
           |=  {a/span b/foot}
           [a [%ash %$ 1]]
     ==
@@ -7037,7 +7038,7 @@
               --
             ::
                 {$fork *}
-              =+  wiz=(turn (~(tap in p.sut)) |=(a/span ^$(sut a)))
+              =+  wiz=(turn ~(tap in p.sut) |=(a/span ^$(sut a)))
               ?~  wiz  ~
               |-  ^-  pony
               ?~  t.wiz  i.wiz
@@ -7083,7 +7084,7 @@
       $&  =+  axe=(tend p.p.tor)
           ?-  -.q.p.tor
             $&  [`span`p.q.p.tor %0 axe]
-            $|  [(fire (~(tap in q.q.p.tor))) [%9 p.q.p.tor %0 axe]]
+            $|  [(fire ~(tap in q.q.p.tor)) [%9 p.q.p.tor %0 axe]]
     ==    ==
   ::
   ++  fire
@@ -7130,7 +7131,7 @@
     ::
         {$core *}   [%0 0]
         {$face *}   $(sut q.sut)
-        {$fork *}   =+  yed=(~(tap in p.sut))
+        {$fork *}   =+  yed=~(tap in p.sut)
                     |-  ^-  nock
                     ?~(yed [%1 1] (flor ^$(sut i.yed) $(yed t.yed)))
         {$hold *}
@@ -7169,7 +7170,7 @@
     ::
         {$core *}  $(sut repo)
         {$face *}  (face p.sut $(sut q.sut))
-        {$fork *}  (fork (turn (~(tap in p.sut)) |=(span ^$(sut +<))))
+        {$fork *}  (fork (turn ~(tap in p.sut) |=(span ^$(sut +<))))
         {$hold *}
       ?:  (~(has in bix) [sut ref])
         ~>(%mean.[%leaf "fuse-loop"] !!)
@@ -7382,7 +7383,7 @@
       {$cell *}  |($(sut p.sut) $(sut q.sut))
       {$core *}  $(sut p.sut)
       {$face *}  $(sut q.sut)
-      {$fork *}  (lien (~(tap in p.sut)) |=(span ^$(sut +<)))
+      {$fork *}  (lien ~(tap in p.sut) |=(span ^$(sut +<)))
       {$hold *}  |((~(has in gil) sut) $(gil (~(put in gil) sut), sut repo))
       $noun      |
       $void      &
@@ -7620,7 +7621,7 @@
                    ==
         {$face *}  dext(sut q.sut)
         {$fork *}  ?.  ?=(?({$atom *} $noun {$cell *} {$core *}) ref)  sint
-                   (lien (~(tap in p.sut)) |=(span dext(tel |, sut +<)))
+                   (lien ~(tap in p.sut) |=(span dext(tel |, sut +<)))
         {$hold *}  ?:  (~(has in seg) sut)  |
                    ?:  (~(has in gil) [sut ref])  &
                    %=  dext
@@ -7639,7 +7640,7 @@
         {$cell *}   |
         {$core *}   dext(ref repo(sut ref))
         {$face *}   dext(ref q.ref)
-        {$fork *}   (levy (~(tap in p.ref)) |=(span sint(ref +<)))
+        {$fork *}   (levy ~(tap in p.ref) |=(span sint(ref +<)))
         {$hold *}   ?:  (~(has in reg) ref)  &
                     ?:  (~(has in gil) [sut ref])  &
                     %=  dext
@@ -7673,7 +7674,7 @@
         ?.(con.pec %noun ^$(sut p.sut, axe 3))
       ==
     ::
-        {$fork *}   (fork (turn (~(tap in p.sut)) |=(span ^$(sut +<))))
+        {$fork *}   (fork (turn ~(tap in p.sut) |=(span ^$(sut +<))))
         {$hold *}
       ?:  (~(has in gil) sut)
         %void
@@ -7770,11 +7771,10 @@
       ~>(%mean.[%leaf "rest-loop"] !!)
     =>  .(fan (~(gas in fan) leg))
     %-  fork
-    %-  %~  tap  in
-          %-  ~(gas in *(set span))
-          (turn leg |=({p/span q/twig} (play(sut p) q)))
-        ==
-    ~
+    %~  tap  in
+      %-  ~(gas in *(set span))
+      (turn leg |=({p/span q/twig} (play(sut p) q)))
+    ==
   ::
   ++  take
     |=  {vit/vein duz/$-(span span)}
@@ -7787,7 +7787,7 @@
       |-  ^-  span
       ?+  sut      ^$(vit t.vit)
         {$face *}  (face p.sut ^$(vit t.vit, sut q.sut))
-        {$fork *}  (fork (turn (~(tap in p.sut)) |=(span ^$(sut +<))))
+        {$fork *}  (fork (turn ~(tap in p.sut) |=(span ^$(sut +<))))
         {$hold *}  $(sut repo)
       ==
     =+  vil=*(set span)
@@ -7806,7 +7806,7 @@
                    $(sut repo)
                  (core $(sut p.sut, u.i.vit lat) q.sut)
       {$face *}  (face p.sut $(sut q.sut))
-      {$fork *}  (fork (turn (~(tap in p.sut)) |=(span ^$(sut +<))))
+      {$fork *}  (fork (turn ~(tap in p.sut) |=(span ^$(sut +<))))
       {$hold *}  ?:  (~(has in vil) sut)
                    %void
                  $(sut repo, vil (~(put in vil) sut))
@@ -7846,7 +7846,7 @@
       {$cell *}  (cell $(sut p.sut) $(sut q.sut))
       {$core *}  ?>(|(=(%gold p.q.sut) =(%lead yoz)) sut(p.q yoz))
       {$face *}  (face p.sut $(sut q.sut))
-      {$fork *}  (fork (turn (~(tap in p.sut)) |=(span ^$(sut +<))))
+      {$fork *}  (fork (turn ~(tap in p.sut) |=(span ^$(sut +<))))
       {$hold *}  $(sut repo)
     ==
   --
@@ -8259,7 +8259,7 @@
       ?^(p.sut yad [p.yad [%face p.sut q.yad]])
     ::
         {$fork *}
-      =+  yed=(~(tap in p.sut))
+      =+  yed=~(tap in p.sut)
       =-  [p [%pick q]]
       |-  ^-  {p/{p/(map span @) q/(map @ wine)} q/(list wine)}
       ?~  yed

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1319,7 +1319,7 @@
           urb.ton
         %-  ~(gas by *(map ship sufi))
         %+  turn
-          (~(tap by urb.ton.fox) ~)
+          ~(tap by urb.ton.fox)
         |=  {p/ship q/sufi}  ^-  {p/ship q/sufi}
         :-  p
         %=    q
@@ -1422,7 +1422,7 @@
     ::
     ++  kick                                            ::    kick:am
       |=  hen/duct                                      ::  refresh net
-      =+  aks=(turn (~(tap by urb.ton.fox) ~) |=({p/ship q/sufi} p))
+      =+  aks=(turn ~(tap by urb.ton.fox) |=({p/ship q/sufi} p))
       |-  ^-  {p/(list boon) q/fort}
       ?~  aks  [~ fox]
       =^  buz  fox  zork:(kick:(um i.aks) hen)

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -370,10 +370,10 @@
     ++  aver                                            ::  verify
       ?>  (lte cur.saw max.saw)
       ?>  !=(0 max.saw)
-      ?.  =(cur.saw (lent (~(tap to liv))))
-        ~&  [%aver-cur cur.saw (lent (~(tap to liv)))]
+      ?.  =(cur.saw (lent ~(tap to liv)))
+        ~&  [%aver-cur cur.saw (lent ~(tap to liv))]
         !!
-      ?>  =(rey.saw (lent (~(tap to lop))))
+      ?>  =(rey.saw (lent ~(tap to lop)))
       ?>  =+  |=  {a/coal b/coal}
               &((lth out.a out.b) (lth lod.a lod.b))
           |-  ?|  ?=($~ liv)
@@ -432,7 +432,7 @@
           [& $(liv l.liv)]
       ?~  ack  [~ ~ liv]
       =.  ded  ?:(top [n.liv ded] ded)
-      =.  ded  ?:(vig.clu.u.ack (~(tap to r.liv) ded) ded)
+      =?  ded  vig.clu.u.ack  (weld ~(tap to r.liv) ded)
       =.  lov  ?:(top [n.liv lov ~] lov)
       [ack ded lov]
     ::                                                  ::
@@ -512,7 +512,7 @@
         ::
         ::  everything in front of a dead packet is dead
         ::
-        $(liv l.liv, ded (~(tap to r.liv) [n.liv ded]))
+        $(liv l.liv, ded (welp ~(tap to r.liv) [n.liv ded]))
       =+  ryt=$(liv r.liv)
       [p.ryt [n.liv l.liv q.ryt]]
     ::                                                  ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1308,7 +1308,7 @@
     :*  hen  %pass  [%ergoing (scot %p her) syd ~]  %f
         %exec  our  ~  [her syd %da now]  %tabl
         ^-  (list (pair silk:ford silk:ford))
-        %+  turn  (~(tap in sum))
+        %+  turn  ~(tap in sum)
         |=  a/path
         ^-  (pair silk:ford silk:ford)
         :-  [%$ %path !>(a)]
@@ -1351,7 +1351,7 @@
     %+  turn  (~(tap by mus))
     |=  {pot/term len/@ud pak/(set path)}
     :*  u.hez  %give  %ergo  pot
-        %+  turn  (~(tap in pak))
+        %+  turn  ~(tap in pak)
         |=  pax/path
         [(slag len pax) (~(got by can) pax)]
     ==
@@ -1522,12 +1522,12 @@
     =<  wake
     =+  ^-  nut/(map tako yaki)
         %-  molt  ^-  (list (pair tako yaki))
-        %+  turn  (~(tap in lar))
+        %+  turn  ~(tap in lar)
         |=  yak/yaki
         [r.yak yak]
     =+  ^-  nat/(map lobe blob)
         %-  molt  ^-  (list (pair lobe blob))
-        %+  turn  (~(tap in bar))
+        %+  turn  ~(tap in bar)
         |=  bol/blob
         [p.bol bol]
     ~|  :*  %bad-foreign-update
@@ -1581,7 +1581,7 @@
         [%foreign-plops (scot %p our) (scot %p her) syd lum ~]
         %f  %exec  our  ~  [her syd cas]  %tabl
         ^-  (list (pair silk:ford silk:ford))
-        %+  turn  (~(tap in pop))
+        %+  turn  ~(tap in pop)
         |=  a/plop
         ?-  -.a
           $direct  [[%$ %blob !>([%direct p.a *page])] (vale-page p.q.a q.q.a)]
@@ -2063,10 +2063,10 @@
       =+  ^-  yal/(set tako)
           %-  silt
           %+  skip
-            (~(tap in (reachable-takos b)))
+            ~(tap in (reachable-takos b))
           |=(tak/tako (~(has in old) tak))
-      :-  (silt (turn (~(tap in yal)) tako-to-yaki))
-      (silt (turn (~(tap in (new-lobes (new-lobes ~ old) yal))) lobe-to-blob))
+      :-  (silt (turn ~(tap in yal) tako-to-yaki))
+      (silt (turn ~(tap in (new-lobes (new-lobes ~ old) yal)) lobe-to-blob))
     ::
     ::  Traverses parentage and finds all ancestor hashes
     ::
@@ -2087,7 +2087,7 @@
     ++  new-lobes                                       ::  object hash set
       |=  {b/(set lobe) a/(set tako)}                   ::  that aren't in b
       ^-  (set lobe)
-      %+  roll  (~(tap in a) ~)
+      %+  roll  ~(tap in a)
       |=  {tak/tako bar/(set lobe)}
       ^-  (set lobe)
       =+  yak=(tako-to-yaki tak)
@@ -2636,7 +2636,7 @@
           ?~  r
             (error:he %merge-no-merge-base ~)
           ?.  ?=({* $~ $~} r)
-            =+  (lent (~(tap in `(set yaki)`r)))
+            =+  (lent ~(tap in `(set yaki)`r))
             (error:he %merge-criss-cross >[-]< ~)
           =.  bas.dat  n.r
           ?:  ?=(?($mate $meld) gem.dat)
@@ -3105,7 +3105,7 @@
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %ergo ~]
             %f  %exec  p.bob  ~  val  %tabl
             ^-  (list (pair silk:ford silk:ford))
-            %+  turn  (~(tap in sum))
+            %+  turn  ~(tap in sum)
             |=  a/path
             ^-  (pair silk:ford silk:ford)
             :-  [%$ %path !>(a)]
@@ -3145,7 +3145,7 @@
         %+  turn  (~(tap by mus))
         |=  {pot/term len/@ud pak/(set path)}
         :*  u.hez  %give  %ergo  pot
-            %+  turn  (~(tap in pak))
+            %+  turn  ~(tap in pak)
             |=  pax/path
             [(slag len pax) (~(got by can) pax)]
         ==
@@ -3222,7 +3222,7 @@
           =|  gud/(set yaki)
           =+  ^=  zar
               ^-  (map tako (set tako))
-              %+  roll  (~(tap in unk))
+              %+  roll  ~(tap in unk)
               |=  {yak/yaki qar/(map tako (set tako))}
               (~(put by qar) r.yak (reachable-takos r.yak))
           |-

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -617,7 +617,7 @@
   ++  duct-lift
     |*  send/_|=({duct *} ..duct-lift)
     |=  {a/(set duct) arg/_+<+.send}  ^+  ..duct-lift
-    =+  all=(~(tap by a))
+    =+  all=~(tap by a)
     |-  ^+  ..duct-lift
     ?~  all  ..duct-lift
     =.  +>.send  ..duct-lift
@@ -714,7 +714,7 @@
     |=  can/(list path)
     ^-  (map term (pair @ud (set path)))
     %-  malt  ^-  (list (trel term @ud (set path)))
-    %+  murn  (~(tap by mon))
+    %+  murn  ~(tap by mon)
     |=  {nam/term bem/beam}
     ^-  (unit (trel term @ud (set path)))
     =-  ?~(- ~ `[nam (lent s.bem) (silt `(list path)`-)])
@@ -729,7 +729,7 @@
     ^+  +>
     =+  pax=s.bem
     =+  cas=(need (case-to-aeon:ze r.bem))
-    =+  can=(turn (~(tap by q:(aeon-to-yaki:ze cas))) head)
+    =+  can=(turn ~(tap by q:(aeon-to-yaki:ze cas)) head)
     =+  mus=(skim can |=(paf/path =(pax (scag (lent pax) paf))))
     ?~  mus
       +>.$
@@ -1222,7 +1222,7 @@
     :*  hen  %pass  [%patching (scot %p her) syd ~]  %f
         %exec  our  :^  ~  [her syd %da now]  %tabl
         ^-  (list (pair silk:ford silk:ford))
-        %+  turn  (~(tap by hat))
+        %+  turn  ~(tap by hat)
         |=  {a/path b/lobe}
         ^-  (pair silk:ford silk:ford)
         :-  [%$ %path-hash !>([a b])]
@@ -1297,7 +1297,7 @@
     ?:  =(~ mus)
       +>.$(dok ~)
     =+  ^-  sum/(set path)
-        =+  (turn (~(tap by mus)) (corl tail tail))
+        =+  (turn ~(tap by mus) (corl tail tail))
         %+  roll  -
         |=  {pak/(set path) acc/(set path)}
         (~(uni in acc) pak)
@@ -1346,9 +1346,9 @@
         ?.  ?=($mime p.mim)
           ~
         `((hard mime) q.q.mim)
-    =+  mus=(must-ergo (turn (~(tap by can)) head))
+    =+  mus=(must-ergo (turn ~(tap by can) head))
     %-  emil
-    %+  turn  (~(tap by mus))
+    %+  turn  ~(tap by mus)
     |=  {pot/term len/@ud pak/(set path)}
     :*  u.hez  %give  %ergo  pot
         %+  turn  ~(tap in pak)
@@ -1656,7 +1656,7 @@
   ::
   ++  wake                                            ::  update subscribers
     ^+  .
-    =+  xiq=(~(tap by qyx))
+    =+  xiq=~(tap by qyx)
     =|  xaq/(list {p/rove q/(set duct)})
     |-  ^+  ..wake
     ?~  xiq
@@ -1884,7 +1884,7 @@
       |=  hat/(map path (pair lobe cage))
       ^-  ankh
       ::  %-  cosh
-      %+  roll  (~(tap by hat) ~)
+      %+  roll  ~(tap by hat)
       |=  {{pat/path lob/lobe zar/cage} ank/ankh}
       ^-  ankh
       ::  %-  cosh
@@ -1951,13 +1951,13 @@
           %-  aeon-to-yaki
           let.dom
       =-  =+  sar=(silt (turn lar |=({p/path *} p)))    ::  changed paths
-          %+  roll  (~(tap by hat) ~)                   ::  find unchanged
+          %+  roll  ~(tap by hat)                       ::  find unchanged
           =<  .(bat bar)
           |=  {{pax/path gar/lobe} bat/(map path blob)}
           ?:  (~(has in sar) pax)                       ::  has update
             bat
           %+  ~(put by bat)  pax
-          ~|  [pax gar (lent (~(tap by lat.ran)))]
+          ~|  [pax gar (lent ~(tap by lat.ran))]
           (lobe-to-blob gar)                            ::  use original
       ^=  bar  ^-  (map path blob)
       %+  roll  lar
@@ -2005,7 +2005,7 @@
     ++  update-lat                                      ::   update-lat:ze
       |=  {lag/(map path blob) sta/(map lobe blob)}     ::  fix lat
       ^-  {(map lobe blob) (map path lobe)}
-      %+  roll  (~(tap by lag) ~)
+      %+  roll  ~(tap by lag)
       =<  .(lut sta)
       |=  {{pat/path bar/blob} {lut/(map lobe blob) gar/(map path lobe)}}
       ?~  (~(has by lut) p.bar)
@@ -2021,7 +2021,6 @@
       ?:  =(0 yon)  ~
       %-  malt
       %+  skim
-        %.  ~
         %~  tap  by
           =<  q
           %-  aeon-to-yaki
@@ -2091,7 +2090,7 @@
       |=  {tak/tako bar/(set lobe)}
       ^-  (set lobe)
       =+  yak=(tako-to-yaki tak)
-      %+  roll  (~(tap by q.yak) ~)
+      %+  roll  ~(tap by q.yak)
       =<  .(far bar)
       |=  {{path lob/lobe} far/(set lobe)}
       ^-  (set lobe)
@@ -2163,8 +2162,8 @@
         :*  ~  ~  %dome  -:!>(%dome)
             ank=`[[%ank-in-old-v-not-implemented *ankh] ~ ~]
             let=yon
-            hit=(molt (skim (~(tap by hit.dom)) |=({p/@ud *} (lte p yon))))
-            lab=(molt (skim (~(tap by lab.dom)) |=({* p/@ud} (lte p yon))))
+            hit=(molt (skim ~(tap by hit.dom) |=({p/@ud *} (lte p yon))))
+            lab=(molt (skim ~(tap by lab.dom) |=({* p/@ud} (lte p yon))))
         ==
       ?:  (gth yon let.dom)
         ~
@@ -2232,7 +2231,7 @@
       %-  molt  ^-  (list (pair knot $~))
       %+  turn
         ^-  (list (pair path lobe))
-        %+  skim  (~(tap by (~(del by q.yak) pax)))
+        %+  skim  ~(tap by (~(del by q.yak) pax))
         |=  {paf/path lob/lobe}
         =(pax (scag len paf))
       |=  {paf/path lob/lobe}
@@ -2258,7 +2257,7 @@
           %+  turn
             ::  ~&  %skimming
             ::  =-  ~&  %skimmed  -
-            %+  skim  (~(tap by (~(del by q.yak) pax)))
+            %+  skim  ~(tap by (~(del by q.yak) pax))
             |=  {paf/path lob/lobe}
             =(pax (scag len paf))
           |=  {paf/path lob/lobe}
@@ -2556,7 +2555,7 @@
           =.  hut.ran  (~(put by hut.ran) r.new.dat new.dat)
           =.  erg.dat
             %-  malt  ^-  (list {path ?})
-            %+  murn  (~(tap by (~(uni by q.bob.dat) q.ali.dat)))
+            %+  murn  ~(tap by (~(uni by q.bob.dat) q.ali.dat))
             |=  {pax/path lob/lobe}
             ^-  (unit {path ?})
             =+  a=(~(get by q.ali.dat) pax)
@@ -2587,7 +2586,7 @@
           =.  new.dat  ali.dat
           =.  erg.dat
             %-  malt  ^-  (list {path ?})
-            %+  murn  (~(tap by (~(uni by q.bob.dat) q.ali.dat)))
+            %+  murn  ~(tap by (~(uni by q.bob.dat) q.ali.dat))
             |=  {pax/path lob/lobe}
             ^-  (unit {path ?})
             =+  a=(~(get by q.ali.dat) pax)
@@ -2643,12 +2642,12 @@
             diff-ali
           =.  new.dal.dat
             %-  molt
-            %+  skip  (~(tap by q.ali.dat))
+            %+  skip  ~(tap by q.ali.dat)
             |=  {pax/path lob/lobe}
             (~(has by q.bas.dat) pax)
           =.  cal.dal.dat
             %-  molt
-            %+  skip  (~(tap by q.ali.dat))
+            %+  skip  ~(tap by q.ali.dat)
             |=  {pax/path lob/lobe}
             =+  (~(get by q.bas.dat) pax)
             |(=(~ -) =([~ lob] -))
@@ -2656,7 +2655,7 @@
             ~
           =.  old.dal.dat
             %-  malt  ^-  (list {path $~})
-            %+  murn  (~(tap by q.bas.dat))
+            %+  murn  ~(tap by q.bas.dat)
             |=  {pax/path lob/lobe}
             ^-  (unit (pair path $~))
             ?.  =(~ (~(get by q.ali.dat) pax))
@@ -2664,12 +2663,12 @@
             `[pax ~]
           =.  new.dob.dat
             %-  molt
-            %+  skip  (~(tap by q.bob.dat))
+            %+  skip  ~(tap by q.bob.dat)
             |=  {pax/path lob/lobe}
             (~(has by q.bas.dat) pax)
           =.  cal.dob.dat
             %-  molt
-            %+  skip  (~(tap by q.bob.dat))
+            %+  skip  ~(tap by q.bob.dat)
             |=  {pax/path lob/lobe}
             =+  (~(get by q.bas.dat) pax)
             |(=(~ -) =([~ lob] -))
@@ -2677,7 +2676,7 @@
             ~
           =.  old.dob.dat
             %-  malt  ^-  (list {path $~})
-            %+  murn  (~(tap by q.bas.dat))
+            %+  murn  ~(tap by q.bas.dat)
             |=  {pax/path lob/lobe}
             ^-  (unit (pair path $~))
             ?.  =(~ (~(get by q.bob.dat) pax))
@@ -2697,7 +2696,7 @@
           ?^  bof
             (error:he %meet-conflict >(~(run by `(map path *)`bof) $~)< ~)
           =+  ^-  old/(map path lobe)
-              %+  roll  (~(tap by (~(uni by old.dal.dat) old.dob.dat)))
+              %+  roll  ~(tap by (~(uni by old.dal.dat) old.dob.dat))
               =<  .(old q.bas.dat)
               |=  {{pax/path $~} old/(map path lobe)}
               (~(del by old) pax)
@@ -2733,7 +2732,7 @@
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali - ~]
             %f  %exec  p.bob  ~  [p.oth q.oth r.oth]  %tabl
             ^-  (list (pair silk:ford silk:ford))
-            %+  murn  (~(tap by q.bas.dat))
+            %+  murn  ~(tap by q.bas.dat)
             |=  {pax/path lob/lobe}
             ^-  (unit (pair silk:ford silk:ford))
             =+  a=(~(get by q.yak) pax)
@@ -2773,12 +2772,12 @@
           +>.$
         =.  new.dal.dat
           %-  molt
-          %+  skip  (~(tap by q.ali.dat))
+          %+  skip  ~(tap by q.ali.dat)
           |=  {pax/path lob/lobe}
           (~(has by q.bas.dat) pax)
         =.  cal.dal.dat
           %-  molt  ^-  (list (pair path lobe))
-          %+  murn  (~(tap by q.bas.dat))
+          %+  murn  ~(tap by q.bas.dat)
           |=  {pax/path lob/lobe}
           ^-  (unit (pair path lobe))
           =+  a=(~(get by q.ali.dat) pax)
@@ -2792,7 +2791,7 @@
         =.  can.dal.dat  p.can
         =.  old.dal.dat
           %-  malt  ^-  (list {path $~})
-          %+  murn  (~(tap by q.bas.dat))
+          %+  murn  ~(tap by q.bas.dat)
           |=  {pax/path lob/lobe}
           ?.  =(~ (~(get by q.ali.dat) pax))
             ~
@@ -2821,12 +2820,12 @@
           +>.$
         =.  new.dob.dat
           %-  molt
-          %+  skip  (~(tap by q.bob.dat))
+          %+  skip  ~(tap by q.bob.dat)
           |=  {pax/path lob/lobe}
           (~(has by q.bas.dat) pax)
         =.  cal.dob.dat
           %-  molt  ^-  (list (pair path lobe))
-          %+  murn  (~(tap by q.bas.dat))
+          %+  murn  ~(tap by q.bas.dat)
           |=  {pax/path lob/lobe}
           ^-  (unit (pair path lobe))
           =+  a=(~(get by q.ali.dat) pax)
@@ -2840,7 +2839,7 @@
         =.  can.dob.dat  p.can
         =.  old.dob.dat
           %-  malt  ^-  (list {path $~})
-          %+  murn  (~(tap by q.bas.dat))
+          %+  murn  ~(tap by q.bas.dat)
           |=  {pax/path lob/lobe}
           ?.  =(~ (~(get by q.bob.dat) pax))
             ~
@@ -2861,7 +2860,7 @@
               [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %merge ~]
               %f  %exec  p.bob  ~  [p.bob q.bob da+now]  %tabl
               ^-  (list (pair silk:ford silk:ford))
-              %+  turn  (~(tap by (~(int by can.dal.dat) can.dob.dat)))
+              %+  turn  ~(tap by (~(int by can.dal.dat) can.dob.dat))
               |=  {pax/path *}
               ^-  (pair silk:ford silk:ford)
               =+  cal=(~(got by can.dal.dat) pax)
@@ -2901,7 +2900,7 @@
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %build ~]
             %f  %exec  p.bob  ~  [p.bob q.bob da+now]  %tabl
             ^-  (list (pair silk:ford silk:ford))
-            %+  murn  (~(tap by bof.dat))
+            %+  murn  ~(tap by bof.dat)
             |=  {pax/path cay/(unit cage)}
             ^-  (unit (pair silk:ford silk:ford))
             ?~  cay
@@ -2938,7 +2937,7 @@
         =.  bop.dat  p.bop
         =+  ^-  con/(map path *)                        ::  2-change conflict
             %-  molt
-            %+  skim  (~(tap by bof.dat))
+            %+  skim  ~(tap by bof.dat)
             |=({pax/path cay/(unit cage)} ?=($~ cay))
         =+  ^-  cas/(map path lobe)                     ::  conflict base
             %-  ~(urn by con)
@@ -2947,7 +2946,7 @@
         =.  con                                         ::  change+del conflict
           %-  ~(uni by con)
           %-  malt  ^-  (list {path *})
-          %+  skim  (~(tap by old.dal.dat))
+          %+  skim  ~(tap by old.dal.dat)
           |=  {pax/path $~}
           ?:  (~(has by new.dob.dat) pax)
             ~|  %strange-add-and-del
@@ -2956,7 +2955,7 @@
         =.  con                                         ::  change+del conflict
           %-  ~(uni by con)
           %-  malt  ^-  (list {path *})
-          %+  skim  (~(tap by old.dob.dat))
+          %+  skim  ~(tap by old.dob.dat)
           |=  {pax/path $~}
           ?:  (~(has by new.dal.dat) pax)
             ~|  %strange-del-and-add
@@ -2965,21 +2964,21 @@
         =.  con                                         ::  add+add conflict
           %-  ~(uni by con)
           %-  malt  ^-  (list {path *})
-          %+  skip  (~(tap by (~(int by new.dal.dat) new.dob.dat)))
+          %+  skip  ~(tap by (~(int by new.dal.dat) new.dob.dat))
           |=  {pax/path *}
           =((~(got by new.dal.dat) pax) (~(got by new.dob.dat) pax))
         ?:  &(?=($mate gem.dat) ?=(^ con))
-          =+  (turn (~(tap by `(map path *)`con)) |=({path *} >[+<-]<))
+          =+  (turn ~(tap by `(map path *)`con) |=({path *} >[+<-]<))
           (error:he %mate-conflict -)
         =+  ^-  old/(map path lobe)                     ::  oldies but goodies
-            %+  roll  (~(tap by (~(uni by old.dal.dat) old.dob.dat)))
+            %+  roll  ~(tap by (~(uni by old.dal.dat) old.dob.dat))
             =<  .(old q.bas.dat)
             |=  {{pax/path $~} old/(map path lobe)}
             (~(del by old) pax)
         =+  ^-  can/(map path cage)                     ::  content changes
             %-  molt
             ^-  (list (pair path cage))
-            %+  murn  (~(tap by bof.dat))
+            %+  murn  ~(tap by bof.dat)
             |=  {pax/path cay/(unit cage)}
             ^-  (unit (pair path cage))
             ?~  cay
@@ -2987,7 +2986,7 @@
             `[pax u.cay]
         =^  hot  lat.ran                                ::  new content
           ^-  {(map path lobe) (map lobe blob)}
-          %+  roll  (~(tap by can))
+          %+  roll  ~(tap by can)
           =<  .(lat lat.ran)
           |=  {{pax/path cay/cage} hat/(map path lobe) lat/(map lobe blob)}
           =+  ^=  bol
@@ -3018,7 +3017,7 @@
         ::  ~&  >  hat=(~(run by hat) mug)
         =+  ^-  del/(map path ?)
             (~(run by (~(uni by old.dal.dat) old.dob.dat)) |=($~ %|))
-        =.  gon.dat  [%& (silt (turn (~(tap by con)) head))]
+        =.  gon.dat  [%& (silt (turn ~(tap by con) head))]
         =.  new.dat
           (make-yaki [r.ali.dat r.bob.dat ~] hat now)
         =.  hut.ran  (~(put by hut.ran) r.new.dat new.dat)
@@ -3048,7 +3047,7 @@
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %checkout ~]
             %f  %exec  p.bob  ~  val  %tabl
             ^-  (list (pair silk:ford silk:ford))
-            %+  murn  (~(tap by q.new.dat))
+            %+  murn  ~(tap by q.new.dat)
             |=  {pax/path lob/lobe}
             ^-  (unit (pair silk:ford silk:ford))
             ?:  (~(has by bop.dat) pax)
@@ -3079,7 +3078,7 @@
         =.  ank.dom  ank.dat
         =>  .(..wake wake)
         ?~  hez  done:he
-        =+  mus=(must-ergo (turn (~(tap by erg.dat)) head))
+        =+  mus=(must-ergo (turn ~(tap by erg.dat) head))
         ?:  =(~ mus)  done:he
         ergo
       ::
@@ -3090,8 +3089,8 @@
       ++  ergo
         ^+  .
         =+  ^-  sum/(set path)
-            =+  (must-ergo (turn (~(tap by erg.dat)) head))
-            =+  (turn (~(tap by -)) (corl tail tail))
+            =+  (must-ergo (turn ~(tap by erg.dat) head))
+            =+  (turn ~(tap by -) (corl tail tail))
             %+  roll  -
             |=  {pak/(set path) acc/(set path)}
             (~(uni in acc) pak)
@@ -3139,10 +3138,10 @@
           (error:he %ergo-no-hez ~)
         ?:  ?=($| -.gon.dat)
           +>.$
-        =+  mus=(must-ergo (turn (~(tap by erg.dat)) head))
+        =+  mus=(must-ergo (turn ~(tap by erg.dat) head))
         =<  done:he
         %-  emil
-        %+  turn  (~(tap by mus))
+        %+  turn  ~(tap by mus)
         |=  {pot/term len/@ud pak/(set path)}
         :*  u.hez  %give  %ergo  pot
             %+  turn  ~(tap in pak)
@@ -3229,7 +3228,7 @@
           ^-  (set yaki)
           ?~  unk  gud
           =+  bun=(~(del in `(set yaki)`unk) n.unk)
-          ?:  %+  levy  (~(tap by (~(uni in gud) bun)) ~)
+          ?:  %+  levy  ~(tap by (~(uni in gud) bun))
               |=  yak/yaki
               !(~(has in (~(got by zar) r.yak)) r.n.unk)
             $(gud (~(put in gud) n.unk), unk bun)
@@ -3280,7 +3279,7 @@
   ?-    -.q.hic
       $boat
     :_  ..^$
-    [hen %give %hill (turn (~(tap by mon.ruf)) head)]~
+    [hen %give %hill (turn ~(tap by mon.ruf) head)]~
   ::
       $drop
     =^  mos  ruf
@@ -3392,11 +3391,11 @@
     :_  %_    ..^$
             mon.ruf
           %-  molt
-          %+  skip  (~(tap by mon.ruf))
+          %+  skip  ~(tap by mon.ruf)
           (corl (cury test p.q.hic) tail)
         ==
     %+  turn
-      (skim (~(tap by mon.ruf)) (corl (cury test p.q.hic) tail))
+      (skim ~(tap by mon.ruf) (corl (cury test p.q.hic) tail))
     |=  {pot/term bem/beam}
     [u.hez.ruf %give %ogre pot]
   ::
@@ -3476,7 +3475,7 @@
     $0  =/  cul
           |=  a/cult-0  ^-  cult
           %-  ~(gas ju *cult)
-          (turn (~(tap by a)) |=({p/duct q/rove} [q p]))
+          (turn ~(tap by a) |=({p/duct q/rove} [q p]))
         =/  rom
           =+  doj=|=(a/dojo-0 a(qyx (cul qyx.a)))
           |=(a/room-0 a(dos (~(run by dos.a) doj)))
@@ -3652,7 +3651,7 @@
       $note  [[hen %give +.q.hin]~ ..^$]
       $wake
     ~|  %why-wakey  !!
-    ::  =+  dal=(turn (~(tap by fat.ruf) ~) |=([a=@p b=room] a))
+    ::  =+  dal=(turn ~(tap by fat.ruf) |=([a=@p b=room] a))
     ::  =|  mos=(list move)
     ::  |-  ^-  [p=(list move) q=_..^^$]
     ::  ?~  dal  [mos ..^^$]
@@ -3696,7 +3695,7 @@
     =+  len=(lent pax)
     =+  ^-  descendants/(list path)
         %+  turn
-          %+  skim  (~(tap by hat))
+          %+  skim  ~(tap by hat)
           |=  {paf/path lob/lobe}
           =(pax (scag len paf))
         |=  {paf/path lob/lobe}

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -203,7 +203,7 @@
           ^-  (list @c)
           ;:  weld
               ?:  =(0 ~(wyt in p.p.a))  ~
-              `(list @c)`(zing (turn (~(tap in p.p.a)) ef))
+              `(list @c)`(zing (turn ~(tap in p.p.a) ef))
               (bg p.q.p.a)
               (fg q.q.p.a)
               q.a

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -981,7 +981,7 @@
         (get-news:(dom-vi q.tee) p.sih)
       ?.  ?=({$on $~} tee)
         ~&(e+lost+[tee hen] +>.$)
-      %+  roll  (~(tap in (~(get ju liz) p.sih)))
+      %+  roll  ~(tap in (~(get ju liz) p.sih))
       =<  .(con ..axon(liz (~(del by liz) p.sih)))
       |=  {sus/(each duct ixor) con/_..axon}
       =.  ..axon  con
@@ -1717,7 +1717,7 @@
     ++  done  .
     ++  abet  ..ix(wix (~(put by wix) ire sem))
     ++  abut
-      =+  sub=(~(tap in sus))
+      =+  sub=~(tap in sus)
       |-  ^+  ..ix
       ?^  sub  $(sub t.sub, ..ix (pul-subs i.sub))
       ..ix(wix (~(del by wix) ire))

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -588,7 +588,7 @@
       ?-  -.q.bot
         $0  amok:(expo [%made dep q.q.bot])
         $2  amok:(expo [%made dep %| q.q.bot])
-        $1  =+  zuk=(~(tap by p.q.bot) ~)
+        $1  =+  zuk=~(tap by p.q.bot)
             =<  abet
             |-  ^+  ..exec
             ?~  zuk  ..exec
@@ -1107,7 +1107,7 @@
       |=  {cof/cafe mal/(map mark $~)}
       ?:  (~(has by mal) for)
         (cope (lace cof for bem) (flux some))
-      =+  opt=(silt (turn (~(tap by mal)) head))        ::  XX asymptotics
+      =+  opt=(silt (turn ~(tap by mal) head))          ::  XX asymptotics
       %+  cope  (lion cof for opt)
       |=  {cof/cafe wuy/(list @tas)}
       ?~  wuy  (flue cof)
@@ -1188,7 +1188,7 @@
       |=  {cof/cafe fro/(set mark)}  ^-  (bolt (list mark))
       ?:  (~(has in tag) p.won)
         (fine cof (flop pax))
-      =+  for=(skip (~(tap by fro)) ~(has by war))
+      =+  for=(skip ~(tap by fro) ~(has by war))
       =.  for  (sort for aor)         ::  XX useful?
       =:  q.won  (~(gas to q.won) for)
           war  (~(gas by war) (turn for |=(mark [+< pax])))
@@ -1490,14 +1490,14 @@
         |=  {cof/cafe sel/_..body}
         ^$(src t.src, ..body sel, cof cof)
       ::
-      :: ++  libs  `(set term)`(silt (turn (~(tap by bil)) head.is))
+      :: ++  libs  `(set term)`(silt (turn ~(tap by bil) head.is))
       ++  chad                                          ::  atomic list
         |=  {cof/cafe bax/vase doe/term hon/horn}
         ^-  (bolt vase)
         %+  cope  (lash cof how (flux (slat doe)))
         |=  {cof/cafe yep/(map knot @)}
         =+  ^=  poy  ^-  (list (pair knot @))
-            %+  sort  (~(tap by yep) ~)
+            %+  sort  ~(tap by yep)
             |=({{* a/@} {* b/@}} (lth a b))
         %+  cope
           |-  ^-  (bolt (list (pair @ vase)))
@@ -1895,7 +1895,7 @@
         ?~  -.q.i.i.a
           [%& (turn (turn a2 head) |=(b/mass ?~(-.q.b p.q.b !!)))]
         [%| $(a (turn (turn a2 head) |=(b/mass ?~(-.q.b !! p.q.b))))]
-    %+  turn  (~(tap by pol))
+    %+  turn  ~(tap by pol)
     |=  {@ baby}
     :~  =<  cache+[%| (turn `(list term)`/hood/bake/slit/slim/slap/slam .)]
         =-  |=(a/term [a %& (~(get ja dep) a)])

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -238,14 +238,14 @@
         :-  [%done ~]
         ;:  weld
           (axap dep (~(del in q.dap) bem))              ::  cancel outstanding
-          (turn (~(tap in p.dap)) |=(hen/duct [hen %give %news dep]))
+          (turn ~(tap in p.dap) |=(hen/duct [hen %give %news dep]))
           mow
     ==  ==
       ==
   ::
   ++  axap                                              ::  unsubscribe beams
     |=  {dep/@uvH dap/(set beam)}
-    %+  turn  (~(tap in dap))
+    %+  turn  ~(tap in dap)
     |=  bem/beam
     :^  hen  %pass  [(scot %p our) (scot %uv dep) (en-beam bem)]
     [%c %warp [our p.bem] q.bem ~]
@@ -277,7 +277,7 @@
           (~(put by deh.bay) dep [%sent [hen ~ ~] p.u.dap])
         ::
             mow
-          =<  (welp :_(mow (turn (~(tap in p.u.dap)) .)))
+          =<  (welp :_(mow (turn ~(tap in p.u.dap) .)))
           |=  bem/beam
           :^  hen  %pass  [(scot %p our) (scot %uv dep) (en-beam bem)]
           [%c [%warp [our p.bem] q.bem ~ [%next %z r.bem (flop s.bem)]]]
@@ -295,7 +295,7 @@
       ==
     ++  camo                                            ::  stop requests
       ^+  .
-      =+  kiz=(~(tap in kig))
+      =+  kiz=~(tap in kig)
       |-  ^+  +>
       ?~  kiz  +>
       $(kiz t.kiz, mow :_(mow [hen (cancel i.kiz)]))
@@ -569,7 +569,7 @@
       |=  {dep/(set beam) deh/(map @uvH deps)}
       ^+  [*@uvH deh.bay]
       =.  dep
-        =<  (silt (skip (~(tap in dep)) .))
+        =<  (silt (skip ~(tap in dep) .))
         |=  dap/beam  ^-  ?
         ?~  s.dap  |
         =>(.(s.dap t.s.dap) |((~(has in dep) dap) $))

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -557,7 +557,7 @@
           $(pyz t.pyz)
         =^  vad  +>  ap-fill(ost p.i.pyz)
         $(pyz t.pyz, ful ?:(vad ful (~(put in ful) p.i.pyz)))
-      =+  ded=(~(tap in ful) ~)
+      =+  ded=~(tap in ful)
       |-  ^+  +>.^$
       ?~  ded  +>.^$
       =>  %*(. $(ded t.ded) ost i.ded)
@@ -1067,8 +1067,8 @@
       =^  tur  +>.$
           %+  ap-call  %prep
           ?~(vux !>(~) (slop !>(~) (slot 13 u.vux)))
-      ?~  tur 
-        `+>.$ 
+      ?~  tur
+        `+>.$
       :_(+>.$ `u.tur)
     ::
     ++  ap-pule                                         ::  silent delete

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1260,12 +1260,12 @@
     :^  hen  %give  %mass
     :-  %gall
     :-  %|
-    %+  turn  (~(tap by pol.all))     :: XX single-home
+    %+  turn  ~(tap by pol.all)       :: XX single-home
     |=  {our/@ mast}  ^-  mass
     :+  (scot %p our)  %|
     :~  [%foreign [%& sap]]
-        [%blocked [%| (sort (~(tap by (~(run by wub) |=(sofa [%& +<])))) aor)]]
-        [%active [%| (sort (~(tap by (~(run by bum) |=(seat [%& +<])))) aor)]]
+        [%blocked [%| (sort ~(tap by (~(run by wub) |=(sofa [%& +<]))) aor)]]
+        [%active [%| (sort ~(tap by (~(run by bum) |=(seat [%& +<]))) aor)]]
     ==
   ==
 ::

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1117,7 +1117,7 @@
   ::                                                    ::  ++exec:su
   ++  exec                                              ::  mass gift
     |=  {yen/(set duct) cad/card}
-    =/  noy  (~(tap in yen))
+    =/  noy  ~(tap in yen)
     |-  ^+  ..exec
     ?~  noy  ..exec
     $(noy t.noy, moz [[i.noy cad] moz])
@@ -1212,7 +1212,7 @@
     ::                                                  ::  ++flow:su
     ++  flow                                            ::  to set of ships
       |=  tar/(set ship)
-      =+  rot=(~(tap in (~(del in tar) our)))
+      =+  rot=~(tap in (~(del in tar) our))
       |-  ^+  ..fire
       ?~  rot  ..fire
       $(rot t.rot, ..fire (home i.rot))
@@ -1238,7 +1238,7 @@
       ::  nex: all wills to add
       ::
       =/  nex
-        =/  rom  (~(tap in mor))
+        =/  rom  ~(tap in mor)
         |-  ^-  farm
         ?~  rom  ~
         %+  ~(put by $(rom t.rom))

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -819,14 +819,14 @@
   ++  remove                                            ::  pig minus gob
     |=  gob/safe
     ^-  safe
-    =/  buv  (~(tap by gob))
+    =/  buv  ~(tap by gob)
     |-  ?~  buv  pig
         $(buv t.buv, pig (delete i.buv))
   ::                                                    ::  ++splice:up
   ++  splice                                            ::  pig plus gob
     |=  gob/safe
     ^-  safe
-    =/  buv  (~(tap by gob))
+    =/  buv  ~(tap by gob)
     |-  ?~  buv  pig
         $(buv t.buv, pig (insert i.buv))
   ::                                                    ::  ++update:up
@@ -844,7 +844,7 @@
   ++  collate                                           ::  sort by version
     |=  ord/$-({{life cert} {life cert}} ?)
     ^-  (list (pair life cert))
-    (sort (~(tap by pub)) ord)
+    (sort ~(tap by pub) ord)
   ::                                                    ::  ++current:we
   ++  current                                           ::  current number
     ^-  (unit life)
@@ -1250,11 +1250,11 @@
       =.  sea  (~(uni in sea) mor)
       =/  wit
         =|  wit/(set ship)
-        =/  fem  (~(tap by nex))
+        =/  fem  ~(tap by nex)
         |-  ^+  wit
         ?~  fem  wit
         =.  wit  $(fem t.fem)
-        =/  naw  (~(tap by q.i.fem))
+        =/  naw  ~(tap by q.i.fem)
         |-  ^+   wit
         ?~  naw  wit
         =.  wit  $(naw t.naw)
@@ -1335,7 +1335,7 @@
       =/  fub
         ^-  (list (pair ship (unit safe)))
         %+  turn
-          (~(tap by pry.urb))
+          ~(tap by pry.urb)
         |=  (pair ship (map ship safe))
         [p (~(get by q) our)]
       =*  veg
@@ -1364,7 +1364,7 @@
       ?.  (~(has in kyz.rel) who)  cod.rel
       =-  (~(uni by cod.rel) -)
       %-  ~(gas by *farm)
-      %+  skim  (~(tap by pug.urb))
+      %+  skim  ~(tap by pug.urb)
       |=({who/ship *} (lth who 65.536))
     ::
     (~(home fire hec) who)
@@ -1559,7 +1559,7 @@
             cod/farm
         ==
     ^+  +>
-    =+  lec=(~(tap by cod))
+    =+  lec=~(tap by cod)
     |-  ^+  ..meet
     ?~  lec  ..meet
     %=  $
@@ -1983,7 +1983,7 @@
           ::
           ::  sow: all new signatures
           ::
-          =+  sow=`(list (trel ship life @))`(~(tap by syg.new))
+          =+  sow=`(list (trel ship life @))`~(tap by syg.new)
           |-  ^-  (pair (list change) cert)
           ?~  sow  [~ u.eld]
           ::

--- a/sys/vane/xmas.hoon
+++ b/sys/vane/xmas.hoon
@@ -709,10 +709,10 @@
     ++  aver                                            ::  verify
       ?>  (lte cur.saw max.saw)
       ?>  !=(0 max.saw)
-      ?.  =(cur.saw (lent (~(tap to liv))))
-        ~&  [%aver-cur cur.saw (lent (~(tap to liv)))]
+      ?.  =(cur.saw (lent ~(tap to liv)))
+        ~&  [%aver-cur cur.saw (lent ~(tap to liv))]
         !!
-      ?>  =(rey.saw (lent (~(tap to lop))))
+      ?>  =(rey.saw (lent ~(tap to lop)))
       ?>  =+  |=  {a/coal b/coal}
               &((lth out.a out.b) (lth lod.a lod.b))
           |-  ?|  ?=($~ liv)
@@ -771,7 +771,7 @@
           [& $(liv l.liv)]
       ?~  ack  [~ ~ liv]
       =.  ded  ?:(top [n.liv ded] ded)
-      =.  ded  ?:(vig.clu.u.ack (~(tap to r.liv) ded) ded)
+      =?  ded  vig.clu.u.ack  (weld ~(tap to r.liv) ded)
       =.  lov  ?:(top [n.liv lov ~] lov)
       [ack ded lov]
     ::                                                  ::
@@ -851,7 +851,7 @@
         ::
         ::  everything in front of a dead packet is dead
         ::
-        $(liv l.liv, ded (~(tap to r.liv) [n.liv ded]))
+        $(liv l.liv, ded (welp ~(tap to r.liv) [n.liv ded]))
       =+  ryt=$(liv r.liv)
       [p.ryt [n.liv l.liv q.ryt]]
     ::                                                  ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -3131,7 +3131,7 @@
       |=  jon/json  ^-  (map _(wonk *fel) _*wit)
       =/  jom  ((om wit) jon)
       %-  malt
-      %+  turn  (~(tap by jom))
+      %+  turn  ~(tap by jom)
       |*  {a/cord b/*}
       =>  .(+< [a b]=+<)
       [(rash a fel) b]
@@ -3280,7 +3280,7 @@
       ?~  jom  ~
       %-  drop-map
       %-  malt
-      %+  turn  (~(tap by jom))
+      %+  turn  ~(tap by jom)
       |*  {a/cord b/*}
       (both (rush a fel) (some b))
     ::                                                  ::  ++pe:dejs-soft:
@@ -3555,7 +3555,7 @@
           $o
         :-  '{'
         =.  rez  ['}' rez]
-        =+  viz=(~(tap by p.val))
+        =+  viz=~(tap by p.val)
         ?~  viz  rez
         !.
         |-  ^+  rez
@@ -4536,7 +4536,7 @@
     ::                                                  ::  ++pale:pubsub:
     ++  pale                                            ::  filter peers
       |=  {hid/bowl fun/$-(sink ?)}
-      (skim (~(tap by sup.hid)) fun)
+      (skim ~(tap by sup.hid) fun)
     ::                                                  ::  ++prix:pubsub:
     ++  prix                                            ::  filter gate
       |=  pax/path  |=  sink  ^-  ?


### PR DESCRIPTION
in order to preserve the crucial Strategic Parenthetical Reserves ...

for each `++in`, `++by`, and `++to`, i've replaced the `+-tap` implementation, indirecting through `+-rap` in case you want to keep the old name. The commits are granular, so it'll be easy to de/re-construct as needed ...

I've also done some dubious-quality work on the jets -- my latest version just dumps core. All this works without jet changes, though. I find that surprising ...

Finally, it's not based on the latest master, but a slightly older master: I couldn't get %clay to work on an up-to-date fake ~zod.