### PR TITLE
Add `++  grad  %mime` to html.hoon mark.

### DIFF
--- a/mar/html.hoon
+++ b/mar/html.hoon
@@ -15,4 +15,6 @@
 ++  grab  |%                                            ::  convert from
           ++  noun  @t                                  ::  clam from %noun
           ++  mime  |=({p/mite q/octs} q.q)             ::  retrieve form $mime
---        --
+          --
+++  grad  %mime
+--


### PR DESCRIPTION
Fixes issue where ford doesn’t know which of two diffed html files to
build.