### PR TITLE
forwardport #360

### DIFF
--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -401,10 +401,14 @@
   +>(mir lin)
 ::
 ++  se-just                                           ::  adjusted buffer
-  |=  lin/(pair @ud stub:dill)
+  |=  {pom/stub:dill lin/(pair @ud (list @c))}
   ^+  +>
-  =.  off  ?:((lth p.lin edg) 0 (sub p.lin edg))
-  (se-show (sub p.lin off) (scag:klr edg (slag:klr off q.lin)))
+  =/  pol  (lent-char:klr pom)
+  =/  end  (sub edg pol)
+  =.  off  ?:((lte p.lin end) 0 (sub p.lin end))
+  %+  se-show
+    (sub (add pol p.lin) off)
+  (welp pom [*stye:dill (swag [off end] q.lin)]~)
 ::
 ++  se-view                                           ::  flush buffer
   ^+  .
@@ -826,11 +830,9 @@
     (ta-hom (cat:edit pos.inp txt))
   ::
   ++  ta-vew                                          ::  computed prompt
-    ^-  (pair @ud stub:dill)
+    ^-  {pom/stub:dill lin/(pair @ud (list @c))}
     =;  vew/(pair (list @c) styx:dill)
-      =+  lin=(make:klr q.vew)
-      :_  (welp lin [*stye:dill p.vew]~)
-      (add pos.inp (lent-char:klr lin))
+      [(make:klr q.vew) pos.inp p.vew]
     ?:  vis.pom
       :-  buf.say.inp                                 ::  default prompt
       ?~  ris

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -640,11 +640,7 @@
   ::
   ++  ta-off                                          ::  reset buffer offset
     |=  ted/sole-edit
-    =.  off  ?:  |-  ?.  ?=({$mor *} ted)
-                   ?=({$set *} ted)
-                 |-  ?~(p.ted | |(^$(ted i.p.ted) $(p.ted t.p.ted)))
-               0
-             off
+    =?  off  (any:edit ted |=(a/sole-edit ?=($set -.a)))  0
     +>
   ::
   ++  ta-got                                          ::  apply change
@@ -891,6 +887,11 @@
         (cut pos num)
         (cat pos txt)
     ==
+  ++  any                                             ::  matches?
+    |=  {a/sole-edit b/$-(sole-edit ?)}
+    ^-  ?
+    ?.  ?=($mor -.a)  (b a)
+    (lien p.a |=(c/sole-edit ^$(a c)))
   --
 ++  offset                                            ::  calculate offsets
   |%

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -570,7 +570,7 @@
         $v  ta-bel
         $w  ?:  =(0 pos.inp)
               ta-bel
-            =+  sop=(ta-off %l %ace pos.inp)
+            =+  sop=(ta-pos %l %ace pos.inp)
             (ta-kil %l [(sub pos.inp sop) sop])
         $x  +>(..ta se-anon)
         $y  ?:  =(0 num.kil)
@@ -632,22 +632,31 @@
       ==
     ==
   ::
+  ++  ta-off                                          ::  reset buffer offset
+    |=  ted/sole-edit
+    =.  off  ?:  |-  ?.  ?=({$mor *} ted)
+                   ?=({$set *} ted)
+                 |-  ?~(p.ted | |(^$(ted i.p.ted) $(p.ted t.p.ted)))
+               0
+             off
+    +>
+  ::
   ++  ta-got                                          ::  apply change
     |=  cal/sole-change
     =^  ted  say.inp  (~(receive sole say.inp) cal)
-    (ta-dog ted)
+    (ta-dog:(ta-off ted.cal) ted)
   ::
   ++  ta-hom                                          ::  local edit
     |=  ted/sole-edit
     ^+  +>
-    =.  +>  (ta-det ted)
+    =.  +>  (ta-det:(ta-off ted) ted)
     (ta-dog(say.inp (~(commit sole say.inp) ted)) ted)
   ::
   ++  ta-jump                                         ::  buffer pos
     |=  {dir/?($l $r) til/?($ace $edg $wrd) pos/@ud}
     ^-  @ud
     %-  ?:(?=($l dir) sub add)
-    [pos (ta-off dir til pos)]
+    [pos (ta-pos dir til pos)]
   ::
   ++  ta-kil                                          ::  kill selection
     |=  {dir/?($l $r) sel/{@ @}}
@@ -688,7 +697,7 @@
             ::
       $bac  ?:  =(0 pos.inp)                          ::  kill left-word
               ta-bel
-            =+  sop=(ta-off %l %edg pos.inp)
+            =+  sop=(ta-pos %l %edg pos.inp)
             (ta-kil %l [(sub pos.inp sop) sop])
             ::
       $b    ?:  =(0 pos.inp)                          ::  jump left-word
@@ -705,7 +714,7 @@
             ::
       $d    ?:  =(pos.inp (lent buf.say.inp))         ::  kill right-word
               ta-bel
-            (ta-kil %r [pos.inp (ta-off %r %edg pos.inp)])
+            (ta-kil %r [pos.inp (ta-pos %r %edg pos.inp)])
             ::
       $f    ?:  =(pos.inp (lent buf.say.inp))         ::  jump right-word
               ta-bel
@@ -722,7 +731,7 @@
             ?:  =(b c)
               ta-bel
             =+  next=[b (sub a b)]
-            =+  prev=[c (ta-off %r %edg c)]
+            =+  prev=[c (ta-pos %r %edg c)]
             %-  ta-hom(pos.inp a)
             :~  %mor
                 (rep:edit next (swag prev buf.say.inp))
@@ -734,7 +743,7 @@
               ta-bel
             =+  case=?:(?=($u key) cuss cass)
             =+  sop=(ta-jump %r %wrd pos.inp)
-            =+  sel=[sop (ta-off %r %edg sop)]
+            =+  sel=[sop (ta-pos %r %edg sop)]
             %-  ta-hom
             %+  rep:edit  sel
             ^-  (list @c)  ^-  (list @)               :: XX unicode
@@ -777,7 +786,7 @@
       old.hit  [buf.say.inp old.hit]
     ==
   ::
-  ++  ta-off                                          ::  buffer pos offset
+  ++  ta-pos                                          ::  buffer pos offset
     |=  {dir/?($l $r) til/?($ace $edg $wrd) pos/@ud}
     ^-  @ud
     %-  ?-  til  $ace  ace:offset

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -302,7 +302,7 @@
   =+  wag=se-amor
   ?~  wag  +
   ::  ~&  [%se-anon inx+inx wag+wag nex+(mod +(inx) (lent se-amor))]
-  +(inx (mod +(inx) (lent wag)))
+  +(off 0, inx (mod +(inx) (lent wag)))
 ::
 ++  se-agon                                           ::  current gill
   ^-  (unit gill:gall)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -405,7 +405,11 @@
   ^+  +>
   =/  pol  (lent-char:klr pom)
   =/  end  (sub edg pol)
-  =.  off  ?:((lte p.lin end) 0 (sub p.lin end))
+  =.  off  ?:  (gth p.lin (add end off))
+             (sub p.lin end)
+           ?:  (lth p.lin off)
+             (min p.lin (dec off))
+           off
   %+  se-show
     (sub (add pol p.lin) off)
   (welp pom [*stye:dill (swag [off end] q.lin)]~)

--- a/lib/drum.hoon
+++ b/lib/drum.hoon
@@ -405,13 +405,19 @@
   ^+  +>
   =/  pol  (lent-char:klr pom)
   =/  end  (sub edg pol)
+  =/  pos  (add pol p.lin)
+  ?:  (gte (div (mul pol 100) edg) 35)      :: old style (long prompt)
+    =/  off  ?:((lte p.lin end) 0 (sub p.lin end))
+    %+  se-show
+      (sub pos off)
+    (swag:klr [off edg] (welp pom [*stye:dill q.lin]~))
   =.  off  ?:  (gth p.lin (add end off))
              (sub p.lin end)
            ?:  (lth p.lin off)
              (min p.lin (dec off))
            off
   %+  se-show
-    (sub (add pol p.lin) off)
+    (sub pos off)
   (welp pom [*stye:dill (swag [off end] q.lin)]~)
 ::
 ++  se-view                                           ::  flush buffer
@@ -1010,5 +1016,9 @@
     =+  n=(snag p.u.i b)
     :_  ~  :-  p.n
     (^scag (sub (snag p.u.i c) (sub q.u.i a)) q.n)
+  ::
+  ++  swag                                            ::  swag stub, keep stye
+    |=  {{a/@ b/@} c/stub}
+    (scag b (slag a c))
   --
 --


### PR DESCRIPTION
This is just a forward port of #360. Due to #357, I'm unable to test it. Instead I was able to test this:

https://github.com/urbit/arvo/compare/4288aab089c46cc9fb575c37e393137f6ec339f6...joemfb:prompt-sticky-tmp

As best I can tell, the only difference is `:^dill` vs `:dill` ...