### PR TITLE
updates ++boil:ap to crash if a book has pages with the same tag

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6772,12 +6772,21 @@
         [%axil %void]
       ?~  t.p.gen
         boil(gen i.p.gen)
-      =+  :*  def=bile(gen i.p.gen)
-              ^=  end  ^-  (list line)
-              ~_  leaf+"book-foul"
-              %+  turn  `(list hoon)`t.p.gen
-              |=(a/hoon =+(bile(gen a) ?>(?=($& -<) ->)))
-          ==
+      =/  def  bile(gen i.p.gen)
+      =|  tag/(set term)
+      =?  tag  ?=($& -.def)  (~(put in tag) `@tas`q.p.p.def)
+      =/  end
+        =|  lit/(list line)
+        |-  ^+  lit
+        =/  tar  bile(gen i.t.p.gen)
+        ?.  ?=($& -.tar)
+          ~_(leaf+"book-foul" !!)
+        =/  hed  `@tas`q.p.p.tar
+        ?:  (~(has in tag) hed)
+          ~_(leaf+"book-dup-page: {<hed>}" !!)
+        =.  lit  [+.tar lit]
+        ?~  t.t.p.gen  lit
+        $(tag (~(put in tag) hed), t.p.gen t.t.p.gen)
       ?-  -.def
         $&  [%kelp p.def end]
         $|  ?~(end p.def [%fern p.def [%kelp end] ~])

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1165,9 +1165,10 @@
       $%  {$west p/ship q/path r/*}                     ::  network request
       ==                                                ::
     ++  sign                                            ::  in response $-<
-      $%  {$g $rend p/path q/*}                         ::  network request
-          {$g $mack p/(unit tang)}                      ::  message ack
-      ==                                                ::
+      $:  $g                                            ::
+          $%  {$rend p/path q/*}                        ::  network request
+              {$mack p/(unit tang)}                     ::  message ack
+      ==  ==                                            ::
     ++  note                                            ::  out request $->
       $%  {$c $west p/ship q/path r/*}                  ::  to %clay
           {$e $west p/ship q/path r/*}                  ::  to %eyre


### PR DESCRIPTION
I've only tested this in a generator -- I can't find a recent commit of master that lets me `|reset` ...

closes #296 
