### PR TITLE
adds optional %tstr aliases prelude to %brcb

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -5514,7 +5514,7 @@
     {$bcts p/toga q/root}                               ::  $= name
     {$bcsm p/twig}                                      ::  $; assembly
   ::                                            ::::::  cores
-    {$brcb p/chap q/root r/(map @ tomb)}                ::  |_
+    {$brcb p/chap q/root r/(list (pair term twig)) s/(map @ tomb)} ::  |_
     {$brcl p/chap q/twig r/twig}                        ::  |:
     {$brcn p/chap q/(map @ tomb)}                       ::  |%
     {$brdt p/chap q/twig}                               ::  |.
@@ -6535,7 +6535,14 @@
         {$halo *}  ~(clam al boil)
         {$bcsm *}  p.gen
     ::
-        {$brcb *}  [%tsls [%bunt q.gen] [%brcn p.gen r.gen]]
+        {$brcb *}  :+  %tsls  [%bunt q.gen]
+                   :+  %brcn  p.gen
+                   %-  ~(run by s.gen)
+                   |=  a/foot  ^+  a
+                   =-  ?:(?=({$ash *} a) [-.a -] [-.a -])
+                   |-  ^-  twig
+                   ?~  r.gen  p.a
+                   [%aka p.i.r.gen q.i.r.gen $(r.gen t.r.gen)]
         {$brcl *}  [%tsls [%ktsg q.gen] [%brdt p.gen r.gen]]
         {$brdt *}  :+  %brcn  p.gen
                    =-  [[0 [~ ~] -] ~ ~]
@@ -6552,8 +6559,8 @@
                    :+  %brcn  p.gen
                    =-  [[0 [~ ~] -] ~ ~]
                    (~(put by *(map term (pair what foot))) %$ ~ [%elm r.gen])
-        {$brts *}  :^  %brcb  p.gen  q.gen 
-                   =-  [[0 [~ ~] -] ~ ~]
+        {$brts *}  :^  %brcb  p.gen  q.gen
+                   =-  [~ [[0 [~ ~] -] ~ ~]]
                    (~(put by *(map term (pair what foot))) %$ ~ [%ash r.gen])
         {$brwt *}  [%ktwt %brdt p.gen q.gen]
     ::
@@ -10387,6 +10394,12 @@
     ::
     ++  whap                                            ::  chapter
       (most muck boog)
+    ++  wasp                                            ::  $brcb aliases
+      ;~  pose  %+  ifix
+                  [;~(plug lus tar muck) muck]
+                (most muck ;~(gunk sym loaf))  :: XX loan?
+                (easy ~)
+      ==
     ::
     ++  wisp                                            ::  core tail
       ?.  tol  fail
@@ -10524,7 +10537,7 @@
     ++  exqs  |.((butt hunk))                           ::  closed gapped roots
     ++  exqg  |.(;~(gunk sym loan))                     ::  term and root
     ++  exqk  |.(;~(gunk loaf ;~(plug loan (easy ~))))  ::  twig with one root
-    ++  exqr  |.(;~(gunk loan wisp))                    ::  root and core tail
+    ++  exqr  |.(;~(gunk loan ;~(plug wasp wisp)))      ::  root/aliases?/tail
     ++  exqn  |.(;~(gunk loan (stag %cltr (butt hank))))::  autoconsed twigs
     ++  exqw  |.(;~(gunk loaf loan))                    ::  twig and root
     ++  exqx  |.(;~(gunk loaf loan loan))               ::  twig, two roots

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6894,8 +6894,7 @@
         $bcwt  (lead -.gen %.(+.gen moar))
         $bcts  (lead -.gen %.(+.gen nexp))
         $bcsm  (lead -.gen %.(+.gen expr))
-        $brcb  (lead -.gen %.(+.gen (trio noop expr arms)))
-        $brcb  (lead -.gen %.(+.gen (trio noop expr arms)))
+        $brcb  (lead -.gen %.(+.gen (quad noop expr exps arms)))
         $brcl  (lead -.gen %.(+.gen (twin noop dubs)))
         $brcn  (lead -.gen %.(+.gen (twin noop arms)))
         $brdt  (lead -.gen %.(+.gen (twin noop expr)))
@@ -6998,6 +6997,15 @@
     ++  expr
       |=  p/twig
       ^$(gen p)
+    ::
+    ++  exps
+      |=  p/(list (pair term twig))
+      =|  out/(list (pair term twig))
+      |-  ^+  [out vit]
+      ?~  p
+        [out vit]
+      =^  nex  vit  ^^$(gen q.i.p)
+      $(p t.p, out [[p.i.p nex] out])
     ::
     ++  heel
       |=  bud/foot

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6538,11 +6538,17 @@
         {$brcb *}  :+  %tsls  [%bunt q.gen]
                    :+  %brcn  p.gen
                    %-  ~(run by s.gen)
-                   |=  a/foot  ^+  a
-                   =-  ?:(?=({$ash *} a) [-.a -] [-.a -])
+                   |=  tom/tomb
+                   ^+  tom
+                   :-  p.tom
+                   %-  ~(run by q.tom)
+                   |=  a/(pair what foot)
+                   ^+  a
+                   :-  p.a
+                   =-  ?:(?=({$ash *} q.a) [-.q.a -] [-.q.a -])
                    |-  ^-  twig
-                   ?~  r.gen  p.a
-                   [%aka p.i.r.gen q.i.r.gen $(r.gen t.r.gen)]
+                   ?~  r.gen  p.q.a
+                   [%tstr [~ p.i.r.gen] q.i.r.gen $(r.gen t.r.gen)]
         {$brcl *}  [%tsls [%ktsg q.gen] [%brdt p.gen r.gen]]
         {$brdt *}  :+  %brcn  p.gen
                    =-  [[0 [~ ~] -] ~ ~]


### PR DESCRIPTION
see #361 for discussion

I had to comment out the `1-d` assertion in `gen/metal` to make a pill from this. I've uploaded it here: https://www.dropbox.com/s/2nz4w5cxdwjqqmo/door-aliases.pill?dl=0

Here's my test case:

```
|=  arg/@
=<  abet:(~(flub . 10) arg)
|/  a/@
+*  this  .
    samp  +<
    cont  +>
++  abet  [~ a]
++  flub
  |=  b/@
  ?>  =(a samp)
  ?>  =(+>+>.$ cont)
  this(a (add a b))
--
```

How should I format the `$door` page to preserve the margin?

Also, there are duplicate `:door` keyword declarations, along with both the `|_` and `|/` runes. Should the keywords be deduplicated? And can `|/` be removed?

closes #361