### PR TITLE
Fixed ++oust to not require faces for [a b].

### DIFF
--- a/arvo/hoon.hoon
+++ b/arvo/hoon.hoon
@@ -731,7 +731,7 @@
 ++  oust                                                ::  remove
   ~/  %oust
   |*  {{a/@ b/@} c/(list)}
-  (weld (scag a c) (slag (add a b) c))
+  (weld (scag +<-< c) (slag (add +<-< +<->) c))
 ::
 ++  reap                                                ::  replicate
   ~/  %reap


### PR DESCRIPTION
This functioned fine when it was originally implemented but, you know, wet gates.