### PR TITLE
prevents nest-fail in ;; / :fry

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6351,7 +6351,11 @@
       :+  %pin  [%name %b [%per [%limb %v] q.gen]]      ::  =+  b==>(v {q.gen})
       :+  %pin                                          ::  =+  c=(a b)
         [%name %c [%call [%limb %a] [%limb %b] ~]]      ::
-      [%sure [%same [%limb %c] [%limb %b]] [%limb %c]]  ::  ?>(=(c b) c)
+      :+  %sure                                         ::  ?>(=(`*`c `*`b) c)
+        :+  %same                                       ::
+        [%cast [%base %noun] [%limb %c]]                ::
+        [%cast [%base %noun] [%limb %b]]                ::
+      [%limb %c]                                        ::
     ::
         {$new *}
       [%pin ~(bunt al %herb p.gen) q.gen]


### PR DESCRIPTION
`++hard` doesn't have this problem, since it's wet.

before:

```
> ((hard (list @)) [0 1 2 3 4 0])
~[0 1 2 3 4]
> ;;((list @) [0 1 2 3 4 0])
nest-fail
```

after:

```
> ((hard (list @)) [0 1 2 3 4 0])
~[0 1 2 3 4]
> ;;((list @) [0 1 2 3 4 0])
~[0 1 2 3 4]
```