### PR TITLE
Enable js urb.bind to a foreign {ship}: v2

### DIFF
--- a/arvo/dill.hoon
+++ b/arvo/dill.hoon
@@ -387,7 +387,6 @@
                      +>.$ 
                    (dump:(crud %reap u.p.p.+>.sih) %logo ~)
             $diff  pump:(from ((hard dill-blit) q:`vase`+>+>.sih))
-            $doff  !!
           ==
         ::
             {$c $note *}

--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -776,8 +776,6 @@
         ::  ~?  ?=($lens r.q.tee)  hen=hen^hcuf=-.cuf
         (get-ack:(ire-ix p.tee) q.tee ?~(p.cuf ~ `[-.cuf u.p.cuf]))
       ::
-      ::  REVIEW handle in gall?
-          $doff  (execute tee (norm-beak -.top) [%vale p.cuf q.cuf])
           $diff
         ?.  ?=($json p.p.cuf)
           :: ~>  %slog.`%*(. >[%backing p.p.cuf %q-p-cuf]< &3.+> (sell q.p.cuf))

--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -776,7 +776,8 @@
         ::  ~?  ?=($lens r.q.tee)  hen=hen^hcuf=-.cuf
         (get-ack:(ire-ix p.tee) q.tee ?~(p.cuf ~ `[-.cuf u.p.cuf]))
       ::
-          $doff  !!
+      ::  REVIEW handle in gall?
+          $doff  (execute tee (norm-beak -.top) [%vale p.cuf q.cuf])
           $diff
         ?.  ?=($json p.p.cuf)
           :: ~>  %slog.`%*(. >[%backing p.p.cuf %q-p-cuf]< &3.+> (sell q.p.cuf))

--- a/arvo/gall.hoon
+++ b/arvo/gall.hoon
@@ -429,14 +429,14 @@
         ?>  ?=({@ $~} t.pax)
         %-  mo-awed
         :*  p.+>.sih
-            (?($peer $peel $poke $pull) i.t.pax)
+            ;;(?($peer $peel $poke $pull) i.t.pax)
             ~
         ==
       ?>  ?=({$a $woot *} sih)
       ?>  ?=({@ $~} t.pax)
       %-  mo-awed
       :*  p.+>.sih
-          (?($peer $poke $pull) i.t.pax)
+          ;;(?($peer $peel $poke $pull) i.t.pax)
           +>+.sih
       ==
     ==

--- a/arvo/gall.hoon
+++ b/arvo/gall.hoon
@@ -536,7 +536,7 @@
       =.  +>  (mo-give %mack ~)
       %+  mo-pass
         [%sys %rep (scot %p him) dap (scot %ud num) ~]
-      [%f %exec our ~ (mo-beak dap) %vale p.ron our q.ron]
+      [%f %exec our ~ (mo-beak dap) %vale p.ron q.ron]
     ::
         $x  =.  +>  (mo-give %mack ~)                  ::  XX should crash
             (mo-give(hen (mo-ball him num)) %unto %quit ~)

--- a/arvo/gall.hoon
+++ b/arvo/gall.hoon
@@ -13,6 +13,7 @@
   ==                                                    ::
 ++  rook                                                ::  forward ames msg
   $%  {$m p/mark q/*}                                   ::  message
+      {$l p/mark q/path}                                ::  "peel" subscribe
       {$s p/path}                                       ::  subscribe
       {$u $~}                                           ::  cancel+unsubscribe
   ==                                                    ::
@@ -251,11 +252,11 @@
     =^  num  +>.$  (mo-bale him)
     =+  ^=  roc  ^-  rook
         ?-  -.q.caz
-          $peel  !!
           $poke  [%m p.p.q.caz q.q.p.q.caz]
           $pull  [%u ~]
           $puff  !!
           $punk  !!
+          $peel  [%l p.q.caz q.q.caz]
           $peer  [%s p.q.caz]
         ==
     %+  mo-pass  
@@ -274,11 +275,12 @@
     `[[%leaf (trip p.u.ars)] q.u.ars]
   ::
   ++  mo-awed                                           ::  foreign response
-    |=  {him/ship why/?($peer $poke $pull) art/(unit ares)}
+    |=  {him/ship why/?($peer $peel $poke $pull) art/(unit ares)}
     ^+  +>
     ::  ~&  [%mo-awed him why art]
     =+  tug=(mo-baba (mo-baal art))
     ?-  why
+      $peel  (mo-give %unto %reap tug)
       $peer  (mo-give %unto %reap tug)
       $poke  (mo-give %unto %coup tug)
       $pull  +>.$
@@ -428,7 +430,7 @@
         ?>  ?=({@ $~} t.pax)
         %-  mo-awed
         :*  p.+>.sih
-            (?($peer $poke $pull) i.t.pax)
+            (?($peer $peel $poke $pull) i.t.pax)
             ~
         ==
       ?>  ?=({$a $woot *} sih)
@@ -554,6 +556,7 @@
     ?-  -.rok
       ::  %m  [%f %exec our ~ (mo-beak dap) %vale p.rok q.rok]
       $m  [%g %deal [him our] dap %puff p.rok q.rok]
+      $l  [%g %deal [him our] dap %peel p.rok q.rok]
       $s  [%g %deal [him our] dap %peer p.rok]
       $u  [%g %deal [him our] dap %pull ~]
     ==

--- a/arvo/gall.hoon
+++ b/arvo/gall.hoon
@@ -408,7 +408,6 @@
         $coup  (mo-give %mack p.cuf)
         $diff  %+  mo-pass  [%sys %red t.pax]
                [%a %wont [our him] [%g %gh dap ~] [num %d p.p.cuf q.q.p.cuf]]
-        $doff  !!
         $quit  %+  mo-pass  [%sys pax]
                [%a %wont [our him] [%g %gh dap ~] [num %x ~]]
         $reap  (mo-give %mack p.cuf)
@@ -460,39 +459,10 @@
               +>.$
             ap-abet:(ap-purr:pap +<.q.hin t.t.t.pax +>.q.hin)
     ::
-      $out  ?:  ?=({$f $made *} q.hin)
-              ?-  -.q.+>.q.hin  
-                $tabl  ~|(%made-tabl !!)
-                $&     =.  ap.pap  (mo-resume-mack:pap ~)
-                       ap-abet:(ap-pout:pap t.t.t.pax %diff +.q.+>.q.hin)
-                $|
-                    =+  why=p.q.+>.q.hin
-                    =.  ..ap  ap-abet:(ap-misvale:pap t.pax)
-                    =.  why  (turn why |=(a/tank rose+[~ "! " ~]^[a]~))
-                    ~>  %slog.`rose+["  " "[" "]"]^[>%mo-cook-fail< (flop why)]
-                    ~&  [him=q.q.pry our=our pax=pax]
-                    ::
-                    ::  here we should crash because the right thing
-                    ::  for the client to do is to upgrade so that it
-                    ::  understands the server's mark, thus allowing
-                    ::  the message to proceed.  but ames is not quite
-                    ::  ready for promiscuous crashes, so instead we
-                    ::  send a pull outward and a quit downward.
-                    ::  or not... outgoing dap (XXX) is not in the path.
-                    ::  =.  +>.$  ap-abet:(ap-pout:pap t.t.t.pax %quit ~)
-                    ::  %+  mo-pass
-                    ::    [%use pax]
-                    ::  [%g %deal [q.q.pry our] XXX %pull ~]
-                    (mo-resume-mack ~ >%mo-cook-fail< p.q.+>.q.hin)
-              ==
-            ?.  ?=({$g $unto *} q.hin)
+      $out  ?.  ?=({$g $unto *} q.hin)
               ~&  [%mo-cook-weird q.hin]
               ~&  [%mo-cook-weird-path pax]
               +>.$
-            ?:  ?=($doff +>-.q.hin)
-              %+  mo-pass
-                [%use pax]
-              [%f %exec our ~ byk.pap %vale +.p.q.hin]
             ?:  ?=($quit +>-.q.hin)
               =.  ap.pap  (mo-resume-mack:pap ~)
               ap-abet:(ap-pout:pap t.t.t.pax +>.q.hin)
@@ -563,11 +533,16 @@
   ::
   ++  mo-gawd                                           ::  ames backward
     |=  {him/@p dap/dude num/@ud ron/roon}
-    =.  mak  (mo-defer-mack hen)
     =.  hen  (mo-ball him num)
-    ?-  -.ron
-      $d  (mo-give %unto %doff p.ron q.ron)
-      $x  (mo-give %unto %quit ~)
+    ?-    -.ron
+        $d
+      =.  mak  (mo-defer-mack hen)
+      %+  mo-pass  
+        [%sys %rep (scot %p him) dap (scot %ud num) ~]
+      [%f %exec our (mo-beak dap) ~ %vale p.ron our q.ron]
+    ::
+        $x  =.  +>  (mo-give %mack ~)                  ::  XX should crash
+            (mo-give(hen (mo-ball him num)) %unto %quit ~)
     ==
   ::
   ++  mo-defer-mack                                     ::  future %mack
@@ -1122,7 +1097,6 @@
       ?-  -.cuf
         $coup  (ap-take q.q.pry %coup +.pax `!>(p.cuf))
         $diff  (ap-diff q.q.pry pax p.cuf)
-        $doff  !!
         $quit  (ap-take q.q.pry %quit +.pax ~)
         $reap  (ap-take q.q.pry %reap +.pax `!>(p.cuf))
       ==

--- a/arvo/gall.hoon
+++ b/arvo/gall.hoon
@@ -530,10 +530,8 @@
   ::
   ++  mo-gawd                                           ::  ames backward
     |=  {him/@p dap/dude num/@ud ron/roon}
-    =.  hen  (mo-ball him num)
     ?-    -.ron
         $d
-      =.  +>  (mo-give %mack ~)
       %+  mo-pass
         [%sys %rep (scot %p him) dap (scot %ud num) ~]
       [%f %exec our ~ (mo-beak dap) %vale p.ron q.ron]

--- a/arvo/gall.hoon
+++ b/arvo/gall.hoon
@@ -534,9 +534,9 @@
     ?-    -.ron
         $d
       =.  +>  (mo-give %mack ~)
-      %+  mo-pass  
+      %+  mo-pass
         [%sys %rep (scot %p him) dap (scot %ud num) ~]
-      [%f %exec our (mo-beak dap) ~ %vale p.ron our q.ron]
+      [%f %exec our ~ (mo-beak dap) %vale p.ron our q.ron]
     ::
         $x  =.  +>  (mo-give %mack ~)                  ::  XX should crash
             (mo-give(hen (mo-ball him num)) %unto %quit ~)

--- a/arvo/gall.hoon
+++ b/arvo/gall.hoon
@@ -59,7 +59,7 @@
       qel/(map bone @ud)                                ::  queue meter
   ==                                                    ::
 ++  mast                                                ::  ship state
-  $:  mak/(unit duct)                                   ::  ames awaiting crash
+  $:  mak/*                                             ::  (deprecated)
       sys/duct                                          ::  system duct
       sap/(map ship scad)                               ::  foreign contacts
       bum/(map dude seat)                               ::  running agents
@@ -463,9 +463,6 @@
               ~&  [%mo-cook-weird q.hin]
               ~&  [%mo-cook-weird-path pax]
               +>.$
-            ?:  ?=($quit +>-.q.hin)
-              =.  ap.pap  (mo-resume-mack:pap ~)
-              ap-abet:(ap-pout:pap t.t.t.pax +>.q.hin)
             ap-abet:(ap-pout:pap t.t.t.pax +>.q.hin)
     ==
   ::
@@ -536,7 +533,7 @@
     =.  hen  (mo-ball him num)
     ?-    -.ron
         $d
-      =.  mak  (mo-defer-mack hen)
+      =.  +>  (mo-give %mack ~)
       %+  mo-pass  
         [%sys %rep (scot %p him) dap (scot %ud num) ~]
       [%f %exec our (mo-beak dap) ~ %vale p.ron our q.ron]
@@ -544,18 +541,6 @@
         $x  =.  +>  (mo-give %mack ~)                  ::  XX should crash
             (mo-give(hen (mo-ball him num)) %unto %quit ~)
     ==
-  ::
-  ++  mo-defer-mack                                     ::  future %mack
-    |=  hon/duct  ^+  mak
-    ?~  mak  `hon
-    ~|(double-mak+[u.mak hon] !!)
-  ::
-  ++  mo-resume-mack                                    ::  route %mack
-    |=  a/(unit tang)  ^+  +>.$
-    ?^  mak
-      +>.$(mak ~, moz :_(moz [u.mak %give %mack a]))
-    ?~  a  +>.$
-    (mean >%gall-mack< u.a)  ::  XX unnecessary?
   ::
   ++  ap                                                ::  agent engine
     ~%  %gall-ap  +>  ~

--- a/arvo/zuse.hoon
+++ b/arvo/zuse.hoon
@@ -2951,7 +2951,6 @@
 ++  cuft                                                ::  internal gift
   $%  {$coup p/(unit tang)}                             ::  poke result
       {$diff p/cage}                                    ::  subscription output
-      {$doff p/mark q/noun}                             ::  untyped diff
       {$quit $~}                                        ::  close subscription
       {$reap p/(unit tang)}                             ::  peer result
   ==                                                    ::


### PR DESCRIPTION
Supercedes #378

In addition to adding remote %peel, this reverts %gall handling of foreign diff results to an earlier version, which incorrectly translates the data using the desk of the local app with the same name. This is caused by an arvo limitation, which necessitates ames negative ackgnolwedgments be given explicitly instead of being generated from a crash.