### PR TITLE
Add minimal noun.hoon mark to /mar

### DIFF
--- a/mar/noun.hoon
+++ b/mar/noun.hoon
@@ -1,0 +1,11 @@
+::
+::::  /hoon/noun/mar
+  ::
+/?    310
+!:
+::::  A minimal noun mark
+|_  non/*
+++  grab  |%
+          ++  noun  *
+          --
+--


### PR DESCRIPTION
Fixes an issue where trivial moves to ++poke-noun app arms across ships
wouldn't resolve, and ++coup in those apps would throw away the stack
trace.

See this Fora post:
<http://urbit.org/fora/posts/~2017.5.30..04.45.41..dbd2~/>

Edit: The ++coup thing is unrelated, @ohAitch explained to me.