### PR TITLE
adds error message to +ticket

### DIFF
--- a/gen/ticket.hoon
+++ b/gen/ticket.hoon
@@ -5,10 +5,12 @@
 /?    310
 ::
 ::::
-  !:
+  !.
 :-  %say
 |=  $:  {now/@da eny/@uvJ bec/beak}
         {{her/@p $~} $~}
     ==
 :-  %noun
+~_  leaf+"can't ticket {<her>} (not a child of {<p.bec>})"
+?>  =(p.bec (sein her))
 .^(@p /a/(scot %p p.bec)/tick/(scot %da now)/(scot %p her))


### PR DESCRIPTION
This is another frequent question on `urbit-meta` -- the current error message ("blocking not care: ~.a") is both wrong and unhelpful.