### PR TITLE
eagerly evaluate "eyre: execute" error info

### DIFF
--- a/arvo/eyre.hoon
+++ b/arvo/eyre.hoon
@@ -960,7 +960,7 @@
     |=  {tea/whir bek/beak sil/silk}
     %+  pass-note  tea
     :^  %f  %exec  our
-    `[bek [%dude |.(leaf+"eyre: execute {<tea>}") sil]]
+    `[bek [%dude [|.(+)]:[%leaf "eyre: execute {<tea>}"] sil]]
   ::
   ++  fail
     |=  {sas/@ud dep/@uvH mez/tang}


### PR DESCRIPTION
to avoid issues from lazy traps in defunct requests

(cherry picked from commit 46320bf9d9579508fa0492b88ab055979929e049)