### PR TITLE
some changes to get :twit working

### DIFF
--- a/app/twit.hoon
+++ b/app/twit.hoon
@@ -29,7 +29,7 @@
   $%  {$quit $~}                                         ::  terminate
       {$diff gilt}                                      ::  send data
   ==
-++  gilt  
+++  gilt
   $%  {$twit-feed p/(list stat)}                        ::  posts in feed
       {$twit-post p/stat}                               ::  tweet accepted
       {$ares term (list tank)}                          ::  error
@@ -97,7 +97,7 @@
   |=  {pax/path mof/(list move)}  ^+  done
   =^  tym  ran  (dely pax)
   :_  +>.$
-  ?~  tym  
+  ?~  tym
     :: ~&  no-wait/ran
     mof
   :: ~&  will-wait/u.tym
@@ -124,7 +124,7 @@
       pus=(~(gas ju *(jug path bone)) (turn ~(tap by sup) .))
   ?~  (~(get ju pus) pax)
     ~
-  ~&  peer-again+[pax ran]  
+  ~&  peer-again+[pax ran]
   (pear | `~. pax) ::(user-from-path pax))
 ::
 ++  sigh-recoverable-error                              ::  Rate-limit
@@ -195,11 +195,11 @@
   |=  {usr/(unit user:eyre) req/(unit user:eyre)}
   ?~(req & =(usr req))
 ::
-::  .^(twit-feed %gx /=twit=/~/home/urbit_test)
-::  .^(twit-stat %gx /=twit=/~./post/0vv0old.0post.hash0.0000)
-++  peek
-  |=  {ren/care:clay pax/path}  ^-  (unit (unit gilt))
-  ?>  ?=($x ren)  ::  others unsupported
+::   /+  twitter
+::  .^((list post:twitter) %gx /=twit=/home/urbit_test/twit-feed)
+::  .^(post:twitter %gx /=twit=/post/0vv0old.0post.hash0.0000/twit-feed)
+++  peek-x
+  |=  pax/path  ^-  (unit (unit gilt))
   =+  usr=`~.  ::   =^  usr  pax  (user-from-path pax)
   ?.  ?=(twit-path pax)
     ~|([%missed-path pax] !!)
@@ -213,7 +213,7 @@
 ++  peer-scry-x
   |=  pax/path  ^+  done
   :_  +>
-  =+  pek=(peek %x pax)
+  =+  pek=(peek-x pax)
   ?^  pek
     ?~  u.pek  ~|(bad-scry+x+pax !!)
     ~[[ost %diff u.u.pek] [ost %quit ~]]
@@ -223,7 +223,7 @@
   =+  hiz=(pear-hiss pax)
   ?~  hiz  ~                          :: already in flight
   ::?>  (compat usr -.u.hiz)                  ::  XX better auth
-  [ost %hiss scry+pax usr +.u.hiz]~  
+  [ost %hiss scry+pax usr +.u.hiz]~
 ::
 ++  peer  |=(pax/path :_(+> (pear & `~. pax)))       ::  accept subscription
 ++  pear                              ::  poll, possibly returning current data

--- a/gen/twit/as.hoon
+++ b/gen/twit/as.hoon
@@ -11,4 +11,4 @@
 |=  $:  {now/@da eny/@uvJ bec/beak}
         {{who/knot msg/cord $~} $~}
     ==
-[%twit-do [who %post eny msg]]
+[%twit-do [who %post `@uvI`(rsh 8 1 eny) msg]]

--- a/gen/twit/feed.hoon
+++ b/gen/twit/feed.hoon
@@ -13,7 +13,7 @@
 |=  $:  {now/@da eny/@uvJ bek/beak}
         {{who/iden $~} typ/?($user $home)}
     ==
-=+  pax=/(scot %p p.bek)/twit/(scot %da now)/[typ]/[who]
+=+  pax=/(scot %p p.bek)/twit/(scot %da now)/[typ]/[who]/twit-feed
 :-  %tang
 %+  turn   (flop .^((list post:twitter) %gx pax))
 |=  post:twitter  ^-  tank

--- a/lib/oauth1.hoon
+++ b/lib/oauth1.hoon
@@ -55,7 +55,7 @@
   |=  {a/purl b/quay}  ^-  hiss
   =.  b  (quay:hep-to-cab b)
   =-  [a %post - ?~(b ~ (some (as-octt +:(tail:en-purl:html b))))]
-  (my content-type+['application/x-www-form-en-urlt:htmlncoded']~ ~)
+  (my content-type+['application/x-www-form-urlencoded']~ ~)
 ::
 ::
 ++  mean-wall  !.

--- a/lib/twitter.hoon
+++ b/lib/twitter.hoon
@@ -20,7 +20,7 @@
   |=  {a/char b/(list @t)}  ^-  @t
   %+  rap  3
   ?~  b  ~
-  |-(?~(t.b b [i.b a $(b t.b)])) 
+  |-(?~(t.b b [i.b a $(b t.b)]))
 ::
 ++  valve                                               ::  produce request
   |=  {med/?($get $post) pax/path quy/quay}
@@ -87,9 +87,10 @@
     :~  id+ni
         user+(ot (fasp screen-name+(su user)) ~)
         (fasp created-at+(cu year (ci stud so)))
-        text+(cu crip (su (star escp:de-xml)))  :: parse html escapes
+        :: parse html escapes and newlines
+        text+(cu crip (su (star ;~(pose (just `@`10) escp:de-xml))))
     ==
-  ++  usel 
+  ++  usel
     =,  ^?(dejs)
     %+  ce  (list who/@ta)
     =-  (ot users+(ar -) ~)
@@ -119,12 +120,12 @@
     (valve med (cowl pax +.a b))
   ::
   ++  lutt  |=(@u `@t`(rsh 3 2 (scot %ui +<)))
-  ++  llsc 
+  ++  llsc
     :: =>  args:reqs
     |=  a/$@(scr (list scr))  ^-  @t
     ?@(a `@t`a (join ',' a))
   ::
-  ++  llst  
+  ++  llst
     |=  a/$@(@t (list @t))  ^-  @t
     ?@(a `@t`a (join ',' a))
   ::
@@ -135,7 +136,7 @@
     ?@(a (lutt a) (join ',' (turn `(list tid)`a lutt)))
   ::
   ++  cowl                                        ::  handle parameters
-    |=  $:  pax/path 
+    |=  $:  pax/path
             ban/(list param)
             quy/quay
         ==


### PR DESCRIPTION
I finally got around to trying out `:twit`. The `++peek` interface was out-of-date*, as were the `|as` and `|feed` generators.

\* The `care` is now passed as part of the path, and the last path segment is ignored (presumed to be a mark?).

I had another problem trying to post: the negotiated access token was read-only and couldn't be upgraded. I created a new read-write access token, but can figure out how to get %eyre to stop using the old one. Is there currently a way to manually configure (or force a request for) a new token?

I also deleted the github driver config. 