### PR TITLE
Allow capitals in web.plan usernames.

### DIFF
--- a/mar/plan.hoon
+++ b/mar/plan.hoon
@@ -40,7 +40,8 @@
                 (malt (turn t.t.a |=(b/cord (rash b account))))
             ::
             ++  user  ;~(pfix (jest 'User ') (cook crip (star prn)))
-            ++  knot  (sear (flit |=(a/^knot !=('' a))) urs:ab)
+            ++  knot  %+  cook  crip
+                      (plus ;~(pose nud low hig hep dot sig cab))
             ++  location  ;~(pfix (jest 'Location ') (cook crip (star prn)))
             ++  account
               ;~  plug


### PR DESCRIPTION
So you can display your username in its canonical capitalization. Also, you can now put crypto addresses in there!

The new `++knot` parser is essentially a simplified `++urs:ab` with `hig` added in.

Is this all it takes? `'UserName'` fits in `@ta` and `@tx` just fine, nothing seems to be complaining, and this renders just fine.

(I'm having trouble doing rigorous testing of `mar/plan` from dojo, but since the changed path also gets covered by loading the profile page, I'm not too worried.)