### PR TITLE
Fixed rendered of %app and %lin speeches in %fat.

### DIFF
--- a/web/talk/main.js
+++ b/web/talk/main.js
@@ -778,7 +778,10 @@ module.exports = recl({
           case speech.url == null:
             return speechArr = speech.url.txt.split(/(\s|-)/);
           case speech.fat == null:
-            return speech.fat.taf.exp.txt.split(/(\s|-)/);
+            if (typeof speech.fat.taf.exp !== 'undefined') { return speech.fat.taf.exp.txt.split(/(\s|-)/); }
+            if (typeof speech.fat.taf.app !== 'undefined') { return speech.fat.taf.app.txt; }
+            if (typeof speech.fat.taf.lin !== 'undefined') { return speech.fat.taf.lin.txt; }
+            return "unsupported fat speech";
           default:
             return [];
         }


### PR DESCRIPTION
It does seem to be the case that %fat messages aren't printed neatly. They overlap with the text below them, like fora post contents used to do.

At least webtalk loads again. (Though a lack of "how do I render this message" shouldn't cause the entire web app to not function. Oh well, it'll get better Soon™.)