### PR TITLE
Added 'Accept: application/json' hiss header to lib/oauth2

### DIFF
--- a/lib/oauth2.hoon
+++ b/lib/oauth2.hoon
@@ -19,7 +19,14 @@
   |=  {a/purl b/quay}  ^-  hiss
   =.  b  (quay:hep-to-cab b)
   =-  [a %post - ?~(b ~ (some (as-octt +:(tail:earn b))))]
-  (my content-type+['application/x-www-form-urlencoded']~ ~)
+  %^  my
+    :+  %accept
+      'application/json'
+    ~
+    :+  %content-type
+      'application/x-www-form-urlencoded'
+    ~
+    ~
 ::
 ++  mean-wall  !.
   |=  {a/term b/tape}  ^+  !!


### PR DESCRIPTION
## Summary
This adds an `Accept: application/json` header to hisses sent from lib/oauth2 and is a solution to urbit/arvo#442. 

## Rationale
The OAuth2 library, as it is currently implemented, requires a JSON response from a service to parse the access token correctly. For this reason, I have added the `Accept: application/json` header to the `++post-quay` arm, as this arm is already used for adding the `Content-Type` header. Without this `Accept` header, some OAuth2 APIs respond with non-JSON formats by default, which the current lib/oauth2 is not prepared to handle, therefore resulting in a `%bad-json` error (see urbit/arvo#442 for more details). 

## Note
1. I've combined *running* and *3-fixed* [forms](http://urbit.org/docs/hoon/syntax/). Is this considered undesirable, in which case I should stick with either/or?
2. HTTP header field names are case insensitive; you'll see that the actual header is `accept` with a lowercase 'a'.