### PR TITLE
Expanded on existing Github marks

### DIFF
--- a/lib/gh-parse.hoon
+++ b/lib/gh-parse.hoon
@@ -79,6 +79,19 @@
       'watchers'^ni
       'default_branch'^so
   ==
+++  commit
+  ^-  $-(json (unit commit:gh))
+  =+  jo
+  %-  ot  :~
+      'sha'^so
+      'url'^so
+      'author'^author
+      'committer'^author
+      'message'^so
+      'tree'^point
+      'parents'^(ar point)
+      'verification'^verification
+  ==
 ++  user
   ^-  $-(json (unit user:gh))
   =+  jo
@@ -127,6 +140,30 @@
       'updated_at'^so
       'closed_at'^(mu so)
       'body'^so
+  ==
+++  author
+  ^-  $-(json (unit author:gh))
+  =+  jo
+  %-  ot  :~
+      'date'^so
+      'name'^so
+      'email'^so
+  ==
+++  point
+  ^-  $-(json (unit point:gh))
+  =+  jo
+  %-  ot  :~
+      'url'^so
+      'sha'^so
+  ==
+++  verification
+  ^-  $-(json (unit verification:gh))
+  =+  jo
+  %-  ot  :~
+      'verified'^bo
+      'reason'^so
+      'signature'^(mu so)
+      'payload'^(mu so)
   ==
 ++  label
   ^-  $-(json (unit label:gh))

--- a/mar/gh/commit.hoon
+++ b/mar/gh/commit.hoon
@@ -1,0 +1,11 @@
+/-  gh
+/+  gh-parse, httr-to-json, old-zuse
+=,  old-zuse
+|_  commit/commit:gh
+++  grab
+  |%
+  ++  noun  commit:gh
+  ++  httr  (cork httr-to-json json)
+  ++  json  commit:gh-parse
+  --
+--

--- a/mar/gh/issue.hoon
+++ b/mar/gh/issue.hoon
@@ -1,11 +1,13 @@
 /-  gh
-/+  gh-parse, old-zuse
+/+  gh-parse, httr-to-json, old-zuse
 =,  mimes:html
 =,  old-zuse
 |_  issue/issue:gh
 ++  grab
   |%
   ++  noun  issue:gh
+  ++  httr  (cork httr-to-json json)
+  ++  json  issue:gh-parse
   --
 ++  grow
   |%

--- a/mar/gh/repository.hoon
+++ b/mar/gh/repository.hoon
@@ -1,0 +1,11 @@
+/-  gh
+/+  gh-parse, httr-to-json, old-zuse
+=,  old-zuse
+|_  repo/repository:gh
+++  grab
+  |%
+  ++  noun  repository:gh
+  ++  httr  (cork httr-to-json json)
+  ++  json  repository:gh-parse
+  --
+--

--- a/sur/gh.hoon
+++ b/sur/gh.hoon
@@ -77,6 +77,16 @@
       watchers/@ud
       default-branch/@t
   ==
+++  commit
+  $:  sha/@t
+      url/@t
+      author/author
+      committer/author
+      message/@t
+      tree/point
+      parents/(list point)
+      verification/verification
+  ==
 ++  user
   $:  login/@t
       id/id
@@ -117,6 +127,21 @@
       updated-at/time
       closed-at/(unit time)
       body/@t
+  ==
+++  author
+  $:  date/@t
+      name/@t
+      email/@t
+  ==
+++  point
+  $:  url/@t
+      sha/@t
+  ==
+++  verification
+  $:  verified/?
+      reason/@t
+      signature/(unit @t)
+      payload/(unit @t)
   ==
 ++  label
   $:  url/@t


### PR DESCRIPTION
Can now take in commit and repository data.  
Issue data can now be extracted directly from a `httr`.