### PR TITLE
Remove registered subscription from gall when sending %quit.

### DIFF
--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -801,7 +801,7 @@
     ++  ap-move-quit                                    ::  give quit move
       |=  {sto/bone vax/vase}
       ^-  {(each cove tang) _+>}
-      :_  +>
+      :_  +>(sup.ged (~(del by sup.ged) sto))
       ?^  q.vax  [%| (ap-suck "quit: improper give")]
       [%& `cove`[sto %give `cuft`[%quit ~]]]
     ::


### PR DESCRIPTION
Apparently gall wasn't actually removing subscriptions from `sup.ged` (and this `sup.bowl`) after killing them with `%quit`.

To reproduce that:
1. Load [this paste](https://pastebin.com/eS7xfNMi) into a fakezod and a star (say, ~palzod), `|start %test`,
2. On ~palzod, `:test [%sub ~zod]`,
3. On ~zod, `:test [%update ~palzod]`, ~palzod should say `%got-diff`,
4. On ~zod, `:test [%quit ~palzod]`, ~palzod should say `%quit-by`,
5. On ~zod, `:test [%update ~palzod]` again, it should still say `%got-diff`.

All this change does is remove the affected subscription from `sup.ged` in gall's state whenever a `%quit` move gets sent.
I don't think anything has to change on the receiving end, since `++quit` gets called properly, and outgoing subscriptions aren't tracked yet. (Considering how simple a fix this was, filling `neb.ged` might not be too difficult either, but that'll have to wait a bit longer.)