### PR TITLE
[hotfix] Reload message counts that got out of sync

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -122,6 +122,10 @@
   ?~  old
     %-  pre-bake
     ta-done:ta-init:ta
+  =.  stories.u.old
+    %-  ~(run by stories.u.old)
+    |=  s/story
+    s(count (lent grams.s))
   [~ ..prep(+<+ u.old)]
 ::
 ::>  ||


### PR DESCRIPTION
As it turns out, the `count` of some stories got out of sync with their `(lent grams)`. Because `count` is relied on for message fetching in a number of different ways, this resulted in unexpected behavior in a number of place, including webtalk loading only a partial backlog, and ;join-ing urbit-meta giving you a similar scrollback.

Notice that this is just a small addition to `++prep` that resets `count` to `(lent grams)`, and doesn't actually address the cause of `count` getting out of sync.  
This is because I genuinely have no idea how it could end up in an incorrect state. There is [only one place](https://github.com/urbit/arvo/blob/master/app/hall.hoon#L1585-L1590) where new messages get appended to `grams`, and it obediently increments `count`. I also haven't been able to reproduce this on newly booted comets at all.
I'm guessing/hoping this is just residual weirdness left over from the talk shenanigans earlier today. Even there I wouldn't be able to point to a cause though.

If this issue pops up again in the future, I'll need to take the deep dive. For now, this fix will restore expected functionality to those affected.

We may or may not want to revert this after it has been pushed to the network, for cleanliness.