### PR TITLE
Fix backlog loading/eyre dig over issue with webtalk

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1926,7 +1926,8 @@
     ?~  soy  ~
     :+  ~  ~
     :-  %circle
-    :+  %+  turn
+    :+  ?.  (~(has in wat.qer) %grams)  ~
+        %+  turn
           =-  (~(so-first-grams so:ta nom.qer ~ -) ran.qer)
           ::TODO  this can be done more efficiently.
           ?~  wer.qer  u.soy

--- a/web/talk/main.js
+++ b/web/talk/main.js
@@ -31,7 +31,7 @@ Persistence = _persistence({
     listenStation: function(station, date) {
       var now;
       if (!date) {
-        date = (now = new Date(), now.setSeconds(0), now.setMilliseconds(0), new Date(now - 24 * 3600 * 1000));
+        date = (now = new Date(), now.setSeconds(0), now.setMilliseconds(0), new Date(now - 6 * 3600 * 1000));
       }
       Dispatcher.handleViewAction({
         type: "messages-fetch"
@@ -1561,10 +1561,7 @@ module.exports = function(arg) {
     listenStation: function(station, since) {
       var $this, begin, path;
       $this = this;
-      begin = since;
-      if (typeof since === "object") {
-        begin = window.urb.util.toDate(since);
-      }
+      begin = window.urb.util.toDate(since);
       path = util.talkPath('circle', station, 'grams', begin);
       return window.urb.bind(path, function(err, res) {
         var ref, ref1, ref2, ref3;
@@ -1579,7 +1576,7 @@ module.exports = function(arg) {
           MessageActions.listeningStation(station);
         }
         if ((ref = res.data) != null ? (ref1 = ref.circle) != null ? ref1.nes : void 0 : void 0) {
-          if ((res.data.circle.nes.length === 0) && (typeof since === "object")) {
+          if (res.data.circle.nes.length === 0) {
             console.log('trying for older than ' + begin);
             $this.listenStation(station, new Date(since - 6 * 3600 * 1000));
           } else {


### PR DESCRIPTION
Apparently converting a large json list of objects into  json string makes eyre unhappy.

This contains two fixes:
1. Makes sure that grams aren't sent for subscriptions that don't explicitly request them. This oversight was causing webtalk's `/config-l/group-l/0` request to also include all messages starting at #0.
2. Changes to webtalk that make it do slightly more modest requests. See urbit/talk#38.