### PR TITLE
Fix erroneous presence handling

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1562,6 +1562,8 @@
           $status
         %_  +>
             locals
+          ?:  ?=($remove -.dif.det)
+            (~(del by locals) who.det)
           %+  ~(put by locals)  who.det
           %+  change-status
             (fall (~(get by locals) who.det) *status)

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -797,26 +797,51 @@
       ::    ==
       ^+  +>
       ?-  -.rum
-        $new      ?:  =(src so-cir)
-                    (so-config-full ~ cof.rum)
-                  $(rum [%config src %full cof.rum])
         $bear     (so-bear bur.rum)
         $peer     (so-delta-our rum)
         $gram     (so-open src nev.rum)
-        $config   ::  full changes to us need to get split up.
-                  ?:  &(=(cir.rum so-cir) ?=($full -.dif.rum))
-                    (so-config-full `shape cof.dif.rum)
-                  ::  we only subscribe to remotes' configs.
-                  ?:  =(src cir.rum)
-                    (so-delta-our rum)
-                  ~!  %unexpected-remote-config-from-remote
-                  !!
-        $status   ::  we only subscribe to remotes' locals.
-                  ?:  |(=(src cir.rum) =(src so-cir))
-                    (so-delta-our rum)
-                  ~!  %unexpected-remote-status-from-remote
-                  !!
         $remove   (so-delta-our %config src %remove ~)
+      ::
+          $new
+        ?:  =(src so-cir)
+          (so-config-full ~ cof.rum)
+        $(rum [%config src %full cof.rum])
+      ::
+          $config
+        ::  we only subscribe to remotes' configs.
+        ?.  =(src cir.rum)
+          ~!  %unexpected-remote-config-from-remote
+          !!
+        =/  old/(unit config)
+          ?:  =(cir.rum so-cir)  `shape
+          (~(get by mirrors) cir.rum)
+        ::  ignore if it won't result in change.
+        ?.  ?|  &(?=($remove -.dif.rum) ?=(^ old))
+                ?=($~ old)
+                !=(u.old (change-config u.old dif.rum))
+            ==
+          +>.$
+        ::  full changes to us need to get split up.
+        ?:  &(=(cir.rum so-cir) ?=($full -.dif.rum))
+          (so-config-full `shape cof.dif.rum)
+        (so-delta-our rum)
+      ::
+          $status
+        ::  we only subscribe to remotes' locals.
+        ?.  |(=(src cir.rum) =(src so-cir))
+          ~!  %unexpected-remote-status-from-remote
+          !!
+        =/  old/(unit status)
+          ?:  =(cir.rum so-cir)  (~(get by locals) who.rum)
+          =-  (~(get by -) who.rum)
+          (fall (~(get by remotes) cir.rum) *group)
+        ::  ignore if it won't result in change.
+        ?.  ?|  &(?=($remove -.dif.rum) ?=(^ old))
+                ?=($~ old)
+                !=(u.old (change-status u.old dif.rum))
+            ==
+          +>.$
+        (so-delta-our rum)
       ==
     ::
     ++  so-bear                                         ::<  accept burden

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -260,15 +260,14 @@
     ::
     |=  {who/ship nos/(set naem) dif/diff-status}
     ^+  +>
-    %-  ta-deltas
-    %+  murn  ~(tap in nos)
-    |=  n/naem
-    ^-  (unit delta)
-    ?.  (~(has by stories) n)  ~
-    ::  only have presence if you have write permission.
-    ?.  (~(so-admire so n ~ (~(got by stories) n)) who)
-      ~
-    `[%story n %status [our.bol n] who dif]
+    =+  nol=~(tap in nos)
+    |-
+    ?~  nol  +>.^$
+    =.  +>.^$
+      ?.  (~(has by stories) i.nol)  +>.^$
+      =+  soy=(~(got by stories) i.nol)
+      so-done:(~(so-present so i.nol ~ soy) who dif)
+    $(nol t.nol)
   ::
   ++  ta-action                                         ::<  apply client action
     ::>  performs action sent by a client.
@@ -915,6 +914,21 @@
     ::>  ||
     ::>    arms that make miscellaneous changes to this story.
     ::+|
+    ::
+    ++  so-present                                      ::<  accept status diff
+      |=  {who/ship dif/diff-status}
+      ^+  +>
+      ::  only have presence if you have write permission.
+      ?.  |((so-admire who) ?=($remove -.dif))  +>
+      ::  ignore if it won't result in change.
+      ?.  ?:  ?=($remove -.dif)  (~(has by locals) who)
+          ?|  !(~(has by locals) who)
+            ::
+              =+  (~(got by locals) who)
+              !=(- (change-status - dif))
+          ==
+        +>
+      (so-delta-our %status so-cir who dif)
     ::
     ++  so-config-full                                  ::<  split full config
       ::>  split a %full config delta up into multiple


### PR DESCRIPTION
Currently, hall doesn't check to make sure that diffs it gets via a %present command, or a %status or %config rumor have any effect. This can lead to diffs being spread around to subscribers when nothing has actually changed.

This implements checks for catching those scenarios, and ignores the diff when they occur. 