### PR TITLE
Rebuild msg number references, fix msg updating, provide debug tools

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1636,8 +1636,8 @@
       ::  changed message
       %_  +>.$
         grams    %+  welp
-                 (scag (dec (max u.old 1)) grams)
-                 [gam (slag u.old grams)]
+                 (scag u.old grams)
+                 [gam (slag +(u.old) grams)]
       ==
     ::
     ++  sa-change-remote                                ::<  apply remote's delta

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -2554,4 +2554,43 @@
       our.bol
       (foal:space:userlib paf [%hall-telegrams !>(-)])
   ==
+::
+::TODO  for debug purposes. remove eventually.
+++  poke-noun
+  |=  a/@t
+  ^-  (quip move _+>)
+  ?:  =(a 'debug')
+    =-  ~&(- [~ +>.$])
+    %-  ~(urn by stories)
+    |=  {n/naem s/story}
+    =+  %-  ~(rep by known.s)
+      |=  {{u/serial a/@ud} k/@ud m/@ud}
+      :-  ?:((gth a k) a k)
+      ?:  =(u uid:(snag a grams.s))  m
+      ~?  (lth m 3)
+        :*  [%fake a u]
+            [%prev uid:(snag (dec a) grams.s)]
+            [%real uid:(snag a grams.s)]
+            [%next uid:(snag +(a) grams.s)]
+        ==
+      +(m)
+    :^  count=count.s
+        lent=(lent grams.s)
+      known=k
+    mismatch=m
+  ?:  =(a 'rebuild')
+    =-  [~ +>.$(stories -)]
+    %-  ~(urn by stories)
+    |=  {nom/naem soy/story}
+    =+  %+  roll  grams.soy
+      |=  {t/telegram c/@ud k/(map serial @ud) s/(map circle (list @ud))}
+      :+  +(c)  (~(put by k) uid.t c)
+      =/  src/circle
+        ?:  (~(has by aud.t) [our.bol nom])  [our.bol nom]
+        ?~  aud.t  ~&(%strange-aud [our.bol %inbox])
+        n.aud.t
+      %+  ~(put by s)  src
+      [c (fall (~(get by s) src) ~)]
+    soy(count c, known k, sourced s)
+  [~ +>]
 --

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -123,9 +123,18 @@
     %-  pre-bake
     ta-done:ta-init:ta
   =.  stories.u.old
-    %-  ~(run by stories.u.old)
-    |=  s/story
-    s(count (lent grams.s))
+    %-  ~(urn by stories.u.old)
+    |=  {nom/naem soy/story}
+    =+  %+  roll  grams.soy
+      |=  {t/telegram c/@ud k/(map serial @ud) s/(map circle (list @ud))}
+      :+  +(c)  (~(put by k) uid.t c)
+      =/  src/circle
+        ?:  (~(has by aud.t) [our.bol nom])  [our.bol nom]
+        ?~  aud.t  ~&(%strange-aud [our.bol %inbox])
+        n.aud.t
+      %+  ~(put by s)  src
+      [c (fall (~(get by s) src) ~)]
+    soy(count c, known k, sourced s)
   [~ ..prep(+<+ u.old)]
 ::
 ::>  ||

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1977,7 +1977,7 @@
             ?.  (~(has by sourced.u.soy) u.wer.qer)  ~
             %+  turn  (~(got by sourced.u.soy) u.wer.qer)
             |=  n/@ud
-            (snag (sub count.u.soy +(n)) grams.u.soy)
+            (snag n grams.u.soy)
           ==
         (cury gram-to-envelope nom.qer)
       :-  shape.u.soy

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -118,6 +118,12 @@
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
+  =*  o  u.old
+  =.  count.o  (lent grams.o)
+  =+  %+  reel  grams.o
+    |=  {t/telegram c/@ud k/(map serial @ud)}
+    [+(c) (~(put by k) uid.t c)]
+  =.  known.o  k
   [~ ..prep(+<+ u.old)]
 ::
 ::>  ||

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -2199,6 +2199,27 @@
   |=  act/sole-action
   ta-done:(ta-sole:ta act)
 ::
+::TODO  for debug purposes. remove eventually.
+++  poke-noun
+  |=  a/@t
+  ^-  (quip move _+>)
+  ?:  =(a 'debug')
+    =-  ~&(- [~ +>.$])
+    =+  %-  ~(rep by known)
+      |=  {{u/serial a/@ud} k/@ud m/@ud}
+      :-  ?:((gth a k) a k)
+      ?:  =(u uid:(snag (sub count +(a)) grams))  m  +(m)
+    :^  %check-talk
+        count=count
+      lent=(lent grams)
+    [known=k mismatch=m]
+  ?:  =(a 'rebuild')
+    =+  %+  reel  grams
+      |=  {t/telegram c/@ud k/(map serial @ud)}
+      [+(c) (~(put by k) uid.t c)]
+    [~ +>.$(count c, known k)]
+  [~ +>]
+::
 ++  coup-client-action                                                ::<  accept n/ack
   ::>
   ::


### PR DESCRIPTION
In my haste to get #471 out the door, I completely overlooked the fact that other parts of state are set using `count`. This means that, for however long halls were running with incorrect `count`s, they accumulated incorrect references to messages. This (0e04242) performs a slightly more involved version of what #471 did, rebuilding `known` and `sourced` as well.  
(Note that `sourced` sadly can't be recreated with 100% certainty, but the approximation we do instead should be accurate for all but some rare edge cases. This is not a big deal, because nothing currently depends on it.)

Additionally, logic for updating existing messages was replacing the wrong message due to an off-by-one error. This includes a fix for that.

I've also included a `++poke-noun` arm in both hall and talk. Doing `:hall 'debug'` prints some sanity-check information which will help me identify if an issue relates to message numbering. `:hall 'rebuild'` will perform the same state rebuilding I added to `++prep`, so that users can easily trigger it as a potential band-aid solution in case of trouble.  
Hopefully this won't be necessary anymore, but I'd like to have this available for now just in case.

Should resolve #477 for people who are or have experienced it.