### PR TITLE
Hall & talk QoL fixes

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -8,10 +8,6 @@
 ::      lists of moons (or just ships in general?) that we define as "standalone"
 ::      so that the "convert to true identity" doesn't happen for them.
 ::
-::TODO  uncouple presence from subscription state. have hall send an initial
-::      presence when we sub to someplace, and remove that when we unsub, but
-::      don't make the target source do that.
-::
 /-    hall                                              ::  structures
 /+    hall, hall-legacy                                 ::  libraries
 /=    seed  /~  !>(.)

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1218,9 +1218,12 @@
       ::
       |=  sep/speech
       ^-  speech
-      ?.  ?=($lin -.sep)  sep
-      %_  sep
-          msg
+      ?+  -.sep  sep
+          ?($ire $fat $app)
+        sep(sep $(sep sep.sep))
+      ::
+          $lin
+        =-  sep(msg -)
         %-  crip
         %-  tufa
         %+  turn  (tuba (trip msg.sep))

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1632,7 +1632,10 @@
       ^+  +>
       ?:  (~(has in settings.she) %quiet)  +>
       ?:  ?=($full -.dif)
-        (sh-note (weld "new " (~(cr-show cr cir) ~)))
+        =.  +>
+          (sh-note (weld "new " (~(cr-show cr cir) ~)))
+        =.  +>  $(dif [%caption cap.cof.dif])
+        $(dif [%filter fit.cof.dif])
       ?:  ?=($remove -.dif)
         (sh-note (weld "rip " (~(cr-show cr cir) ~)))
       %-  sh-note
@@ -1644,7 +1647,7 @@
         ~(cr-full cr cir.src.dif)
       ::
           $caption
-        "cap {(trip cap.dif)}"
+        "cap: {(trip cap.dif)}"
       ::
           $filter
         ;:  weld

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -341,7 +341,12 @@
         =<  sh-done
         %-  ~(sh-show-config sh cli)
         [cir.rum cur dif.rum]
-      =?  +>.$  &(?=($source -.dif.rum) add.dif.rum)
+      =?  +>.$
+          ?&  ?=($source -.dif.rum)
+              add.dif.rum
+              =(cir.rum incir)
+              ?=($~ ran.src.dif.rum)
+          ==
         =*  cir  cir.src.dif.rum
         =+  ren=~(cr-phat cr cir)
         =+  gyf=(~(get by bound) [cir ~ ~])

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1542,7 +1542,9 @@
       ::
       |=  txt/tape
       ^+  +>
-      (sh-fact %txt (runt [14 '-'] `tape`['|' ' ' (scag 64 txt)]))
+      %+  sh-fact  %txt
+      %+  runt  [14 '-']
+      `tape`['|' ' ' (scag (sub width.she 16) txt)]
     ::
     ++  sh-prod                                         ::<  show prompt
       ::>  makes and stores a move to modify the cli


### PR DESCRIPTION
Couple tiny things.

- Properly sanitize "nested" messages, like replies and messages with attachments.
- Print circle description and message sanitizing rules on-join.
- Don't send presence when a non-default subscription occurs (as a result of `;source`).
- Slightly more adaptive rendering for informational messages, like presence notifications.