### PR TITLE
Revert hall's ++prep back to normal.

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -129,19 +129,6 @@
   ?~  old
     %-  pre-bake
     ta-done:ta-init:ta
-  =.  stories.u.old
-    %-  ~(urn by stories.u.old)
-    |=  {nom/naem soy/story}
-    =+  %+  roll  grams.soy
-      |=  {t/telegram c/@ud k/(map serial @ud) s/(map circle (list @ud))}
-      :+  +(c)  (~(put by k) uid.t c)
-      =/  src/circle
-        ?:  (~(has by aud.t) [our.bol nom])  [our.bol nom]
-        ?~  aud.t  ~&(%strange-aud [our.bol %inbox])
-        n.aud.t
-      %+  ~(put by s)  src
-      [c (fall (~(get by s) src) ~)]
-    soy(count c, known k, sourced s)
   [~ ..prep(+<+ u.old)]
 ::
 :>  #  %engines


### PR DESCRIPTION
Hall's `++prep` no longer performs any cleaning whatsoever.

Now that #481 has gone onto the network, everyone's halls should be in a sane state again. Bringing `++prep` back to baseline prevents `sourced` data from being overwritten with potentially incorrect guesses if hall gets modified in the future. The debug tools introduced in #481 still allow the user to run the from `++prep` removed code if necessary.