### PR TITLE
Remove old hall susbcriptions in talk's ++prep

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -63,6 +63,7 @@
       $%  {$diff lime}                                  ::
           {$poke wire dock pear}                        ::
           {$peer wire dock path}                        ::
+          {$pull wire dock $~}                          ::
       ==                                                ::
     ++  work                                            ::>  interface action
       $%  ::  circle management                         ::
@@ -118,7 +119,8 @@
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
-  [~ ..prep(+<+ u.old)]
+  :_  ..prep(+<+ u.old)
+  [[ost.bol %pull / server ~] ~]
 ::
 ::>  ||
 ::>  ||  %utility

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -118,12 +118,6 @@
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
-  =*  o  u.old
-  =.  count.o  (lent grams.o)
-  =+  %+  reel  grams.o
-    |=  {t/telegram c/@ud k/(map serial @ud)}
-    [+(c) (~(put by k) uid.t c)]
-  =.  known.o  k
   [~ ..prep(+<+ u.old)]
 ::
 ::>  ||


### PR DESCRIPTION
This really should've been included in #487. It's not as necessary here, but still good to get it back to baseline.