### PR TITLE
Customizable filter for incoming hall messages

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -11,6 +11,11 @@
 /-    hall                                              ::  structures
 /+    hall, hall-legacy                                 ::  libraries
 /=    seed  /~  !>(.)
+/=    filter-gram
+      /^  $-(telegram:hall telegram:hall)
+      /|  /:  /%/filter  /!noun/
+          /~  |=(t/telegram:hall t)
+      ==
 ::
 ::::
   ::
@@ -1292,6 +1297,7 @@
       ?.  (so-admire aut.gam)  +>
       ::  clean up the message to conform to our rules.
       =.  sep.gam  (so-sane sep.gam)
+      =.  gam  (filter-gram gam)
       ::  if we already have it, ignore.
       =+  old=(~(get by known) uid.gam)
       ?.  &(?=(^ old) =(gam (snag u.old grams)))

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -12,9 +12,9 @@
 /+    hall, hall-legacy                                 ::  libraries
 /=    seed  /~  !>(.)
 /=    filter-gram
-      /^  $-(telegram:hall telegram:hall)
+      /^  $-({telegram:hall bowl:gall} telegram:hall)
       /|  /:  /%/filter  /!noun/
-          /~  |=(t/telegram:hall t)
+          /~  |=({t/telegram:hall bowl:gall} t)
       ==
 ::
 ::::
@@ -1297,7 +1297,7 @@
       ?.  (so-admire aut.gam)  +>
       ::  clean up the message to conform to our rules.
       =.  sep.gam  (so-sane sep.gam)
-      =.  gam  (filter-gram gam)
+      =.  gam  (filter-gram gam bol)
       ::  if we already have it, ignore.
       =+  old=(~(get by known) uid.gam)
       ?.  &(?=(^ old) =(gam (snag u.old grams)))


### PR DESCRIPTION
Creating `/app/hall/filter.hoon` allows you to modify messages before storing & resending them.

Intended to be used by stream for audience fixing. If we don't want to manually define the web ship's name in there, we may want to modify this to accept additional arguments. Maybe just the entire `bowl`. If that's desired, let me know and I'll put that in before getting this merged.