### PR TITLE
Hall & talk: subs & sources

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -2619,12 +2619,7 @@
   ::
   |=  wir/wire
   ^-  (quip move _+>)
-  :_  +>
-  ?.  =(src.bol our.bol)
-    ~&  [%kicked-by src.bol wir]
-    ~
-  ~&  [%self-quit--resubbing wir]
-  [(wire-to-peer wir) ~]
+  [[(wire-to-peer wir) ~] +>]
 ::
 ++  quit-circle
   :>    dropped circle sub
@@ -2636,9 +2631,6 @@
   %+  etch-circle  [%circle wir]
   |=  {nom/naem src/source}
   %-  pre-bake
-  ::  when we got kicked, don't resub, remove source.
-  ?.  =(src.bol our.bol)
-    ta-done:(ta-action:ta %source nom | [src ~ ~])
   ta-done:(ta-resub:ta nom src)
 ::
 ++  coup-repeat

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -2624,18 +2624,18 @@
   ::
   |=  {wir/wire fal/(unit tang)}
   ^-  (quip move _+>)
-  ?.  ?=($circle -.wir)
-    ?~  fal  [~ +>]
-    ~|  reap-fail+wir
-    (mean u.fal)
-  %+  etch-circle  wir
-  |=  {nom/naem src/source}
-  ?~  fal
-    %-  pre-bake
-    ta-done:(ta-greet:ta nom src)
   %-  pre-bake
+  %+  welp
+    ?.  ?=({$circle *} wir)  ~
+    =+  wer=(etch wir)
+    ?>  ?=($circle -.wer)
+    =<  ta-done
+    %.  [nom.wer src.wer]
+    ?~  fal  ta-greet:ta
+    ta-leave:ta
+  ?~  fal  ~
   =<  ta-done
-  =-  (ta-grieve:(ta-leave:ta nom src) - u.fal)
+  =-  (ta-grieve:ta - u.fal)
   =+  (wire-to-target wir)
   %+  weld  "failed (re)subscribe to {(scow %p p)} on "
   %+  roll  q

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -174,13 +174,27 @@
     |=  des/(list delta)
     %_(+> deltas (welp (flop des) deltas))
   ::
-  ++  ta-note
-    :>  sends {msg} as an %app message to the user's inbox.
+  ++  ta-speak
+    :>  sends {sep} as an %app message to the user's inbox.
     ::
-    |=  msg/tape
+    |=  sep/speech
     %+  ta-action  %phrase
     :-  [[our.bol %inbox] ~ ~]
-    [%app dap.bol %lin | (crip msg)]~
+    [%app dap.bol sep]~
+  ::
+  ++  ta-grieve
+    :>  sends a stack trace to the user's inbox.
+    ::
+    |=  {msg/tape fal/tang}
+    %^  ta-speak  %fat
+      [%name 'stack trace' %tank fal]
+    [%lin | (crip msg)]
+  ::
+  ++  ta-note
+    :>  sends {msg} to the user's inbox.
+    ::
+    |=  msg/tape
+    (ta-speak %lin | (crip msg))
   ::
   ++  ta-evil
     :>  tracing printf and crash.
@@ -641,10 +655,12 @@
     ::
     |=  {who/circle ses/(list serial) fal/(unit tang)}
     ^+  +>
-    ~?  ?=(^ fal)  u.fal
-    =-  (ta-delta %done who ses -)
-    ?~  fal  %accepted
-    ~>(%slog.[0 u.fal] %rejected)
+    ?~  fal
+      (ta-delta %done who ses %accepted)
+    =.  +>  (ta-delta %done who ses %rejected)
+    =-  (ta-grieve - u.fal)
+    %+  weld  "{(scow %ud (lent ses))} message(s) "
+    "rejected by {(scow %p hos.who)}/{(trip nom.who)}"
   ::
   ++  ta-resub
     :>    subscription dropped
@@ -1296,6 +1312,12 @@
       |=  {src/circle gam/telegram}
       ^+  +>
       ::  check for write permissions.
+      ::TODO  we want to !! instead of silently failing,
+      ::      so that ++coup-repeat of the caller gets
+      ::      an error. but the caller may not be the
+      ::      author. if we check for that to be true,
+      ::      can we guarantee it's not an older message
+      ::      getting resent? does that matter? think.
       ?.  (so-admire aut.gam)  +>
       ::  clean up the message to conform to our rules.
       =.  sep.gam  (so-sane sep.gam)
@@ -2607,10 +2629,14 @@
   ?~  fal
     %-  pre-bake
     ta-done:(ta-greet:ta nom src)
-  =.  u.fal  [>%failed-subscribe nom src< u.fal]
-  %-  (slog (flop u.fal))
   %-  pre-bake
-  ta-done:(ta-leave:ta nom src)
+  =<  ta-done
+  =-  (ta-grieve:(ta-leave:ta nom src) - u.fal)
+  =+  (wire-to-target wir)
+  %+  weld  "failed (re)subscribe to {(scow %p p)} on "
+  %+  roll  q
+  |=  {a/@ta b/tape}
+  :(weld b "/" (trip a))
 ::
 ++  quit
   :>    dropped subscription

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -2795,10 +2795,12 @@
   ==
 ::
 ::TODO  for debug purposes. remove eventually.
+::  users beware, here be dragons.
 ++  poke-noun
   |=  a/@t
   ^-  (quip move _+>)
-  ?:  =(a 'debug')
+  ?:  =(a 'check')
+    ~&  'verifying message reference integrity...'
     =-  ~&(- [~ +>.$])
     %-  ~(urn by stories)
     |=  {n/naem s/story}
@@ -2818,6 +2820,7 @@
       known=k
     mismatch=m
   ?:  =(a 'rebuild')
+    ~&  'rebuilding message references...'
     =-  [~ +>.$(stories -)]
     %-  ~(urn by stories)
     |=  {nom/naem soy/story}
@@ -2831,5 +2834,25 @@
       %+  ~(put by s)  src
       [c (fall (~(get by s) src) ~)]
     soy(count c, known k, sourced s)
+  ?:  =(a 'refederate')
+    ~&  'refederating. may take a while...'
+    :_  +>
+    =+  bov=(above our.bol)
+    ?:  =(bov our.bol)  ~
+    :~  [0 %pull /burden [bov dap.bol] ~]
+        (wire-to-peer /burden)
+    ==
+  ?:  =(a 'incoming')
+    ~&  'incoming subscriptions (ignoring circle subs):'
+    ~&  %+  skip  ~(tap by sup.bol)
+        |=  {bone (pair ship path)}
+        &(?=({$circle *} q) !?=({$circle $inbox *} q))
+    [~ +>]
+  ?:  =(a 'sources')
+    ~&  'sources per story:'
+    ~&  %-  ~(urn by stories)
+        |=  {n/naem s/story}
+        [n src.shape.s]
+    [~ +>]
   [~ +>]
 --

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1150,6 +1150,15 @@
       |=  src/source
       ^+  +>
       =+  seq=(~(get by sequence) cir.src)
+      =/  ner/range
+        ?~  seq  ran.src
+        =-  `[[%ud u.seq] -]
+        ?~  ran.src  ~
+        tal.u.ran.src
+      ::  if our subscription changes or ends, remove
+      ::  the original source.
+      =?  +>.$  !=(ner ran.src)
+        (so-delta-our %config so-cir %source | src)
       ::  if we're past the range, don't resubscribe.
       ?:  ?&  ?=(^ ran.src)
               ?=(^ tal.u.ran.src)
@@ -1161,13 +1170,8 @@
                       ==
               ==
           ==
-        (so-delta-our %follow | [src ~ ~])
-      =-  (so-delta-our %follow & [[cir.src -] ~ ~])
-      ^-  range
-      ?~  seq  ran.src
-      =-  `[[%ud u.seq] -]
-      ?~  ran.src  ~
-      tal.u.ran.src
+        +>.$
+      (so-delta-our %follow & [[cir.src -] ~ ~])
     ::
     ++  so-first-grams
       :>    beginning of stream

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -120,7 +120,12 @@
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
-  [~ ..prep(+<+ u.old)]
+  :_  ..prep(+<+ u.old)
+  :~  [ost.bol %pull /server/client server ~]
+      [ost.bol %pull /server/inbox server ~]
+      peer-client
+      peer-inbox
+  ==
 ::
 ::>  ||
 ::>  ||  %utility
@@ -190,7 +195,7 @@
 ::
 ++  peer-client                                         ::<  ui state peer move
   ^-  move
-  :*  ost.bol
+  :*  0
       %peer
       /server/client
       server
@@ -199,7 +204,7 @@
 ::
 ++  peer-inbox
   ^-  move
-  :*  ost.bol
+  :*  0
       %peer
       /server/inbox
       server

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -2245,10 +2245,12 @@
   ta-done:(ta-sole:ta act)
 ::
 ::TODO  for debug purposes. remove eventually.
+::  users beware, here be dragons.
 ++  poke-noun
   |=  a/@t
   ^-  (quip move _+>)
-  ?:  =(a 'debug')
+  ?:  =(a 'check')
+    ~&  'verifying message reference integrity...'
     =-  ~&(- [~ +>.$])
     =+  %-  ~(rep by known)
       |=  {{u/serial a/@ud} k/@ud m/@ud}
@@ -2259,10 +2261,19 @@
       lent=(lent grams)
     [known=k mismatch=m]
   ?:  =(a 'rebuild')
+    ~&  'rebuilding message references...'
     =+  %+  reel  grams
       |=  {t/telegram c/@ud k/(map serial @ud)}
       [+(c) (~(put by k) uid.t c)]
     [~ +>.$(count c, known k)]
+  ?:  =(a 'reconnect')
+    ~&  'disconnecting and reconnecting to hall...'
+    :_  +>
+    :~  [0 %pull /server/client server ~]
+        [0 %pull /server/inbox server ~]
+        peer-client
+        peer-inbox
+    ==
   [~ +>]
 ::
 ++  coup-client-action                                                ::<  accept n/ack

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -119,8 +119,7 @@
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
-  :_  ..prep(+<+ u.old)
-  [[ost.bol %pull / server ~] ~]
+  [~ ..prep(+<+ u.old)]
 ::
 ::>  ||
 ::>  ||  %utility

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1060,9 +1060,17 @@
         ::
         |=  pas/(set circle)
         ^+  ..sh-work
+        ::  remove *all* sources relating to {pas}.
         =/  pos
-          %-  ~(run in pas)
-          |=(p/circle [p ~])
+          %-  ~(gas in *(set ^source))
+          %-  zing
+          =/  sos
+            =-  ~(tap in src:-)
+            (fall (~(get by mirrors) incir) *config)
+          %+  turn  ~(tap in pas)
+          |=  c/circle
+          %+  skim  sos
+          |=(s/^source =(cir.s c))
         =.  ..sh-work
           (sh-act %source inbox | pos)
         (sh-act %notify pas ~)

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -89,6 +89,7 @@
           {$number $@(@ud {@u @ud})}                    ::<  relative/absolute
           {$who audience}                               ::<  presence
           {$what (unit $@(char audience))}              ::<  show bound glyph
+          {$sources circle}                               ::<  show active sources
           ::  ui settings                               ::
           {$bind char (unit audience)}                  ::<  bind glyph
           {$unbind char (unit audience)}                ::<  unbind glyph
@@ -784,6 +785,8 @@
             ==
           ==
         ::
+          ;~((glue ace) (perk %sources ~) circ)
+        ::
           ;~((glue ace) (perk %show ~) circ)
         ::
           ;~((glue ace) (perk %hide ~) circ)
@@ -954,6 +957,7 @@
           $number  (number +.job)
           $who     (who +.job)
           $what    (what +.job)
+          $sources  (list-sources +.job)
           ::  ui settings
           $bind    (bind +.job)
           $unbind  (unbind +.job)
@@ -1253,6 +1257,24 @@
           =.  ..sh-fact  (sh-fact %txt "? {(scow %ud msg)}")
           (activate (snag (sub count +(msg)) grams))
         (sh-lame "…{(reap p.num '0')}{(scow %ud q.num)}: no such telegram")
+      ::
+      ++  list-sources                                  ::<  %sources
+        ::>  display the active sources for our circle.
+        ::
+        |=  cir/circle
+        ^+  ..sh-work
+        %+  sh-fact  %mor
+        %+  turn
+          ::  make sure to exclude {nom} itself.
+          =-  ~(tap in (~(del in src:-) [cir ~]))
+          (fall (~(get by mirrors) cir) *config)
+        |=  s/^source
+        ^-  sole-effect
+        :-  %txt
+        %+  weld  ~(cr-phat cr cir.s)
+        %+  roll  (range-to-path ran.s)
+        |=  {a/@ta b/tape}
+        :(weld b "/" (trip a))
       ::
       ::>  ||
       ::>  ||  %ui-settings

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1047,6 +1047,11 @@
         =+  pas=~(key by pos)
         =.  ..sh-work
           sh-prod(active.she pas)
+        ::  default to a day of backlog
+        =.  pos
+          %-  ~(run by pos)
+          |=  r/range
+          ?~(r `[da+(sub now.bol ~d1) ~] r)
         (sh-act %source inbox & pos)
       ::
       ++  leave                                         ::<  %leave

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1599,7 +1599,7 @@
       ==
     ::
         %cake
-      ~?  ?=(^ r.bon)  [%cake-woot-bad hen r.bon]
+      ::  ~?  ?=(^ r.bon)  [%cake-woot-bad hen r.bon]
       :_  fox
       :~  [s.bon %give %woot q.p.bon r.bon]
       ==


### PR DESCRIPTION
Bunch of fixes for subscriptions, and some higher ease-of-use for circle sources.

- `++quit` now always tries to re-subscribe. (Turns out gall doesn't do that for you.)
- Subscription (and poke) fails get handled more gracefully.
- Improved sources tracking for circles.
- `;join` loads a single day of backlog by default (rather than everything).
- `;leave` unsubscribes the inbox from _all_ related sources.
- Command for inspecting sources of circles. `;sources %whatever`

Also makes talk force-reconnect to hall on update (people got unlinked again somehow?), and includes more debug poke options/actions.