### PR TITLE
Make talk actually revise reheard messages

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -120,7 +120,7 @@
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
-  :_  ..prep(+<+ u.old)
+  :_  ..prep(+<+ u.old(grams ~, known ~, count 0))
   :~  [ost.bol %pull /server/client server ~]
       [ost.bol %pull /server/inbox server ~]
       peer-client

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -2255,13 +2255,12 @@
   ?:  =(a 'check')
     ~&  'verifying message reference integrity...'
     =-  ~&(- [~ +>.$])
+    ~&  [%count--lent count (lent grams)]
     =+  %-  ~(rep by known)
       |=  {{u/serial a/@ud} k/@ud m/@ud}
       :-  ?:((gth a k) a k)
       ?:  =(u uid:(snag (sub count +(a)) grams))  m  +(m)
-    :^  %check-talk
-        count=count
-      lent=(lent grams)
+    :-  %check-talk
     [known=k mismatch=m]
   ?:  =(a 'rebuild')
     ~&  'rebuilding message references...'

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -460,7 +460,10 @@
     |=  {num/@ud gam/telegram}
     =+  old=(snag num grams)
     ?:  =(gam old)  +>.$                                ::  no change
-    =.  grams  (oust [num 1] grams)
+    =.  grams
+      %+  welp
+      (scag num grams)
+      [gam (slag +(num) grams)]
     ?:  =(sep.gam sep.old)  +>.$                        ::  no worthy change
     =<  sh-done
     (~(sh-gram sh cli) gam)


### PR DESCRIPTION
Okay now it's just getting embarrassing.

Fixed an issue where talk, upon hearing a message it had already heard, tried to "revise" it by just deleting it from the messages list and... doing nothing else.

Since that means hall's local copy of the inbox can't be trusted to be any kind of coherent anymore, the ++prep cleans it out, causing it to be rebuilt from the hall re-sub that was still there.  
This will cause everyone's backlog to be printed all over again, but that's just local load. (We'll definitely want to push out a clean ++prep after we've confirmed this fixes people's issues though.)

Closes #497, and should take care of #501, hopefully. This resolves the stack trace that was being thrown there, so if that's what's blocking it, this clears that up.