### PR TITLE
New key for ~tyr

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -267,7 +267,7 @@
         0w2g.gLmg4.MtrHQ.A5VmH.WPk6G  ::  150, ~ryg, Dan Haffey (oldkey)
         0w0                           ::  151, ~ryx, Tlon
         0w0                           ::  152, ~fep, Tlon
-        0w2j.T1u2s.BfXjV.ldOGR.aiZrQ  ::  153, ~tyr, Steve Dee (oldkey)
+        0w3x.y5stk.FMmvV.LQo3X.OCXkI  ::  153, ~tyr, Steven Dee
         0w0                           ::  154, ~tus, Tlon
         0w0                           ::  155, ~tyc, Tlon
         0w0                           ::  156, ~leg, Tlon


### PR DESCRIPTION
Also put on an n in compliance with current Steven Dee naming
conventions (and various government IDs.)