### PR TITLE
Federation performance hotfix

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -921,6 +921,8 @@
       ::
       |=  {gaz/(list telegram) cos/lobby pes/crowd}
       ^+  +>
+      ~?  (gth (lent gaz) 2.000)
+        [%unexpected-scrollback-length nom (lent gaz)]
       =*  self  +>
       ::  local config
       =.  self
@@ -2171,7 +2173,9 @@
     ::  only auto-federate channels for now.
     ?.  ?=($channel sec.con.shape.s)  ~
     :+  ~  n
-    :+  grams.s
+    ::  share no more than 2k messages at once, for performance reasons.
+    :+  ?:  (lte count.s 2.000)  grams.s
+        (slag (sub count.s 2.000) grams.s)
       [shape.s mirrors.s]
     [locals.s remotes.s]
   ::


### PR DESCRIPTION
Turns out always sending the full scrollback isn't a good idea, considering resubscribes can happen at any time.

This makes sure only the last 2000 messages get shared.

Not entirely sure if this will take care of the cases ~marzod and ~samzod are experiencing, since they crashed in a state where they're trying to process a received package. Will have to swap the printf out for a truncation of `gaz` if that's the case.