### PR TITLE
Prevent gall from breaking things over bone 0

### DIFF
--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -782,7 +782,7 @@
       ?^  -.q.vax  :_(+>.$ [%| (ap-suck "move: invalid move (bone)")])
       ?@  +.q.vax  :_(+>.$ [%| (ap-suck "move: invalid move (card)")])
       =+  hun=(~(get by r.zam) -.q.vax)
-      ?.  (~(has by r.zam) -.q.vax) 
+      ?.  &((~(has by r.zam) -.q.vax) !=(0 -.q.vax))
         :_(+>.$ [%| (ap-suck "move: invalid card (bone {<-.q.vax>})")])
       =^  pec  vel  (~(spot wa vel) 3 vax)
       =^  cav  vel  (~(slot wa vel) 3 pec)


### PR DESCRIPTION
Maybe not ready for merging. Want to get a PR up for further discussion.

Apps that send `%peer` moves with bone 0 can get in trouble for that. When gall tries to kill the subscription (because some error occurred because of it) it tries to get at bone 0, but by its own rules, this isn't allowed.  
Considering bone 0 means "no cause", that's fair. Everything an app does has a cause. At the very least, that is "app was booted".

This change rejects moves that use bone 0, giving the same error message that is used for unknown bones. (And it technically is, because 0 only ever has empty ducts associated with it for some reason.)

An alternative approach saw [this line](https://github.com/urbit/arvo/blob/master/sys/vane/gall.hoon#L600) changed to set a 0 bone to be the bone that was used for booting the app, but that's silent and doesn't tell the developer bone 0 is semantically incorrect.

Prevents #501 and similar cases from happening. Note that this does nothing to reverse the damage that has been done.