### PR TITLE
Clay multi-%next: %mult (and fix for %next)

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -270,9 +270,15 @@
 ::  Like a ++rave but with caches of current versions for %next and %many.
 ::  Generally used when we store a request in our state somewhere.
 ::
+++  cach  (unit (each cage lobe))                       ::  cached result
 ++  rove                                                ::  stored request
           $%  {$sing p/mood}                            ::  single request
               {$next p/mood q/(unit (each cage lobe))}  ::  next version
+              $:  $mult                                 ::  next version of any
+                  p/care                                ::
+                  q/(jug case spur)                     ::
+                  r/(map case (map spur cach))          ::
+              ==                                        ::
               {$many p/? q/moat r/(map path lobe)}      ::  change range
           ==                                            ::
 ::
@@ -318,6 +324,7 @@
           {$note p/@tD q/tank}                          ::  debug message
           {$ogre p/@tas}                                ::  delete mount point
           {$writ p/riot}                                ::  response
+          {$wris p/(set rant)}                          ::  responses
       ==                                                ::
 ++  note                                                ::  out request $->
   $%  $:  $a                                            ::  to %ames
@@ -587,6 +594,16 @@
         %f  %exec  our  ~  [her syd q.mun]  (lobe-to-silk:ze r.mun p.dat)
     ==
   ::
+  ++  blas
+    |=  {hen/duct das/(map mood (each cage lobe))}
+    ^+  +>
+    =-  (emit hen %give %wris -)
+    %-  ~(run in das)
+    |=  {mun/mood dat/(each cage lobe)}
+    ~|  %lobe-unsupported-tmp
+    ?>  ?=($& -.dat)
+    [[p.mun q.mun syd] r.mun p.dat]
+  ::
   ::  Give next step in a subscription.
   ::
   ++  bleb
@@ -621,6 +638,7 @@
   ::
   ++  blub-all  (duct-lift |=({a/duct $~} (blub a)))    ::  lifted ++blub
   ++  blab-all  (duct-lift blab)                        ::  lifted ++blab
+  ++  blas-all  (duct-lift blas)                        ::  lifted ++blas
   ++  balk-all  (duct-lift balk)                        ::  lifted ++balk
   ++  bleb-all  (duct-lift bleb)                        ::  lifted ++bleb
   ::
@@ -688,6 +706,25 @@
           =(p.a p.rov(q q.p.a))
           ?=(^ (case-to-aeon:ze q.p.a))
       ==
+    ::
+        $mult
+      =+  %+  roll  ~(tap in q.rov)
+          |=  {{c/case s/(set spur)} sus/(jug aeon spur) val/?}
+          ?.  val  [~ |]
+          =+  a=(case-to-aeon:ze c)
+          ?~  a  [~ |]
+          [(~(put by sus) u.a s) &]
+      ?.  val  ~
+      %+  skim  ~(tap in ~(key by qyx))
+      |=  a=rove  ^-  ?
+      ?.  ?=($mult -.a)  |
+      ?.  =(~(wyt by q.a) ~(wyt by q.rov))  |
+      =-  val  %-  ~(rep in q.a)
+      |=  {{c/case s/(set spur)} val/?}
+      ?.  val  |
+      =+  a=(case-to-aeon:ze c)
+      ?~  a  |
+      =((~(get by sus) u.a) `s)
     ::
         $many
       ?~  (case-to-aeon:ze p.q.rov)  ~
@@ -807,6 +844,30 @@
       ?:  (equivalent-data:ze u.u.ver u.u.var)
         $(yon +(yon))
       (blab hen p.rav u.u.var)
+    ::
+        $mult
+      ::  check to make sure that the request doesn't contain any historic or
+      ::  foreign targets.
+      ?:  %+  lien  ~(tap by q.rav)
+          |=  {c/case s/(set spur)}
+          =+  (case-to-aeon:ze c)
+          &(?=(^ -) (lth u.- let.dom))
+        (blub hen)
+      ::  considering targets in the past are invalid, always store request.
+      =-  (duce -.rav p.rav q.rav -)
+      %-  ~(gas by *(map case (map spur cach)))
+      %+  turn  ~(tap by q.rav)
+      |=  {c/case s/(set spur)}
+      ^-  (pair case (map spur cach))
+      :-  c
+      =+  aey=(case-to-aeon:ze c)
+      ?~  aey  ~  ::  case in the future.
+      %-  ~(gas by *(map spur cach))
+      %+  turn  ~(tap in s)
+      |=  p/spur
+      =+  (aver p.rav c p)
+      ~|  [%unexpected-async p.rav c p]
+      ?>(?=(^ -) [p u.-])
     ::
         $many
       =+  nab=(case-to-aeon:ze p.q.rav)
@@ -1622,6 +1683,9 @@
           `p.q.p.rov
         ::
             $next  ~
+        ::
+            $mult  ~
+        ::
             $many
           %^  hunt  lth
             ?.  ?=($da -.p.q.rov)  ~
@@ -1638,6 +1702,7 @@
     ?-  -.rov
       $sing  rov
       $next  [- p]:rov
+      $mult  [- p q]:rov
       $many  [- p q]:rov
     ==
   ::
@@ -1645,7 +1710,7 @@
   ::
   ++  wake                                            ::  update subscribers
     ^+  .
-    =+  xiq=~(tap by qyx)
+    =+  xiq=~(tap by qyx)  ::  (list (pair rove (set duct)))
     =|  xaq/(list {p/rove q/(set duct)})
     |-  ^+  ..wake
     ?~  xiq
@@ -1693,6 +1758,50 @@
       ?:  (equivalent-data:ze u.q.p.i.xiq u.u.var)
         $(xiq t.xiq, xaq [i.xiq xaq])
       $(xiq t.xiq, ..wake (blab-all q.i.xiq muc u.u.var))
+    ::
+        $mult
+      =*  rov  p.i.xiq
+      =-  ?^  res
+            $(xiq t.xiq, ..wake (blas-all q.i.xiq res))
+          $(xiq t.xiq, xaq [i.xiq(r.p (~(uni by r.rov) cac)) xaq])
+      %+  roll  ~(tap by q.rov)
+      |=  $:  {cas/case sus/(set spur)}
+              cac/(map case (map spur cach))
+              res/(map mood (each cage lobe))
+          ==
+      ^+  [cac res]
+      =+  hav=(~(got by r.rov) cas)
+      ::  if we don't have an existing cache, try to build it.
+      ?~  hav
+        =-  ?~  -  [cac res]
+            [(~(put by cac) cas -) res]
+        =+  aey=(case-to-aeon:ze cas)
+        ?~  aey  ~  ::  case in the future.
+        %-  ~(gas by *(map spur cach))
+        %+  turn  ~(tap in sus)
+        |=  s/spur
+        ^-  (pair spur cach)
+        =+  (aver p.rov [%ud let.dom] s)
+        ~|  [%unexpected-async p.rov cas s]
+        ?>(?=(^ -) [s u.-])
+      ::  if we have an existing cache, compare it to current data.
+      :-  cac
+      %-  ~(gas by res)
+      %+  murn  ~(tap in sus)
+      |=  s/spur
+      ^-  (unit (pair mood (each cage lobe)))
+      =+  o=(~(got by `(map spur cach)`hav) s)
+      =+  n=(aver p.rov [%ud let.dom] s)
+      ~|  [%unexpected-async p.rov let.dom s]
+      ?>  ?=(^ n)
+      =+  m=[p.rov [%ud let.dom] s]
+      ?~  o
+       ?~  u.n  ~                                   ::  not added
+       `[m u.u.n]                                   ::  added
+      ?~  u.n
+        `[m [%& %null [%atom %n ~] ~]]              ::  deleted
+      ?:  (equivalent-data:ze u.u.n u.o)  ~         ::  unchanged
+      `[m u.u.n]                                    ::  changed
     ::
         $many
       =+  mot=`moat`q.p.i.xiq

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -273,7 +273,7 @@
 ++  cach  (unit (each cage lobe))                       ::  cached result
 ++  rove                                                ::  stored request
           $%  {$sing p/mood}                            ::  single request
-              {$next p/mood q/(unit (each cage lobe))}  ::  next version
+              {$next p/mood q/(unit cach)}              ::  next version
               $:  $mult                                 ::  next version of any
                   p/care                                ::
                   q/(jug case spur)                     ::
@@ -827,14 +827,11 @@
     ::
         $next
       =+  ver=(aver p.rav)
-      ?~  ver
-        (duce [- p ~]:rav)
-      ?~  u.ver
-        (blub hen)
+      ?.  ?=({$~ $~ *} ver)  (duce -.rav p.rav ver)
       =+  yon=+((need (case-to-aeon:ze q.p.rav)))
       |-  ^+  +>.^$
       ?:  (gth yon let.dom)
-        (duce -.rav p.rav u.ver)
+        (duce -.rav p.rav ver)
       =+  var=(aver p.rav(q [%ud yon]))
       ?~  var
         ~&  [%oh-no rave=rav aeon=yon letdom=let.dom]
@@ -1740,24 +1737,29 @@
     ::
         $next
       =*  mun  p.p.i.xiq
-      ::  =*  dat  q.p.i.xiq    XX can't fuse right now
-      ?~  q.p.i.xiq
+      =*  dat  q.p.i.xiq
+      =;  nex/(each _..wake _xaq)
+        ?:  ?=($& -.nex)
+          $(xiq t.xiq, ..wake p.nex)
+        $(xiq t.xiq, xaq p.nex)
+      ?~  dat
+        :-  %|
         =+  ver=(aver mun)
-        ?~  ver
-          $(xiq t.xiq, xaq [i.xiq xaq])
-        ?~  u.ver
-          $(xiq t.xiq, ..wake (blub-all q.i.xiq ~))
-        $(xiq t.xiq, xaq [i.xiq(q.p u.ver) xaq])
-      =/  muc  mun(q [%ud let.dom])  ::  current mood
+        ?~  ver  [i.xiq xaq]
+        [i.xiq(q.p ver) xaq]
+      =/  muc  mun(q [%ud let.dom])
       =+  var=(aver muc)
       ?~  var
         ~&  [%oh-noes old=mun mood=muc letdom=let.dom]
-        $(xiq t.xiq)
+        |+xaq
+      ?~  u.dat
+        ?~  u.var  |+[i.xiq xaq]                        ::  not added
+        &+(blab-all q.i.xiq muc u.u.var)                ::  added
       ?~  u.var
-        $(xiq t.xiq, ..wake (blab-all q.i.xiq muc %& %null [%atom %n ~] ~))
-      ?:  (equivalent-data:ze u.q.p.i.xiq u.u.var)
-        $(xiq t.xiq, xaq [i.xiq xaq])
-      $(xiq t.xiq, ..wake (blab-all q.i.xiq muc u.u.var))
+        &+(blab-all q.i.xiq muc %& %null [%atom %n ~] ~)::  deleted
+      ?:  (equivalent-data:ze u.u.dat u.u.var)
+        |+[i.xiq xaq]                                   ::  unchanged
+      &+(blab-all q.i.xiq muc u.u.var)                  ::  changed
     ::
         $mult
       =*  rov  p.i.xiq
@@ -3579,7 +3581,11 @@
     $3  ..^$(ruf ruf.old)
     $2  =/  rov
           |=  a/rove-2  ^-  rove
-          a
+          ?+  -.a  a
+              $next
+            ?~  q.a  a
+            a(q `q.a)
+          ==
         =/  cul
           |=  a/cult-2  ^-  cult
           %-  ~(gas by *cult)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -737,20 +737,20 @@
       ==
     ::
         $many
-        =+  aey=(case-to-aeon:ze p.q.rov)
-        ?~  aey  ~
-        %+  roll  ~(tap in ~(key by qyx))
-        |=  {hav/rove res/(unit rove)}
-        ?^  res  res
-        =-  ?:(- `hav ~)
-        ?&  ?=($many -.hav)
-            =(hav rov(p.q p.q.hav))
-          ::
-            ::  only a match if this request is before
-            ::  or at our starting case.
-            =+  hay=(case-to-aeon:ze p.q.hav)
-            ?~(hay | (lte u.hay u.aey))
-        ==
+      =+  aey=(case-to-aeon:ze p.q.rov)
+      ?~  aey  ~
+      %+  roll  ~(tap in ~(key by qyx))
+      |=  {hav/rove res/(unit rove)}
+      ?^  res  res
+      =-  ?:(- `hav ~)
+      ?&  ?=($many -.hav)
+          =(hav rov(p.q p.q.hav))
+        ::
+          ::  only a match if this request is before
+          ::  or at our starting case.
+          =+  hay=(case-to-aeon:ze p.q.hav)
+          ?~(hay | (lte u.hay u.aey))
+      ==
     ==
   ::
   ::  Takes a list of changed paths and finds those paths that are inside a

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1787,7 +1787,7 @@
       =/  mod  mun(q [%ud let.dom])
       ::  we either update the state (to include a response to send),
       ::  or add the request back into the waiting list.
-      =;  nex/(each (each lobe cage) _xaq)
+      =;  nex/(each (each cage lobe) _xaq)
         ?:  ?=($& -.nex)
           $(xiq t.xiq, ..wake (blab-all q.i.xiq mod p.nex))
         $(xiq t.xiq, xaq p.nex)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -277,8 +277,8 @@
               $:  $mult                                 ::  next version of any
                   p/mool                                ::  original request
                   q/(unit aeon)                         ::  checking for change
-                  r/(map spur (unit cach))              ::  old version
-                  s/(map spur (unit cach))              ::  new version
+                  r/(map path (unit cach))              ::  old version
+                  s/(map path (unit cach))              ::  new version
               ==
               {$many p/? q/moat r/(map path lobe)}      ::  change range
           ==                                            ::
@@ -844,23 +844,23 @@
       ::  if the requested case is in the future, we can't know anything yet.
       ?~  aey  (duce -.rav p.rav ~ ~ ~)
       =/  old
-        %-  ~(gas by *(map spur (unit cach)))
+        %-  ~(gas by *(map path (unit cach)))
         %+  turn  ~(tap by r.p.rav)
-        |=  s/spur
-        ^-  (pair spur (unit cach))
-        [s (aver p.p.rav q.p.rav s)]
-      =+  hav=|=({s/spur c/(unit cach)} ?=(^ c))
+        |=  p/path
+        ^-  (pair path (unit cach))
+        [p (aver p.p.rav q.p.rav p)]
+      =+  hav=|=({p/path c/(unit cach)} ?=(^ c))
       =+  yon=+((need (case-to-aeon:ze q.p.rav)))
       |-  ^+  +>.^$
       ::  if we're need future revisions to look for change, wait.
       ?:  (gth yon let.dom)
         (duce -.rav p.rav `yon old ~)
       =/  new
-        %-  ~(gas by *(map spur (unit cach)))
+        %-  ~(gas by *(map path (unit cach)))
         %+  turn  ~(tap by r.p.rav)
-        |=  s/spur
-        ^-  (pair spur (unit cach))
-        [s (aver p.p.rav q.p.rav s)]
+        |=  p/path
+        ^-  (pair path (unit cach))
+        [p (aver p.p.rav q.p.rav p)]
       ::  if we don't know everything now, store the request for later.
       ?.  &((levy ~(tap by old) hav) (levy ~(tap by new) hav))
         (duce -.rav p.rav `yon old new)
@@ -870,14 +870,14 @@
         ?~  res  $(old new, yon +(yon))
         (blas hen res)
       %+  roll  ~(tap by old)
-      |=  $:  {sup/spur ole/(unit cach)}
+      |=  $:  {pax/path ole/(unit cach)}
               res/(map mood (each cage lobe))
           ==
-      =+  neu=(~(got by new) sup)
+      =+  neu=(~(got by new) pax)
       ?<  |(?=($~ ole) ?=($~ neu))
       =-  ?~(- res (~(put by res) u.-))
       ^-  (unit (pair mood (each cage lobe)))
-      =+  mod=[p.p.rav [%ud yon] sup]
+      =+  mod=[p.p.rav [%ud yon] pax]
       ?~  u.ole
        ?~  u.neu  ~                                     ::  not added
        `[mod u.u.neu]                                   ::  added
@@ -1758,29 +1758,29 @@
         $next
       =*  mun  p.p.i.xiq
       =*  old  q.p.i.xiq
+      =/  mod  mun(q [%ud let.dom])
       ::  we either update the state (to include a response to send),
       ::  or add the request back into the waiting list.
-      =;  nex/(each _..wake _xaq)
+      =;  nex/(each (each lobe cage) _xaq)
         ?:  ?=($& -.nex)
-          $(xiq t.xiq, ..wake p.nex)
+          $(xiq t.xiq, ..wake (blab-all q.i.xiq mod p.nex))
         $(xiq t.xiq, xaq p.nex)
       ::  if we don't have an existing cache of the old version,
       ::  try to get it now.
       ?~  old
         |+[i.xiq(q.p (aver mun)) xaq]
-      =/  mod  mun(q [%ud let.dom])
       =+  new=(aver mod)
       ?~  new
         ~&  [%oh-noes old=mun mood=mod letdom=let.dom]
         |+xaq
       ?~  u.old
         ?~  u.new  |+[i.xiq xaq]                        ::  not added
-        &+(blab-all q.i.xiq mod u.u.new)                ::  added
+        &+u.u.new                                       ::  added
       ?~  u.new
-        &+(blab-all q.i.xiq mod %& %null [%atom %n ~] ~)::  deleted
+        &+[%& %null [%atom %n ~] ~]                     ::  deleted
       ?:  (equivalent-data:ze u.u.old u.u.new)
         |+[i.xiq xaq]                                   ::  unchanged
-      &+(blab-all q.i.xiq mod u.u.new)                  ::  changed
+      &+u.u.new                                         ::  changed
     ::
         $mult
       ::  because %mult requests need to wait on multiple files for each
@@ -1806,24 +1806,24 @@
         ?~  aey  |+rov
         ::  if we do, update the request and retry.
         $(rov [-.rov mol `+(u.aey) ~ ~])
-      =+  hav=|=({s/spur c/(unit cach)} ?=(^ c))
+      =+  hav=|=({p/path c/(unit cach)} ?=(^ c))
       ::  create a gate that tries to fill the unknown data into a cache map.
       =/  fill
         =/  d  ::  for easier iteraton.
-          %-  ~(gas by *(map spur (unit cach)))
-          (turn ~(tap in r.mol) |=(s/spur [s ~]))
-        |=  {m/(map spur (unit cach)) c/case}
+          %-  ~(gas by *(map path (unit cach)))
+          (turn ~(tap in r.mol) |=(p/path [p ~]))
+        |=  {m/(map path (unit cach)) c/case}
         %-  ~(urn by ?~(m d m))
-        |=  {s/spur o/(unit cach)}
-        ?^(o o (aver p.mol c s))
+        |=  {p/path o/(unit cach)}
+        ?^(o o (aver p.mol c p))
       ::  if old isn't complete, try fillin in the gaps.
-      =?  old  |(?=($~ old) !(levy ~(tap by `(map spur (unit cach))`old) hav))
+      =?  old  |(?=($~ old) !(levy ~(tap by `(map path (unit cach))`old) hav))
         (fill old [%ud (dec u.yon)])
       ::  if the next aeon we want to compare is in the future, wait again.
       =+  aey=(case-to-aeon:ze [%ud u.yon])
       ?~  aey  |+rov
       ::  if new isn't complete, try filling in the gaps.
-      =?  new  |(?=($~ new) !(levy ~(tap by `(map spur (unit cach))`new) hav))
+      =?  new  |(?=($~ new) !(levy ~(tap by `(map path (unit cach))`new) hav))
         (fill new [%ud u.yon])
       ::  if they're still not both complete, wait again.
       ?.  ?&  (levy ~(tap by old) hav)
@@ -1835,14 +1835,14 @@
         ?^  res  &+res
         $(rov [-.rov mol `+(u.yon) new ~])
       %+  roll  ~(tap by old)
-      |=  $:  {sup/spur ole/(unit cach)}
+      |=  $:  {pax/path ole/(unit cach)}
               res/(map mood (each cage lobe))
           ==
-      =+  neu=(~(got by new) sup)
+      =+  neu=(~(got by new) pax)
       ?<  |(?=($~ ole) ?=($~ neu))
       =-  ?~(- res (~(put by res) u.-))
       ^-  (unit (pair mood (each cage lobe)))
-      =+  mod=[p.mol [%ud u.yon] sup]
+      =+  mod=[p.mol [%ud u.yon] pax]
       ?~  u.ole
        ?~  u.neu  ~                                     ::  not added
        `[mod u.u.neu]                                   ::  added

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3352,7 +3352,7 @@
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 =|                                                    ::  instrument state
-    $:  $2                                            ::  vane version
+    $:  $3                                            ::  vane version
         ruf/raft                                      ::  revision tree
     ==                                                ::
 |=  {now/@da eny/@ ski/sley}                          ::  activate
@@ -3558,38 +3558,40 @@
 ::
 ++  load
   =>  |%
-      +=  rove-1  ?(rove [%many p=? q=case r=case s=path t=(map path lobe)])
-      ++  cult-1  (jug rove-1 duct)
-      ++  dojo-1  (cork dojo |=(a/dojo a(qyx *cult-1)))
-      ++  rede-1  (cork rede |=(a/rede a(qyx *cult-1)))
-      ++  room-1  (cork room |=(a/room a(dos (~(run by dos.a) dojo-1))))
-      ++  rung-1  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-1))))
-      ++  raft-1
+      +=  rove-2
+        $%  {$sing p/mood}
+            {$next p/mood q/(unit (each cage lobe))}
+            {$many p/? q/moat r/(map path lobe)}
+        ==
+      ++  cult-2  (jug rove-2 duct)
+      ++  dojo-2  (cork dojo |=(a/dojo a(qyx *cult-2)))
+      ++  rede-2  (cork rede |=(a/rede a(qyx *cult-2)))
+      ++  room-2  (cork room |=(a/room a(dos (~(run by dos.a) dojo-2))))
+      ++  rung-2  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-2))))
+      ++  raft-2
         %+  cork  raft
-        |=(a/raft a(fat (~(run by fat.a) room-1), hoy (~(run by hoy.a) rung-1)))
-      ++  axle    $%({$1 ruf/raft-1} {$2 ruf/raft})
+        |=(a/raft a(fat (~(run by fat.a) room-2), hoy (~(run by hoy.a) rung-2)))
+      ++  axle    $%({$2 ruf/raft-2} {$3 ruf/raft})
       --
   |=  old/axle
   ^+  ..^$
   ?-  -.old
-    $2  ..^$(ruf ruf.old)
-    $1  =/  rov
-          |=  a/rove-1  ^-  rove
-          ?+  a  a
-            [%many @ [@ @] *]  [%many p.a [q.a r.a s.a] t.a]
-          ==
+    $3  ..^$(ruf ruf.old)
+    $2  =/  rov
+          |=  a/rove-2  ^-  rove
+          a
         =/  cul
-          |=  a/cult-1  ^-  cult
+          |=  a/cult-2  ^-  cult
           %-  ~(gas by *cult)
-          (turn ~(tap by a) |=({p/rove-1 q/(set duct)} [(rov p) q]))
+          (turn ~(tap by a) |=({p/rove-2 q/(set duct)} [(rov p) q]))
         =/  rom
-          =+  doj=|=(a/dojo-1 a(qyx (cul qyx.a)))
-          |=(a/room-1 a(dos (~(run by dos.a) doj)))
+          =+  doj=|=(a/dojo-2 a(qyx (cul qyx.a)))
+          |=(a/room-2 a(dos (~(run by dos.a) doj)))
         =/  run
-          =+  red=|=(a/rede-1 a(qyx (cul qyx.a)))
-          |=(a/rung-1 a(rus (~(run by rus.a) red)))
+          =+  red=|=(a/rede-2 a(qyx (cul qyx.a)))
+          |=(a/rung-2 a(rus (~(run by rus.a) red)))
         =+  r=ruf.old
-        $(old [%2 r(fat (~(run by fat.r) rom), hoy (~(run by hoy.r) run))])
+        $(old [%3 r(fat (~(run by fat.r) rom), hoy (~(run by hoy.r) run))])
   ==
 ::
 ++  scry                                              ::  inspect
@@ -3613,7 +3615,7 @@
   ?:  ?=($& -.u.u.-)  ``p.u.u.-
   ~
 ::
-++  stay  [%2 ruf]
+++  stay  [%3 ruf]
 ++  take                                              ::  accept response
   |=  {tea/wire hen/duct hin/(hypo sign)}
   ^+  [p=*(list move) q=..^$]

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -596,14 +596,11 @@
     ==
   ::
   ++  blas
-    |=  {hen/duct das/(map mood (each cage lobe))}
+    |=  {hen/duct das/(set mood)}
     ^+  +>
-    =-  (emit hen %give %wris -)
-    %-  ~(run in das)
-    |=  {mun/mood dat/(each cage lobe)}
-    ~|  %lobe-unsupported-tmp
-    ?>  ?=($& -.dat)
-    [[p.mun q.mun syd] r.mun p.dat]
+    ?>  ?=(^ das)
+    =-  (emit hen %give %wris q.n.das -)
+    (~(run in `(set mood)`das) |=(m/mood r.m))
   ::
   ::  Give next step in a subscription.
   ::
@@ -900,7 +897,7 @@
       ++  respond                                       ::  send changes
         |=  res/(map mood (each cage lobe))
         ^+  ..start-request
-        ?:  ?=($mult -.rav)  (blas hen res)
+        ?:  ?=($mult -.rav)  (blas hen ~(key by res))
         ?>  ?=({* $~ $~} res)
         (blab hen n.res)
       ::
@@ -1871,7 +1868,7 @@
         ^+  ..wake
         ::NOTE  want to use =-, but compiler bug?
         ?:  ?=($mult -.vor)
-          ^^$(xiq t.xiq, ..wake (blas-all q.i.xiq res))
+          ^^$(xiq t.xiq, ..wake (blas-all q.i.xiq ~(key by res)))
         ?>  ?=({* $~ $~} res)
         ^^$(xiq t.xiq, ..wake (blab-all q.i.xiq n.res))
       ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -825,8 +825,12 @@
         (blub hen)
       (blab hen p.rav u.u.ver)
     ::
+    ::  for %next, get the data at the specified case, then go forward in time
+    ::  until we find a change. if we find no change, store request for later.
         $next
       =+  ver=(aver p.rav)
+      ::  if we know nothing, or we know the file doesn't exist right now,
+      ::  store the request for later answering.
       ?.  ?=({$~ $~ *} ver)  (duce -.rav p.rav ver)
       =+  yon=+((need (case-to-aeon:ze q.p.rav)))
       |-  ^+  +>.^$
@@ -1707,7 +1711,7 @@
   ::
   ++  wake                                            ::  update subscribers
     ^+  .
-    =+  xiq=~(tap by qyx)  ::  (list (pair rove (set duct)))
+    =+  xiq=~(tap by qyx)
     =|  xaq/(list {p/rove q/(set duct)})
     |-  ^+  ..wake
     ?~  xiq
@@ -1737,29 +1741,30 @@
     ::
         $next
       =*  mun  p.p.i.xiq
-      =*  dat  q.p.i.xiq
+      =*  old  q.p.i.xiq
+      ::  we either update the state (to include a response to send),
+      ::  or add the request back into the waiting list.
       =;  nex/(each _..wake _xaq)
         ?:  ?=($& -.nex)
           $(xiq t.xiq, ..wake p.nex)
         $(xiq t.xiq, xaq p.nex)
-      ?~  dat
-        :-  %|
-        =+  ver=(aver mun)
-        ?~  ver  [i.xiq xaq]
-        [i.xiq(q.p ver) xaq]
-      =/  muc  mun(q [%ud let.dom])
-      =+  var=(aver muc)
-      ?~  var
-        ~&  [%oh-noes old=mun mood=muc letdom=let.dom]
+      ::  if we don't have an existing cache of the old version,
+      ::  try to get it now.
+      ?~  old
+        |+[i.xiq(q.p (aver mun)) xaq]
+      =/  mod  mun(q [%ud let.dom])
+      =+  new=(aver mod)
+      ?~  new
+        ~&  [%oh-noes old=mun mood=mod letdom=let.dom]
         |+xaq
-      ?~  u.dat
-        ?~  u.var  |+[i.xiq xaq]                        ::  not added
-        &+(blab-all q.i.xiq muc u.u.var)                ::  added
-      ?~  u.var
-        &+(blab-all q.i.xiq muc %& %null [%atom %n ~] ~)::  deleted
-      ?:  (equivalent-data:ze u.u.dat u.u.var)
+      ?~  u.old
+        ?~  u.new  |+[i.xiq xaq]                        ::  not added
+        &+(blab-all q.i.xiq mod u.u.new)                ::  added
+      ?~  u.new
+        &+(blab-all q.i.xiq mod %& %null [%atom %n ~] ~)::  deleted
+      ?:  (equivalent-data:ze u.u.old u.u.new)
         |+[i.xiq xaq]                                   ::  unchanged
-      &+(blab-all q.i.xiq muc u.u.var)                  ::  changed
+      &+(blab-all q.i.xiq mod u.u.new)                  ::  changed
     ::
         $mult
       =*  rov  p.i.xiq
@@ -1772,9 +1777,9 @@
               res/(map mood (each cage lobe))
           ==
       ^+  [cac res]
-      =+  hav=(~(got by r.rov) cas)
+      =+  ole=(~(got by r.rov) cas)
       ::  if we don't have an existing cache, try to build it.
-      ?~  hav
+      ?~  ole
         =-  ?~  -  [cac res]
             [(~(put by cac) cas -) res]
         =+  aey=(case-to-aeon:ze cas)
@@ -1790,20 +1795,20 @@
       :-  cac
       %-  ~(gas by res)
       %+  murn  ~(tap in sus)
-      |=  s/spur
+      |=  sup/spur
       ^-  (unit (pair mood (each cage lobe)))
-      =+  o=(~(got by `(map spur cach)`hav) s)
-      =+  n=(aver p.rov [%ud let.dom] s)
-      ~|  [%unexpected-async p.rov let.dom s]
-      ?>  ?=(^ n)
-      =+  m=[p.rov [%ud let.dom] s]
-      ?~  o
-       ?~  u.n  ~                                   ::  not added
-       `[m u.u.n]                                   ::  added
-      ?~  u.n
-        `[m [%& %null [%atom %n ~] ~]]              ::  deleted
-      ?:  (equivalent-data:ze u.u.n u.o)  ~         ::  unchanged
-      `[m u.u.n]                                    ::  changed
+      =+  old=(~(got by `(map spur cach)`ole) sup)
+      =+  new=(aver p.rov [%ud let.dom] sup)
+      ~|  [%unexpected-async p.rov let.dom sup]
+      ?>  ?=(^ new)
+      =+  mod=[p.rov [%ud let.dom] sup]
+      ?~  old
+       ?~  u.new  ~                                     ::  not added
+       `[mod u.u.new]                                   ::  added
+      ?~  u.new
+        `[mod [%& %null [%atom %n ~] ~]]                ::  deleted
+      ?:  (equivalent-data:ze u.u.new u.old)  ~         ::  unchanged
+      `[mod u.u.new]                                    ::  changed
     ::
         $many
       =+  mot=`moat`q.p.i.xiq

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -270,15 +270,15 @@
 ::  Like a ++rave but with caches of current versions for %next and %many.
 ::  Generally used when we store a request in our state somewhere.
 ::
-++  cach  (unit (each cage lobe))                       ::  cached result
+++  cach  (unit (unit (each cage lobe)))                ::  cached result
 ++  rove                                                ::  stored request
           $%  {$sing p/mood}                            ::  single request
-              {$next p/mood q/(unit cach)}              ::  next version
+              {$next p/mood q/cach}                     ::  next version
               $:  $mult                                 ::  next version of any
                   p/mool                                ::  original request
                   q/(unit aeon)                         ::  checking for change
-                  r/(map path (unit cach))              ::  old version
-                  s/(map path (unit cach))              ::  new version
+                  r/(map path cach)                     ::  old version
+                  s/(map path cach)                     ::  new version
               ==
               {$many p/? q/moat r/(map path lobe)}      ::  change range
           ==                                            ::
@@ -864,7 +864,7 @@
         ?~  res  $(yon +(yon))
         (respond res)
       %+  roll  ~(tap by old)
-      |=  $:  {pax/path ole/(unit cach)}
+      |=  $:  {pax/path ole/cach}
               res/(map mood (each cage lobe))
           ==
       =+  neu=(~(got by new) pax)
@@ -882,8 +882,8 @@
       ::
       ++  store                                         ::  check again later
         |=  $:  nex/(unit aeon)
-                old/(map path (unit cach))
-                new/(map path (unit cach))
+                old/(map path cach)
+                new/(map path cach)
             ==
         ^+  ..start-request
         ?:  ?=($mult -.rav)
@@ -892,7 +892,7 @@
         =+  ole=~(tap by old)
         ?>  (lte (lent ole) 1)
         ?~  ole  ~
-        q:(snag 0 `(list (pair path (unit cach)))`ole)
+        q:(snag 0 `(list (pair path cach))`ole)
       ::
       ++  respond                                       ::  send changes
         |=  res/(map mood (each cage lobe))
@@ -901,17 +901,17 @@
         ?>  ?=({* $~ $~} res)
         (blab hen n.res)
       ::
-      ++  know  |=({p/path c/(unit cach)} ?=(^ c))      ::  know awout file
+      ++  know  |=({p/path c/cach} ?=(^ c))             ::  know about file
       ::
-      ++  read-all-at                                   ::  initialize cache
+      ++  read-all-at                                   ::  files at case, maybe
         |=  cas/case
-        %-  ~(gas by *(map path (unit cach)))
+        %-  ~(gas by *(map path cach))
         =/  pax/(set path)
           ?:  ?=($mult -.rav)  r.p.rav
           [r.p.rav ~ ~]
         %+  turn  ~(tap by pax)
         |=  p/path
-        ^-  (pair path (unit cach))
+        ^-  (pair path cach)
         [p (aver p.p.rav cas p)]
       --
     ::
@@ -1819,14 +1819,14 @@
         ?~  aey  |+rov
         ::  if we do, update the request and retry.
         $(rov [-.rov mol `+(u.aey) ~ ~])
-      ::  if old isn't complete, try fillin in the gaps.
-      =?  old  |(?=($~ old) !(levy ~(tap by `(map path (unit cach))`old) know))
+      ::  if old isn't complete, try filling in the gaps.
+      =?  old  |(?=($~ old) !(levy ~(tap by `(map path cach)`old) know))
         (read-unknown mol(q [%ud (dec u.yon)]) old)
       ::  if the next aeon we want to compare is in the future, wait again.
       =+  aey=(case-to-aeon:ze [%ud u.yon])
       ?~  aey  |+rov
       ::  if new isn't complete, try filling in the gaps.
-      =?  new  |(?=($~ new) !(levy ~(tap by `(map path (unit cach))`new) know))
+      =?  new  |(?=($~ new) !(levy ~(tap by `(map path cach)`new) know))
         (read-unknown mol(q [%ud u.yon]) new)
       ::  if they're still not both complete, wait again.
       ?.  ?&  (levy ~(tap by old) know)
@@ -1838,7 +1838,7 @@
         ?^  res  &+res
         $(rov [-.rov mol `+(u.yon) old ~])
       %+  roll  ~(tap by old)
-      |=  $:  {pax/path ole/(unit cach)}
+      |=  $:  {pax/path ole/cach}
               res/(map mood (each cage lobe))
           ==
       =+  neu=(~(got by new) pax)
@@ -1872,15 +1872,15 @@
         ?>  ?=({* $~ $~} res)
         ^^$(xiq t.xiq, ..wake (blab-all q.i.xiq n.res))
       ::
-      ++  know  |=({p/path c/(unit cach)} ?=(^ c))      ::  know awout file
+      ++  know  |=({p/path c/cach} ?=(^ c))             ::  know about file
       ::
       ++  read-unknown                                  ::  fill in the blanks
-        |=  {mol/mool hav/(map path (unit cach))}
-        %.  |=  {p/path o/(unit cach)}
+        |=  {mol/mool hav/(map path cach)}
+        %.  |=  {p/path o/cach}
             ?^(o o (aver p.mol q.mol p))
         =-  ~(urn by -)
         ?^  hav  hav
-        %-  ~(gas by *(map path (unit cach)))
+        %-  ~(gas by *(map path cach))
         (turn ~(tap in r.mol) |=(p/path [p ~]))
       --
     ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -696,35 +696,61 @@
   ::
   ++  dedupe                                            ::  find existing alias
     |=  rov/rove  ^-  rove
-    =;  ros/(list rove)  ?+(ros rov {^ $~} i.ros)
+    =;  ron/(unit rove)  (fall ron rov)
     ?-    -.rov
         $sing  ~
         $next
-      ?~  (case-to-aeon:ze q.p.rov)  ~
-      %+  skim  ~(tap in ~(key by qyx))
-      |=  a=rove  ^-  ?
-      ?&  ?=($next -.a)
-          =(p.a p.rov(q q.p.a))
-          ?=(^ (case-to-aeon:ze q.p.a))
+      =+  aey=(case-to-aeon:ze q.p.rov)
+      ?~  aey  ~
+      %+  roll  ~(tap in ~(key by qyx))
+      |=  {hav/rove res/(unit rove)}
+      ?^  res  res
+      =-  ?:(- `hav ~)
+      ?&  ?=($next -.hav)
+          =(p.hav p.rov(q q.p.hav))
+        ::
+          ::  only a match if this request is before
+          ::  or at our starting case.
+          =+  hay=(case-to-aeon:ze q.p.hav)
+          ?~(hay | (lte u.hay u.aey))
       ==
     ::
         $mult
-      ?~  (case-to-aeon:ze q.p.rov)  ~
-      %+  skim  ~(tap in ~(key by qyx))
-      |=  a=rove  ^-  ?
-      ?&  ?=($mult -.a)
-          =(p.a p.rov(q q.p.a))
-          ?=(^ (case-to-aeon:ze q.p.a))
+      =+  aey=(case-to-aeon:ze q.p.rov)
+      ?~  aey  ~
+      %+  roll  ~(tap in ~(key by qyx))
+      |=  {hav/rove res/(unit rove)}
+      ?^  res  res
+      =-  ?:(- `hav ~)
+      ?&  ?=($mult -.hav)
+          =(p.hav p.rov(q q.p.hav))
+        ::
+          ::  only a match if this request is before
+          ::  or at our starting case, and it has been
+          ::  tested at least that far.
+          =+  hay=(case-to-aeon:ze q.p.hav)
+          ?&  ?=(^ hay)
+              (lte u.hay u.aey)
+              ?=(^ q.hav)
+              (gte u.q.hav u.aey)
+          ==
       ==
     ::
         $many
-      ?~  (case-to-aeon:ze p.q.rov)  ~
-      %+  skim  ~(tap in ~(key by qyx))
-      |=  a=rove  ^-  ?
-      ?&  ?=($many -.a)
-          =(a rov(p.q p.q.a))
-          ?=(^ (case-to-aeon:ze p.q.a))
-      ==
+        =+  aey=(case-to-aeon:ze p.q.rov)
+        ?~  aey  ~
+        %+  roll  ~(tap in ~(key by qyx))
+        |=  {hav/rove res/(unit rove)}
+        ?^  res  res
+        =-  ?:(- `hav ~)
+        ?&  ?=($many -.hav)
+            =(hav rov(p.q p.q.hav))
+          ::
+            ::  only a match if this request is before
+            ::  or at our starting case.
+            =+  hay=(case-to-aeon:ze p.q.hav)
+            ?~(hay | (lte u.hay u.aey))
+        ==
     ==
   ::
   ::  Takes a list of changed paths and finds those paths that are inside a

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -828,23 +828,25 @@
     ::  for %next, get the data at the specified case, then go forward in time
     ::  until we find a change. if we find no change, store request for later.
         $next
-      =+  ver=(aver p.rav)
-      ::  if we know nothing, or we know the file doesn't exist right now,
-      ::  store the request for later answering.
-      ?.  ?=({$~ $~ *} ver)  (duce -.rav p.rav ver)
+      =+  old=(aver p.rav)
+      ::  if we know nothing now, store the request for later answering.
+      ?:  ?=($~ old)  (duce -.rav p.rav old)
       =+  yon=+((need (case-to-aeon:ze q.p.rav)))
       |-  ^+  +>.^$
       ?:  (gth yon let.dom)
-        (duce -.rav p.rav ver)
-      =+  var=(aver p.rav(q [%ud yon]))
-      ?~  var
+        (duce -.rav p.rav old)
+      =+  new=(aver p.rav(q [%ud yon]))
+      ?~  new
         ~&  [%oh-no rave=rav aeon=yon letdom=let.dom]
         +>.^$
-      ?~  u.var
-        (blab hen p.rav %& %null [%atom %n ~] ~)          ::  only her %x
-      ?:  (equivalent-data:ze u.u.ver u.u.var)
-        $(yon +(yon))
-      (blab hen p.rav u.u.var)
+      ?~  u.old
+        ?~  u.new  $(yon +(yon))                        ::  not added
+        (blab hen p.rav u.u.new)                        ::  added
+      ?~  u.new
+        (blab hen p.rav %& %null [%atom %n ~] ~)        ::  removed, only her %x
+      ?:  (equivalent-data:ze u.u.old u.u.new)
+        $(yon +(yon))                                   ::  unchanged
+      (blab hen p.rav u.u.new)                          ::  changed
     ::
         $mult
       ::  check to make sure that the request doesn't contain any historic or

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -467,7 +467,7 @@
   ++  moat  {p/case q/case r/path}                      ::  change range
   ++  mode  (list {path (unit mime)})                   ::  external files
   ++  mood  {p/care q/case r/path}                      ::  request in desk
-  ++  mool  {p/care q/case r/(set spur)}                ::  requests in desk
+  ++  mool  {p/care q/case r/(set path)}                ::  requests in desk
   ++  nori                                              ::  repository action
     $%  {$& p/soba}                                     ::  delta
         {$| p/@tas}                                     ::  label
@@ -483,7 +483,7 @@
         lat/(map lobe blob)                             ::  data
     ==                                                  ::
   ++  rant                                              ::  response to request
-    $:  p/{p/care q/case r/@tas}                        ::  clade release book
+    $:  p/{p/care q/case r/desk}                        ::  clade release book
         q/path                                          ::  spur
         r/cage                                          ::  data
     ==                                                  ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -467,6 +467,7 @@
   ++  moat  {p/case q/case r/path}                      ::  change range
   ++  mode  (list {path (unit mime)})                   ::  external files
   ++  mood  {p/care q/case r/path}                      ::  request in desk
+  ++  mool  {p/care q/case r/(set spur)}                ::  requests in desk
   ++  nori                                              ::  repository action
     $%  {$& p/soba}                                     ::  delta
         {$| p/@tas}                                     ::  label
@@ -489,7 +490,7 @@
   ++  rave                                              ::  general request
     $%  {$sing p/mood}                                  ::  single request
         {$next p/mood}                                  ::  await next version
-        {$mult p/care q/(jug case spur)}                ::  next version of any
+        {$mult p/mool}                                  ::  next version of any
         {$many p/? q/moat}                              ::  track range
     ==                                                  ::
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -391,7 +391,7 @@
           {$ogre p/@tas}                                ::  delete mount point
           {$send p/lane:ames q/@}                       ::  transmit packet
           {$writ p/riot}                                ::  response
-          {$wris p/(set rant)}                          ::  responses
+          {$wris p/case p/(set path)}                   ::  responses
       ==                                                ::
     ++  task                                            ::  in request ->$
       $%  {$boat $~}                                    ::  pier rebooted

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -391,6 +391,7 @@
           {$ogre p/@tas}                                ::  delete mount point
           {$send p/lane:ames q/@}                       ::  transmit packet
           {$writ p/riot}                                ::  response
+          {$wris p/(set rant)}                          ::  responses
       ==                                                ::
     ++  task                                            ::  in request ->$
       $%  {$boat $~}                                    ::  pier rebooted
@@ -488,6 +489,7 @@
   ++  rave                                              ::  general request
     $%  {$sing p/mood}                                  ::  single request
         {$next p/mood}                                  ::  await next version
+        {$mult p/care q/(jug case spur)}                ::  next version of any
         {$many p/? q/moat}                              ::  track range
     ==                                                  ::
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist


### PR DESCRIPTION
This is the simplest possible implementation of a %next for multiple simultaneous files.  
If the subscription includes files in the past, or on other ships, then it is ended immediately. If one or more of the watched files change, then all those changes are sent in one response.

Not yet ready for merge. Lobes currently [aren't dealt with at all](https://github.com/Fang-/arvo/blob/afb1836f4477c8f35d5bc862efa3a1926354a8b3/sys/vane/clay.hoon#L604), as I'm not entirely sure how to do that here. It appears as if `++blab` calls out to ford to build the file into data for us, which won't happen for our restricted set of supported cases. Correct y/n?

(Also I should maybe change existing uses of `(unit (each cage lobe))` into `cach` (and probably rename that into like re`sult` or something), for brevity.)