### PR TITLE
Fixed weird code for updating /circles subscriptions.

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -2323,17 +2323,25 @@
     ::REVIEW  this could be considered leaky, since it
     ::        doesn't check if {who} ever knew of {nom},
     ::        but does that matter? can't really check..
+    ::  if the story got deleted, remove it from the circles listing.
     ?:  ?=($remove -.det.det)  `|
-    =+  soy=(~(got by stories) who.qer)
-    ?.  ?|  ?=($new -.det.det)
-            ?&  ?=($config -.det.det)
-                ?=($permit -.dif.det.det)
-                ?=(?($channel $village) sec.con.shape.soy)
-                (~(has in sis.dif.det.det) who.qer)
-            ==
+    =+  soy=(~(got by stories) nom.det)
+    ::  if the story got created, or something about the read permissions set
+    ::  for the subscriber changed, update the circles listing.
+    =;  dif/?
+      ?.  dif  ~
+      =+  (~(so-visible so:ta nom.det ~ soy) who.qer)
+      ::  if the story just got created, don't send a remove rumor, because it
+      ::  never showed up in the first place.
+      ?:(?=($new -.det.det) ?:(- `- ~) `-)
+    ?|  ?=($new -.det.det)
+      ::
+        ?&  ?=($config -.det.det)
+            ?=($permit -.dif.det.det)
+            ?=(?($channel $village) sec.con.shape.soy)
+            (~(has in sis.dif.det.det) who.qer)
         ==
-      ~
-    `(~(so-visible so:ta nom.det ~ soy) who.qer)
+    ==
   ::
       $public
     ?.  ?=($public -.det)  ~

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -2330,10 +2330,12 @@
     ::  for the subscriber changed, update the circles listing.
     =;  dif/?
       ?.  dif  ~
-      =+  (~(so-visible so:ta nom.det ~ soy) who.qer)
       ::  if the story just got created, don't send a remove rumor, because it
       ::  never showed up in the first place.
-      ?:(?=($new -.det.det) ?:(- `- ~) `-)
+      =-  ?:(&(?=($new -.det.det) !-) ~ `-)
+      ?|  (team:title our.bol who.qer)
+          (~(so-visible so:ta nom.det ~ soy) who.qer)
+      ==
     ?|  ?=($new -.det.det)
       ::
         ?&  ?=($config -.det.det)


### PR DESCRIPTION
No longer incorrectly uses the subscriber's ship name when getting the affected story.

(The real fix is the change from `who.qer` to `nom.det` on line 2328. The rest is just cleanup and comments to make this block easier to follow, since it had me struggling for a little while when revisiting it just now.)

cc @c-johnson