### PR TITLE
Clay permissions

### DIFF
--- a/app/hood.hoon
+++ b/app/hood.hoon
@@ -133,6 +133,7 @@
 ++  coup-kiln-spam            (wrap take-coup-spam):from-kiln
 ++  diff-sole-effect-drum-phat  (wrap diff-sole-effect-phat):from-drum
 ++  init-helm                 |=({way/wire *} [~ +>])
+++  mack-kiln                 (wrap mack):from-kiln
 ++  made-write                (wrap made):from-write
 ++  made-kiln                 (wrap take-made):from-kiln
 ++  mere-kiln                 (wrap take-mere):from-kiln
@@ -186,6 +187,7 @@
 ++  poke-kiln-overload        (wrap poke-overload):from-kiln
 ++  poke-kiln-unmount         (wrap poke-unmount):from-kiln
 ++  poke-kiln-unsync          (wrap poke-unsync):from-kiln
+++  poke-kiln-permission      (wrap poke-permission):from-kiln
 ++  poke-womb-invite          (wrap poke-invite):from-womb
 ++  poke-womb-save            (wrap poke-save):from-womb
 ++  poke-womb-obey            (wrap poke-obey):from-womb

--- a/gen/hood/private.hoon
+++ b/gen/hood/private.hoon
@@ -1,0 +1,10 @@
+::  Kiln: make (subtree in) desk privately readable.
+::
+::::  /gen/hood/private/hoon
+  ::
+:-  %say
+|=  $:  {now/@da eny/@uvJ bec/beak}
+        {arg/{des/desk may/?($~ {pax/path $~})} $~}
+    ==
+:-  %kiln-permission
+[des ?~(may / pax.may) |]:arg

--- a/gen/hood/public.hoon
+++ b/gen/hood/public.hoon
@@ -1,0 +1,10 @@
+::  Kiln: make (subtree in) desk publicly readable.
+::
+::::  /gen/hood/public/hoon
+  ::
+:-  %say
+|=  $:  {now/@da eny/@uvJ bec/beak}
+        {arg/{des/desk may/?($~ {pax/path $~})} $~}
+    ==
+:-  %kiln-permission
+[des ?~(may / pax.may) &]:arg

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -371,14 +371,7 @@
     ==  ==
   ::
   ++  writ
-    |=  $:  reset/?
-            $=  rot
-            %-  unit
-            $:  p/{p/?($d $p $u $v $w $x $y $z) q/case r/desk}
-                q/path
-                r/cage
-            ==
-        ==
+    |=  {reset/? rot/riot}
     ?~  rot
       %^    spam
           leaf+"bad %writ response"

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -70,7 +70,7 @@
           {$poke wire dock pear}                        ::
           {$wipe wire @p $~}                            ::
           {$wait wire @da}                              ::
-          {$warp wire sock riff}                        ::
+          {$warp wire ship sock riff}                   ::
       ==                                                ::
     ++  pear                                            ::  poke fruit
       $%  {$hall-command command:hall}                  ::
@@ -222,7 +222,7 @@
   ++  subscribe-next
     %-  emit
     ^-  card
-    :*  %warp  /kiln/autoload  [our our]  %home  ~
+    :*  %warp  /kiln/autoload  our  [our our]  %home  ~
         %next  %z  da+now  /sys
     ==
   ::
@@ -349,7 +349,7 @@
     %-  blab  :_  ~
     :*  ust  %warp
         /kiln/sync/[syd]/(scot %p her)/[sud]
-        [our her]  sud  ~
+        our  [our her]  sud  ~
     ==
   ::
   ++  start-track
@@ -358,7 +358,7 @@
     %-  blab
     :~  :*  ost  %warp
             /kiln/sync/[syd]/(scot %p her)/[sud]
-            [our her]  sud  ~  %sing  %y  ud+let  /
+            our  [our her]  sud  ~  %sing  %y  ud+let  /
     ==  ==
   ::
   ++  start-sync
@@ -367,7 +367,7 @@
     %-  blab
     :~  :*  ost  %warp
             [%kiln %sync syd (scot %p her) sud ?:(reset /reset /)]
-            [our her]  sud  ~  %sing  %w  [%da now]  /
+            our  [our her]  sud  ~  %sing  %w  [%da now]  /
     ==  ==
   ::
   ++  writ
@@ -414,7 +414,7 @@
     %-  blab  :_  ~
     :*  ost  %warp
         /kiln/sync/[syd]/(scot %p her)/[sud]
-        [our her]  sud  ~  %sing  %y  ud+let  /
+        our  [our her]  sud  ~  %sing  %y  ud+let  /
     ==
   --
 ::

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -67,6 +67,7 @@
           {$dirk wire @tas}                             ::
           {$ogre wire $@(@tas beam)}                    ::
           {$merg wire @p @tas @p @tas case germ}        ::
+          {$perm wire ship desk path rite:clay}         ::
           {$poke wire dock pear}                        ::
           {$wipe wire @p $~}                            ::
           {$wait wire @da}                              ::
@@ -191,6 +192,12 @@
   =+  old=;;((map @da cord) (fall (file where) ~))
   `(foal where %sched !>((~(put by old) tym eve)))
 ::
+++  poke-permission
+  |=  {syd/desk pax/path pub/?}
+  =<  abet
+  %^  emit  %perm  /kiln/permission
+  [our syd pax %r ~ ?:(pub %black %white) ~]
+::
 ++  poke-autoload  |=(lod/(unit ?) abet:(poke:autoload lod))
 ++  poke-start-autoload  |=($~ abet:start:autoload)
 ::
@@ -272,6 +279,11 @@
   abet:(emit %wait /kiln/overload/(scot %dr tym) (add ~s10 now))
 ::
 ++  poke-wipe-ford  |=($~ abet:(emit %wipe /kiln our ~))
+::
+++  mack
+  |=  {way/wire saw/(unit tang)}
+  ~?  ?=(^ saw)  [%kiln-nack u.saw]
+  abet
 ::
 ++  take  |=(way/wire ?>(?=({@ $~} way) (work i.way))) ::  general handler
 ++  take-mere                                         ::

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -79,6 +79,12 @@
           {$helm-reset $~}                              ::
       ==                                                ::
     ++  move  (pair bone card)                          ::  user-level move
+    ++  riot                                            ::tmp  up-to-date riot
+      %-  unit
+      $:  p/{p/?($d $p $u $v $w $x $y $z) q/case r/desk}
+          q/path
+          r/cage
+      ==
     --
 |_  moz/(list move)
 ++  abet                                                ::  resolve

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -70,7 +70,7 @@
           {$poke wire dock pear}                        ::
           {$wipe wire @p $~}                            ::
           {$wait wire @da}                              ::
-          {$warp wire ship sock riff}                   ::
+          {$warp wire sock riff}                        ::
       ==                                                ::
     ++  pear                                            ::  poke fruit
       $%  {$hall-command command:hall}                  ::
@@ -222,7 +222,7 @@
   ++  subscribe-next
     %-  emit
     ^-  card
-    :*  %warp  /kiln/autoload  our  [our our]  %home  ~
+    :*  %warp  /kiln/autoload  [our our]  %home  ~
         %next  %z  da+now  /sys
     ==
   ::
@@ -349,7 +349,7 @@
     %-  blab  :_  ~
     :*  ust  %warp
         /kiln/sync/[syd]/(scot %p her)/[sud]
-        our  [our her]  sud  ~
+        [our her]  sud  ~
     ==
   ::
   ++  start-track
@@ -358,7 +358,7 @@
     %-  blab
     :~  :*  ost  %warp
             /kiln/sync/[syd]/(scot %p her)/[sud]
-            our  [our her]  sud  ~  %sing  %y  ud+let  /
+            [our her]  sud  ~  %sing  %y  ud+let  /
     ==  ==
   ::
   ++  start-sync
@@ -367,11 +367,18 @@
     %-  blab
     :~  :*  ost  %warp
             [%kiln %sync syd (scot %p her) sud ?:(reset /reset /)]
-            our  [our her]  sud  ~  %sing  %w  [%da now]  /
+            [our her]  sud  ~  %sing  %w  [%da now]  /
     ==  ==
   ::
   ++  writ
-    |=  {reset/? rot/riot}
+    |=  $:  reset/?
+            $=  rot
+            %-  unit
+            $:  p/{p/?($d $p $u $v $w $x $y $z) q/case r/desk}
+                q/path
+                r/cage
+            ==
+        ==
     ?~  rot
       %^    spam
           leaf+"bad %writ response"
@@ -414,7 +421,7 @@
     %-  blab  :_  ~
     :*  ost  %warp
         /kiln/sync/[syd]/(scot %p her)/[sud]
-        our  [our her]  sud  ~  %sing  %y  ud+let  /
+        [our her]  sud  ~  %sing  %y  ud+let  /
     ==
   --
 ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3536,7 +3536,7 @@
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 =|                                                    ::  instrument state
-    $:  $3                                            ::  vane version
+    $:  $4                                            ::  vane version
         ruf/raft                                      ::  revision tree
     ==                                                ::
 |=  {now/@da eny/@ ski/sley}                          ::  activate
@@ -3767,44 +3767,55 @@
 ::
 ++  load
   =>  |%
-      +=  rove-2
-        $%  {$sing p/mood}
-            {$next p/mood q/(unit (each cage lobe))}
-            {$many p/? q/moat r/(map path lobe)}
+      +=  wove-3  rove
+      ++  cult-3  (jug wove-3 duct)
+      ++  dojo-3
+        $:  qyx/cult-3
+            dom/dome
+            dok/(unit dork)
+            mer/(unit mery)
         ==
-      ++  cult-2  (jug rove-2 duct)
-      ++  dojo-2  (cork dojo |=(a/dojo a(qyx *cult-2)))
-      ++  rede-2  (cork rede |=(a/rede a(qyx *cult-2)))
-      ++  room-2  (cork room |=(a/room a(dos (~(run by dos.a) dojo-2))))
-      ++  rung-2  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-2))))
-      ++  raft-2
-        %+  cork  raft
-        |=(a/raft a(fat (~(run by fat.a) room-2), hoy (~(run by hoy.a) rung-2)))
-      ++  axle    $%({$2 ruf/raft-2} {$3 ruf/raft})
+      ++  rede-3
+        $:  lim/@da
+            ref/(unit rind)
+            qyx/cult-3
+            dom/dome
+            dok/(unit dork)
+            mer/(unit mery)
+        ==
+      ++  room-3  (cork room |=(a/room a(dos (~(run by dos.a) dojo-3))))
+      ++  rung-3  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-3))))
+      ++  raft-3
+        $:  fat/(map ship room-3)
+            hoy/(map ship rung-3)
+            ran/rang
+            mon/(map term beam)
+            hez/(unit duct)
+        ==
+      ++  axle    $%({$3 ruf/raft-3} {$4 ruf/raft})
       --
   |=  old/axle
   ^+  ..^$
   ?-  -.old
-    $3  ..^$(ruf ruf.old)
-    $2  =/  rov
-          |=  a/rove-2  ^-  rove
-          ?+  -.a  a
-              $next
-            ?~  q.a  a
-            a(q `q.a)
-          ==
+    $4  ..^$(ruf ruf.old)
+    $3  =/  wov
+          |=  a/wove-3  ^-  wove
+          [~ a]
         =/  cul
-          |=  a/cult-2  ^-  cult
+          |=  a/cult-3  ^-  cult
           %-  ~(gas by *cult)
-          (turn ~(tap by a) |=({p/rove-2 q/(set duct)} [(rov p) q]))
+          (turn ~(tap by a) |=({p/wove-3 q/(set duct)} [(wov p) q]))
         =/  rom
-          =+  doj=|=(a/dojo-2 a(qyx (cul qyx.a)))
-          |=(a/room-2 a(dos (~(run by dos.a) doj)))
+          =+  doj=|=(dojo-3 [(cul qyx) dom dok mer ~ ~])
+          |=(a/room-3 a(dos (~(run by dos.a) doj)))
         =/  run
-          =+  red=|=(a/rede-2 a(qyx (cul qyx.a)))
-          |=(a/rung-2 a(rus (~(run by rus.a) red)))
-        =+  r=ruf.old
-        $(old [%3 r(fat (~(run by fat.r) rom), hoy (~(run by hoy.r) run))])
+          =/  red
+            |=  rede-3
+            =+  [[/ %black ~] ~ ~]
+            [lim ref (cul qyx) dom dok mer - -]
+          |=(a/rung-3 a(rus (~(run by rus.a) red)))
+        =+  ruf.old
+        $(old [%4 [(~(run by fat) rom) (~(run by hoy) run) ran mon hez ~]])
   ==
 ::
 ++  scry                                              ::  inspect
@@ -3836,7 +3847,7 @@
   ?:  ?=($& -.u.u.-)  ``p.u.u.-
   ~
 ::
-++  stay  [%3 ruf]
+++  stay  [%4 ruf]
 ++  take                                              ::  accept response
   |=  {tea/wire hen/duct hin/(hypo sign)}
   ^+  [p=*(list move) q=..^$]

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -329,7 +329,8 @@
       $:  $c                                            ::  to %clay
   $%  {$info p/@p q/@tas r/nori}                        ::  internal edit
       {$merg p/@p q/@tas r/@p s/@tas t/case u/germ}     ::  merge desks
-      {$warp p/ship q/sock r/riff}                      ::
+      {$warp p/sock q/riff}                             ::
+      {$werp p/ship q/sock r/riff}                      ::
   ==  ==                                                ::
       $:  $d                                            ::
   $%  {$flog p/{$crud p/@tas q/(list tank)}}            ::  to %dill
@@ -2777,7 +2778,7 @@
         %-  emit(wat.dat %ali)
         :*  hen  %pass
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %ali ~]
-            %c  %warp  p.bob  [p.bob p.ali]  q.ali
+            %c  %warp  [p.bob p.ali]  q.ali
             `[%sing %v cas.dat /]
         ==
       ::
@@ -3707,9 +3708,16 @@
       abet:(perm:den pax.q.hic rit.q.hic)
     [mos ..^$]
   ::
-      $warp
+      ?($warp $werp)
+    =^  for  q.hic
+      ?:  ?=($warp -.q.hic)
+        [~ q.hic]
+      :_  [%warp q.q.hic r.q.hic]
+      ?:  =(p.q.hic p.q.q.hic)  ~&([%huh-this-west-may-be-weird p.q.hic] ~)
+      `p.q.hic
+    ?>  ?=($warp -.q.hic)
     =^  mos  ruf
-      =+  den=((de now hen ruf) q.q.hic p.r.q.hic)
+      =+  den=((de now hen ruf) p.q.hic p.q.q.hic)
       ::  =-  ~?  ?=([~ %sing %w *] q.r.q.hic)
       ::        :*  %someones-warping
       ::            rav=u.q.r.q.hic
@@ -3717,10 +3725,9 @@
       ::        ==
       ::      -
       =<  abet
-      ?~  q.r.q.hic
+      ?~  q.q.q.hic
         cancel-request:den
-      =+  for=?:(=(p.q.hic p.q.q.hic) ~ `p.q.hic)
-      (start-request:den for u.q.r.q.hic)
+      (start-request:den for u.q.q.q.hic)
     [mos ..^$]
   ::
       $went
@@ -3735,7 +3742,7 @@
           :-  hen
           :^  %pass  [(scot %p p.p.q.hic) (scot %p q.p.q.hic) t.q.q.hic]
             %c
-          [%warp q.p.q.hic [p.p.q.hic p.p.q.hic] ryf]
+          [%werp q.p.q.hic [p.p.q.hic p.p.q.hic] ryf]
       ==
     ?>  ?=({$answer @ @ $~} q.q.hic)
     =+  syd=(slav %tas i.t.q.q.hic)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2241,6 +2241,8 @@
       |=  {for/(unit ship) yon/aeon pax/path}
       ^-  (map path lobe)
       ?:  =(0 yon)  ~
+      ::  we use %z for the check because it looks at all child paths.
+      ?:  |(?=($~ for) (may-read u.for %z yon pax))  ~
       %-  malt
       %+  skim
         %~  tap  by

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3550,36 +3550,37 @@
   |=  $:  hen/duct
           hic/(hypo (hobo task:able))
       ==
+  =*  req  q.hic
   =>  %=    .                                         ::  XX temporary
-          q.hic
+          req
         ^-  task:able
-        ?:  ?=($soft -.q.hic)
+        ?:  ?=($soft -.req)
           =+
-          ~|([%bad-soft (@t -.p.q.hic)] ((soft task:able) p.q.hic))
+          ~|([%bad-soft (@t -.p.req)] ((soft task:able) p.req))
           ?~  -
-            ~&  [%bad-softing (@t -.p.q.hic)]  !!
+            ~&  [%bad-softing (@t -.p.req)]  !!
           u.-
-        ?:  (~(nest ut -:!>(*task:able)) | p.hic)  q.hic
-        ~&  [%clay-call-flub (@tas `*`-.q.hic)]
-        ((hard task:able) q.hic)
+        ?:  (~(nest ut -:!>(*task:able)) | p.hic)  req
+        ~&  [%clay-call-flub (@tas `*`-.req)]
+        ((hard task:able) req)
       ==
   ^+  [p=*(list move) q=..^$]
-  ?-    -.q.hic
+  ?-    -.req
       $boat
     :_  ..^$
     [hen %give %hill (turn ~(tap by mon.ruf) head)]~
   ::.
       $cred
     =.  cez.ruf
-      ?~  cew.q.hic  (~(del by cez.ruf) nom.q.hic)
-      (~(put by cez.ruf) nom.q.hic cew.q.hic)
+      ?~  cew.req  (~(del by cez.ruf) nom.req)
+      (~(put by cez.ruf) nom.req cew.req)
     ::  wake all desks, a request may have been affected.
     =|  mos/(list move)
-    =+  rom=(fall (~(get by fat.ruf) our.q.hic) *room)
+    =+  rom=(fall (~(get by fat.ruf) our.req) *room)
     =+  des=~(tap in ~(key by dos.rom))
     |-
     ?~  des  [[[hen %give %mack ~] mos] ..^^$]
-    =+  den=((de now hen ruf) [. .]:our.q.hic i.des)
+    =+  den=((de now hen ruf) [. .]:our.req i.des)
     =^  mor  ruf  abet:wake:den
     $(des t.des, mos (weld mos mor))
   ::
@@ -3588,28 +3589,28 @@
   ::
       $drop
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.req q.req)
       abet:drop-me:den
     [mos ..^$]
   ::
       $info
-    ?:  =(%$ q.q.hic)
+    ?:  =(%$ q.req)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
-      abet:(edit:den now r.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.req q.req)
+      abet:(edit:den now r.req)
     [mos ..^$]
   ::
       $init
     :_  %_    ..^$
             fat.ruf
-          ?<  (~(has by fat.ruf) p.q.hic)
-          (~(put by fat.ruf) p.q.hic [-(hun hen)]:[*room .])
+          ?<  (~(has by fat.ruf) p.req)
+          (~(put by fat.ruf) p.req [-(hun hen)]:[*room .])
         ==
-    =+  [bos=(sein:title p.q.hic) can=(clan:title p.q.hic)]
+    =+  [bos=(sein:title p.req) can=(clan:title p.req)]
     %-  zing  ^-  (list (list move))
-    :~  ?:  =(bos p.q.hic)  ~
-        [hen %pass /init-merge %c %merg p.q.hic %base bos %kids da+now %init]~
+    :~  ?:  =(bos p.req)  ~
+        [hen %pass /init-merge %c %merg p.req %base bos %kids da+now %init]~
     ::
         ~
     ==
@@ -3617,9 +3618,9 @@
       $into
     =.  hez.ruf  `hen
     :_  ..^$
-    =+  bem=(~(get by mon.ruf) p.q.hic)
-    ?:  &(?=($~ bem) !=(%$ p.q.hic))
-      ~|([%bad-mount-point-from-unix p.q.hic] !!)
+    =+  bem=(~(get by mon.ruf) p.req)
+    ?:  &(?=($~ bem) !=(%$ p.req))
+      ~|([%bad-mount-point-from-unix p.req] !!)
     =+  ^-  bem/beam
         ?^  bem
           u.bem
@@ -3631,7 +3632,7 @@
     ?~  dos
       ~
     ?:  =(0 let.dom.u.dos)
-      =+  cos=(mode-to-soba ~ s.bem q.q.hic r.q.hic)
+      =+  cos=(mode-to-soba ~ s.bem q.req r.req)
       =+  ^-  {one/(list {path miso}) two/(list {path miso})}
           %+  skid  cos
           |=  {a/path b/miso}
@@ -3643,85 +3644,85 @@
           [hen %pass /two %c %info p.bem q.bem %& two]
       ==
     =+  yak=(~(got by hut.ran.ruf) (~(got by hit.dom.u.dos) let.dom.u.dos))
-    =+  cos=(mode-to-soba q.yak (flop s.bem) q.q.hic r.q.hic)
+    =+  cos=(mode-to-soba q.yak (flop s.bem) q.req r.req)
     [hen %pass /both %c %info p.bem q.bem %& cos]~
   ::
       $merg                                               ::  direct state up
-    ?:  =(%$ q.q.hic)
+    ?:  =(%$ q.req)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
-      abet:abet:(start:(me:ze:den [r.q.hic s.q.hic] ~ &) t.q.hic u.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.req q.req)
+      abet:abet:(start:(me:ze:den [r.req s.req] ~ &) t.req u.req)
     [mos ..^$]
   ::
       $mont
     =.  hez.ruf  ?^(hez.ruf hez.ruf `[[%$ %sync ~] ~])
-    =+  pot=(~(get by mon.ruf) p.q.hic)
+    =+  pot=(~(get by mon.ruf) p.req)
     ?^  pot
       ~&  [%already-mounted pot]
       [~ ..^$]
     =.  mon.ruf
-      (~(put by mon.ruf) p.q.hic [p.q.q.hic q.q.q.hic r.q.q.hic] s.q.q.hic)
-    =+  yar=(~(get by fat.ruf) p.q.q.hic)
+      (~(put by mon.ruf) p.req [p.q.req q.q.req r.q.req] s.q.req)
+    =+  yar=(~(get by fat.ruf) p.q.req)
     ?~  yar
       [~ ..^$]
-    =+  dos=(~(get by dos.u.yar) q.q.q.hic)
+    =+  dos=(~(get by dos.u.yar) q.q.req)
     ?~  dos
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.q.hic q.q.q.hic)
-      abet:(mont:den p.q.hic q.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.q.req q.q.req)
+      abet:(mont:den p.req q.req)
     [mos ..^$]
   ::
       $dirk
     ?~  hez.ruf
       ~&  %no-sync-duct
       [~ ..^$]
-    ?.  (~(has by mon.ruf) p.q.hic)
-      ~&  [%not-mounted p.q.hic]
+    ?.  (~(has by mon.ruf) p.req)
+      ~&  [%not-mounted p.req]
       [~ ..^$]
-    :-  ~[[u.hez.ruf %give %dirk p.q.hic]]
+    :-  ~[[u.hez.ruf %give %dirk p.req]]
         ..^$
   ::
       $ogre
     ?~  hez.ruf
       ~&  %no-sync-duct
       [~ ..^$]
-    ?@  p.q.hic
-      ?.  (~(has by mon.ruf) p.q.hic)
-        ~&  [%not-mounted p.q.hic]
+    ?@  p.req
+      ?.  (~(has by mon.ruf) p.req)
+        ~&  [%not-mounted p.req]
         [~ ..^$]
-      :_  ..^$(mon.ruf (~(del by mon.ruf) p.q.hic))
-      [u.hez.ruf %give %ogre p.q.hic]~
+      :_  ..^$(mon.ruf (~(del by mon.ruf) p.req))
+      [u.hez.ruf %give %ogre p.req]~
     :_  %_    ..^$
             mon.ruf
           %-  molt
           %+  skip  ~(tap by mon.ruf)
-          (corl (cury test p.q.hic) tail)
+          (corl (cury test p.req) tail)
         ==
     %+  turn
-      (skim ~(tap by mon.ruf) (corl (cury test p.q.hic) tail))
+      (skim ~(tap by mon.ruf) (corl (cury test p.req) tail))
     |=  {pot/term bem/beam}
     [u.hez.ruf %give %ogre pot]
   ::
       $perm
     =^  mos  ruf
       ::TODO  after new boot system, just use our from global.
-      =+  den=((de now hen ruf) [. .]:our.q.hic des.q.hic)
-      abet:(perm:den pax.q.hic rit.q.hic)
+      =+  den=((de now hen ruf) [. .]:our.req des.req)
+      abet:(perm:den pax.req rit.req)
     [mos ..^$]
   ::
       ?($warp $werp)
-    =^  for  q.hic
-      ?:  ?=($warp -.q.hic)
-        [~ q.hic]
-      :_  [%warp q.q.hic r.q.hic]
-      ?:  =(p.q.hic p.q.q.hic)  ~
-      `p.q.hic
-    ?>  ?=($warp -.q.hic)
-    =*  rif  q.q.hic
+    =^  for  req
+      ?:  ?=($warp -.req)
+        [~ req]
+      :_  [%warp q.req r.req]
+      ?:  =(p.req p.q.req)  ~
+      `p.req
+    ?>  ?=($warp -.req)
+    =*  rif  q.req
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.q.hic p.rif)
+      =+  den=((de now hen ruf) p.req p.rif)
       =<  abet
       ?~  q.rif
         cancel-request:den
@@ -3733,21 +3734,21 @@
     !!
   ::
       $west
-    ?:  ?=({$question *} q.q.hic)
-      =+  ryf=((hard riff) r.q.hic)
+    ?:  ?=({$question *} q.req)
+      =+  ryf=((hard riff) r.req)
       :_  ..^$
       :~  [hen %give %mack ~]
           :-  hen
-          :^  %pass  [(scot %p p.p.q.hic) (scot %p q.p.q.hic) t.q.q.hic]
+          :^  %pass  [(scot %p p.p.req) (scot %p q.p.req) t.q.req]
             %c
-          [%werp q.p.q.hic [p.p.q.hic p.p.q.hic] ryf]
+          [%werp q.p.req [p.p.req p.p.req] ryf]
       ==
-    ?>  ?=({$answer @ @ $~} q.q.hic)
-    =+  syd=(slav %tas i.t.q.q.hic)
-    =+  inx=(slav %ud i.t.t.q.q.hic)
+    ?>  ?=({$answer @ @ $~} q.req)
+    =+  syd=(slav %tas i.t.q.req)
+    =+  inx=(slav %ud i.t.t.q.req)
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.q.hic syd)
-      abet:(take-foreign-update:den inx ((hard (unit rand)) r.q.hic))
+      =+  den=((de now hen ruf) p.req syd)
+      abet:(take-foreign-update:den inx ((hard (unit rand)) r.req))
     [[[hen %give %mack ~] mos] ..^$]
   ::
       $wegh

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3622,6 +3622,27 @@
       $crew
     [[hen %give %cruz cez.ruf]~ ..^$]
   ::
+      $crow
+    =+  rom=(fall (~(get by fat.ruf) our.req) *room)
+    =+  des=~(tap by dos.rom)
+    =|  rus/(map desk {r/regs w/regs})
+    |^
+      ?~  des  [[hen %give %croz rus]~ ..^^$]
+      =+  per=(filter-rules per.q.i.des)
+      =+  pew=(filter-rules pew.q.i.des)
+      $(des t.des, rus (~(put by rus) p.i.des per pew))
+    ::
+    ++  filter-rules
+      |=  pes/regs
+      ^+  pes
+      =-  (~(gas in *regs) -)
+      %+  murn  ~(tap by pes)
+      |=  {p/path r/rule}
+      ^-  (unit (pair path rule))
+      ?.  (~(has in who.r) |+nom.req)  ~
+      `[p r]
+    --
+  ::
       $drop
     =^  mos  ruf
       =+  den=((de now hen ruf) [. .]:our.req des.req)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -792,6 +792,23 @@
         (lobe-to-silk:ze a p.-)
     ==
   ::
+  ::  Set permissions for a node.
+  ::
+  ++  perm
+    |=  {pax/path rit/rite}
+    ^+  +>
+    =<  (emit hen %give %mack ~)
+    ?-  -.rit
+      $r    wake(per (put-perm per pax red.rit))
+      $w    wake(pew (put-perm pew pax wit.rit))
+      $rw   wake(per (put-perm per pax red.rit), pew (put-perm pew pax wit.rit))
+    ==
+  ::
+  ++  put-perm
+    |=  {pes/(map path rule) pax/path new/(unit rule)}
+    ?~  new  (~(del by pes) pax)
+    (~(put by pes) pax u.new)
+  ::
   ::  Cancel a request.
   ::
   ::  For local requests, we just remove it from `qyx`.  For foreign requests,
@@ -3586,6 +3603,13 @@
       (skim ~(tap by mon.ruf) (corl (cury test p.q.hic) tail))
     |=  {pot/term bem/beam}
     [u.hez.ruf %give %ogre pot]
+  ::
+      $perm
+    =^  mos  ruf
+      ::TODO  after new boot system, just use our from global.
+      =+  den=((de now hen ~ ruf) [. .]:our.q.hic des.q.hic)
+      abet:(perm:den pax.q.hic rit.q.hic)
+    [mos ..^$]
   ::
       $warp
     =^  mos  ruf

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -818,6 +818,21 @@
     ?~  new  (~(del by pes) pax)
     (~(put by pes) pax u.new)
   ::
+  ::  Remove a group from all rules.
+  ::
+  ++  forget-crew
+    |=  nom/@ta
+    %=  +>
+      per  (forget-crew-in nom per)
+      pew  (forget-crew-in nom pew)
+    ==
+  ::
+  ++  forget-crew-in
+    |=  {nom/@ta rus/(map path rule)}
+    %-  ~(run by rus)
+    |=  r/rule
+    r(who (~(del in who.r) |+nom))
+  ::
   ::  Cancel a request.
   ::
   ::  For local requests, we just remove it from `qyx`.  For foreign requests,
@@ -3581,7 +3596,10 @@
     |-
     ?~  des  [[[hen %give %mack ~] mos] ..^^$]
     =+  den=((de now hen ruf) [. .]:our.req i.des)
-    =^  mor  ruf  abet:wake:den
+    =^  mor  ruf
+      =<  abet:wake
+      ?:  ?=(^ cew.req)  den
+      (forget-crew:den nom.req)
     $(des t.des, mos (weld mos mor))
   ::
       $crew

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -56,7 +56,7 @@
 ::  A map of requests to a set of all the subscribers who should be notified
 ::  when the request is filled/updated.
 ::
-++  cult  (jug rove duct)
+++  cult  (jug wove duct)
 ::
 ::  Domestic desk state.
 ::
@@ -277,6 +277,7 @@
 ::  Generally used when we store a request in our state somewhere.
 ::
 ++  cach  (unit (unit (each cage lobe)))                ::  cached result
+++  wove  {p/(unit ship) q/rove}                        ::  stored source + req
 ++  rove                                                ::  stored request
           $%  {$sing p/mood}                            ::  single request
               {$next p/mood q/cach}                     ::  next version
@@ -413,9 +414,9 @@
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 |%
 ++  de                                                  ::  per desk
-  |=  {now/@da hen/duct for/(unit ship) raft}
+  |=  {now/@da hen/duct raft}
   |=  {{our/@p her/@p} syd/desk}
-  =*  ruf  +>+<+>+
+  =*  ruf  +>+<+>
   =+  ^-  {hun/(unit duct) rede}
       =+  rom=(~(get by fat.ruf) her)
       ?~  rom
@@ -458,14 +459,14 @@
   ::  Handle `%sing` requests
   ::
   ++  aver
-    |=  mun/mood
+    |=  {for/(unit ship) mun/mood}
     ^-  (unit (unit (each cage lobe)))
     =+  ezy=?~(ref ~ (~(get by haw.u.ref) mun))
     ?^  ezy
       `(bind u.ezy |=(a/cage [%& a]))
     =+  nao=(case-to-aeon:ze q.mun)
     ::  ~&  [%aver-mun nao [%from syd lim q.mun]]
-    ?~(nao ~ (read-at-aeon:ze u.nao mun))
+    ?~(nao ~ (read-at-aeon:ze for u.nao mun))
   ::
   ++  ford-fail  |=(tan/tang ~|(%ford-fail (mean tan)))
   ::
@@ -662,14 +663,14 @@
   ::  foreign ship.
   ::
   ++  duce                                              ::  produce request
-    |=  rov/rove
+    |=  wov/wove
     ^+  +>
-    =.  rov  (dedupe rov)
-    =.  qyx  (~(put ju qyx) rov hen)
+    =.  wov  (dedupe wov)
+    =.  qyx  (~(put ju qyx) wov hen)
     ?~  ref
-      (mabe rov |=(@da (bait hen +<)))
+      (mabe q.wov |=(@da (bait hen +<)))
     |-  ^+  +>+.$
-    =+  rav=(reve rov)
+    =+  rav=(reve q.wov)
     =+  ^=  vaw  ^-  rave
       ?.  ?=({$sing $v *} rav)  rav
       [%many %| [%ud let.dom] `case`q.p.rav r.p.rav]
@@ -691,17 +692,21 @@
   ::  all get filled at once.
   ::
   ++  dedupe                                            ::  find existing alias
-    |=  rov/rove  ^-  rove
-    =;  ron/(unit rove)  (fall ron rov)
+    |=  wov/wove
+    ^-  wove
+    =;  won/(unit wove)  (fall won wov)
+    =*  rov  q.wov
     ?-    -.rov
         $sing  ~
         $next
       =+  aey=(case-to-aeon:ze q.p.rov)
       ?~  aey  ~
-      %+  roll  ~(tap in ~(key by qyx))
-      |=  {hav/rove res/(unit rove)}
+      %-  ~(rep in ~(key by qyx))
+      |=  {haw/wove res/(unit wove)}
       ?^  res  res
-      =-  ?:(- `hav ~)
+      ?.  =(p.wov p.haw)  ~
+      =*  hav  q.haw
+      =-  ?:(- `haw ~)
       ?&  ?=($next -.hav)
           =(p.hav p.rov(q q.p.hav))
         ::
@@ -714,10 +719,12 @@
         $mult
       =+  aey=(case-to-aeon:ze p.p.rov)
       ?~  aey  ~
-      %+  roll  ~(tap in ~(key by qyx))
-      |=  {hav/rove res/(unit rove)}
+      %-  ~(rep in ~(key by qyx))
+      |=  {haw/wove res/(unit wove)}
       ?^  res  res
-      =-  ?:(- `hav ~)
+      ?.  =(p.wov p.haw)  ~
+      =*  hav  q.haw
+      =-  ?:(- `haw ~)
       ?&  ?=($mult -.hav)
           =(p.hav p.rov(p p.p.hav))
         ::
@@ -735,10 +742,12 @@
         $many
       =+  aey=(case-to-aeon:ze p.q.rov)
       ?~  aey  ~
-      %+  roll  ~(tap in ~(key by qyx))
-      |=  {hav/rove res/(unit rove)}
+      %-  ~(rep in ~(key by qyx))
+      |=  {haw/wove res/(unit wove)}
       ?^  res  res
-      =-  ?:(- `hav ~)
+      ?.  =(p.wov p.haw)  ~
+      =*  hav  q.haw
+      =-  ?:(- `haw ~)
       ?&  ?=($many -.hav)
           =(hav rov(p.q p.q.hav))
         ::
@@ -816,17 +825,17 @@
   ::
   ++  cancel-request                                    ::  release request
     ^+  .
-    =^  ros/(list rove)  qyx
+    =^  wos/(list wove)  qyx
       :_  (~(run by qyx) |=(a/(set duct) (~(del in a) hen)))
       %-  ~(rep by qyx)
-      |=  {{a/rove b/(set duct)} c/(list rove)}
+      |=  {{a/wove b/(set duct)} c/(list wove)}
       ?.((~(has in b) hen) c [a c])
     ?~  ref
       =>  .(ref `(unit rind)`ref)     ::  XX TMI
-      ?:  =(~ ros)  +                                        ::  XX handle?
+      ?:  =(~ wos)  +                                        ::  XX handle?
       |-  ^+  +>
-      ?~  ros  +>
-      $(ros t.ros, +> (mabe i.ros |=(@da (best hen +<))))
+      ?~  wos  +>
+      $(wos t.wos, +> (mabe q.i.wos |=(@da (best hen +<))))
     ^+  ..cancel-request
     =+  nux=(~(get by fod.u.ref) hen)
     ?~  nux  ..cancel-request
@@ -844,13 +853,13 @@
   ::  and then waiting if the subscription range extends into the future.
   ::
   ++  start-request
-    |=  rav/rave
+    |=  {for/(unit ship) rav/rave}
     ^+  +>
     ?-    -.rav
         $sing
-      =+  ver=(aver p.rav)
+      =+  ver=(aver for p.rav)
       ?~  ver
-        (duce rav)
+        (duce for rav)
       ?~  u.ver
         (blub hen)
       (blab hen p.rav u.u.ver)
@@ -903,9 +912,11 @@
                 new/(map (pair care path) cach)
             ==
         ^+  ..start-request
+        %+  duce  for
+        ^-  rove
         ?:  ?=($mult -.rav)
-          (duce -.rav p.rav nex old new)
-        %^  duce  -.rav  p.rav
+          [-.rav p.rav nex old new]
+        :+  -.rav  p.rav
         =+  ole=~(tap by old)
         ?>  (lte (lent ole) 1)
         ?~  ole  ~
@@ -929,26 +940,26 @@
         %+  turn  ~(tap by req)
         |=  {c/care p/path}
         ^-  (pair (pair care path) cach)
-        [[c p] (aver c cas p)]
+        [[c p] (aver for c cas p)]
       --
     ::
         $many
       =+  nab=(case-to-aeon:ze p.q.rav)
       ?~  nab
         ?>  =(~ (case-to-aeon:ze q.q.rav))
-        (duce [- p q ~]:rav)
+        (duce for [- p q ~]:rav)
       =+  huy=(case-to-aeon:ze q.q.rav)
       ?:  &(?=(^ huy) |((lth u.huy u.nab) &(=(0 u.huy) =(0 u.nab))))
         (blub hen)
       =+  top=?~(huy let.dom u.huy)
-      =+  ear=(lobes-at-path:ze top r.q.rav)
+      =+  ear=(lobes-at-path:ze for top r.q.rav)
       =.  +>.$
         (bleb hen u.nab ?:(p.rav ~ `[u.nab top]))
       ?^  huy
         (blub hen)
       =+  ^=  ptr  ^-  case
           [%ud +(let.dom)]
-      (duce `rove`[%many p.rav [ptr q.q.rav r.q.rav] ear])
+      (duce for `rove`[%many p.rav [ptr q.q.rav r.q.rav] ear])
     ==
   ::
   ::  Print a summary of changes to dill.
@@ -1774,32 +1785,34 @@
   ++  wake                                            ::  update subscribers
     ^+  .
     =+  xiq=~(tap by qyx)
-    =|  xaq/(list {p/rove q/(set duct)})
+    =|  xaq/(list {p/wove q/(set duct)})
     |-  ^+  ..wake
     ?~  xiq
       ..wake(qyx (~(gas by *cult) xaq))
     ?:  =(~ q.i.xiq)  $(xiq t.xiq, xaq xaq)           :: drop forgotten
-    ?-    -.p.i.xiq
+    =*  for  p.p.i.xiq
+    =*  rov  q.p.i.xiq
+    ?-    -.rov
         $sing
-      =+  cas=?~(ref ~ (~(get by haw.u.ref) `mood`p.p.i.xiq))
+      =+  cas=?~(ref ~ (~(get by haw.u.ref) `mood`p.rov))
       ?^  cas
         %=    $
             xiq  t.xiq
             ..wake  ?~  u.cas  (blub-all q.i.xiq ~)
-                    (blab-all q.i.xiq p.p.i.xiq %& u.u.cas)
+                    (blab-all q.i.xiq p.rov %& u.u.cas)
         ==
-      =+  nao=(case-to-aeon:ze q.p.p.i.xiq)
+      =+  nao=(case-to-aeon:ze q.p.rov)
       ?~  nao  $(xiq t.xiq, xaq [i.xiq xaq])
       ::  ~&  %reading-at-aeon
-      =+  vid=(read-at-aeon:ze u.nao p.p.i.xiq)
+      =+  vid=(read-at-aeon:ze for u.nao p.rov)
       ::  ~&  %red-at-aeon
       ?~  vid
         ::  ?:  =(0 u.nao)
-        ::    ~&  [%oh-poor `path`[syd '0' r.p.p.i.xiq]]
+        ::    ~&  [%oh-poor `path`[syd '0' r.p.rov]]
         ::    $(xiq t.xiq)
-        ::  ~&  [%oh-well desk=syd mood=p.p.i.xiq aeon=u.nao]
+        ::  ~&  [%oh-well desk=syd mood=p.rov aeon=u.nao]
         $(xiq t.xiq, xaq [i.xiq xaq])
-      $(xiq t.xiq, ..wake (balk-all q.i.xiq u.vid p.p.i.xiq))
+      $(xiq t.xiq, ..wake (balk-all q.i.xiq u.vid p.rov))
     ::
     ::  %next is just %mult with one path, so we pretend %next = %mult here.
         ?($next $mult)
@@ -1808,7 +1821,7 @@
       ::  {old} is the revision at {(dec yon)}, {new} is the revision at {yon}.
       ::  if we have no {yon} yet, that means it was still unknown last time
       ::  we checked.
-      =*  vor  p.i.xiq
+      =*  vor  rov
       |^
       =/  rov/rove
         ?:  ?=($mult -.vor)  vor
@@ -1874,7 +1887,7 @@
       ++  store                                         ::  check again later
         |=  rov/rove
         ^+  ..wake
-        =-  ^^$(xiq t.xiq, xaq [i.xiq(p -) xaq])
+        =-  ^^$(xiq t.xiq, xaq [i.xiq(p [for -]) xaq])
         ?>  ?=($mult -.rov)
         ?:  ?=($mult -.vor)  rov
         ?>  ?=({* $~ $~} r.rov)
@@ -1901,7 +1914,7 @@
       ++  read-unknown                                  ::  fill in the blanks
         |=  {mol/mool hav/(map (pair care path) cach)}
         %.  |=  {{c/care p/path} o/cach}
-            ?^(o o (aver c p.mol p))
+            ?^(o o (aver for c p.mol p))
         =-  ~(urn by -)
         ?^  hav  hav
         %-  ~(gas by *(map (pair care path) cach))
@@ -1909,8 +1922,8 @@
       --
     ::
         $many
-      =+  mot=`moat`q.p.i.xiq
-      =*  sav  r.p.i.xiq
+      =+  mot=`moat`q.rov
+      =*  sav  r.rov
       =+  nab=(case-to-aeon:ze p.mot)
       ?~  nab
         $(xiq t.xiq, xaq [i.xiq xaq])
@@ -1919,19 +1932,19 @@
         =.  p.mot  [%ud +(let.dom)]
         %=  $
           xiq     t.xiq
-          xaq     [i.xiq(q.p mot) xaq]
+          xaq     [i.xiq(q.q.p mot) xaq]
           ..wake  =+  ^=  ear
-                      (lobes-at-path:ze let.dom r.mot)
+                      (lobes-at-path:ze for let.dom r.mot)
                   ?:  =(sav ear)  ..wake
-                  (bleb-all q.i.xiq let.dom ?:(p.p.i.xiq ~ `[u.nab let.dom]))
+                  (bleb-all q.i.xiq let.dom ?:(p.rov ~ `[u.nab let.dom]))
         ==
       %=  $
         xiq     t.xiq
         ..wake  =-  (blub-all:- q.i.xiq ~)
                 =+  ^=  ear
-                    (lobes-at-path:ze u.huy r.mot)
+                    (lobes-at-path:ze for u.huy r.mot)
                 ?:  =(sav ear)  (blub-all q.i.xiq ~)
-                (bleb-all q.i.xiq +(u.nab) ?:(p.p.i.xiq ~ `[u.nab u.huy]))
+                (bleb-all q.i.xiq +(u.nab) ?:(p.rov ~ `[u.nab u.huy]))
       ==
     ==
   ++  drop-me
@@ -2221,7 +2234,7 @@
     ::  Gets a map of the data at the given path and all children of it.
     ::
     ++  lobes-at-path
-      |=  {yon/aeon pax/path}
+      |=  {for/(unit ship) yon/aeon pax/path}
       ^-  (map path lobe)
       ?:  =(0 yon)  ~
       %-  malt
@@ -2488,7 +2501,7 @@
     ::  Should change last few lines to an explicit ++read-w.
     ::
     ++  read-at-aeon                                    ::    read-at-aeon:ze
-      |=  {yon/aeon mun/mood}                           ::  seek and read
+      |=  {for/(unit ship) yon/aeon mun/mood}           ::  seek and read
       ^-  (unit (unit (each cage lobe)))
       ?:  &(?=($w p.mun) !?=($ud -.q.mun))              ::  NB only her speed
         ?^(r.mun [~ ~] [~ ~ %& %aeon !>(yon)])
@@ -3488,7 +3501,7 @@
   ::
       $drop
     =^  mos  ruf
-      =+  den=((de now hen ~ ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
       abet:drop-me:den
     [mos ..^$]
   ::
@@ -3496,7 +3509,7 @@
     ?:  =(%$ q.q.hic)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ~ ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
       abet:(edit:den now r.q.hic)
     [mos ..^$]
   ::
@@ -3550,7 +3563,7 @@
     ?:  =(%$ q.q.hic)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ~ ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
       abet:abet:(start:(me:ze:den [r.q.hic s.q.hic] ~ &) t.q.hic u.q.hic)
     [mos ..^$]
   ::
@@ -3569,7 +3582,7 @@
     ?~  dos
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ~ ruf) [. .]:p.q.q.hic q.q.q.hic)
+      =+  den=((de now hen ruf) [. .]:p.q.q.hic q.q.q.hic)
       abet:(mont:den p.q.hic q.q.hic)
     [mos ..^$]
   ::
@@ -3607,14 +3620,13 @@
       $perm
     =^  mos  ruf
       ::TODO  after new boot system, just use our from global.
-      =+  den=((de now hen ~ ruf) [. .]:our.q.hic des.q.hic)
+      =+  den=((de now hen ruf) [. .]:our.q.hic des.q.hic)
       abet:(perm:den pax.q.hic rit.q.hic)
     [mos ..^$]
   ::
       $warp
     =^  mos  ruf
-      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~&(%local-warp ~) `q.p.q.hic)
-      =+  den=((de now hen for ruf) p.q.hic p.q.q.hic)
+      =+  den=((de now hen ruf) p.q.hic p.q.q.hic)
       ::  =-  ~?  ?=([~ %sing %w *] q.q.q.hic)
       ::        :*  %someones-warping
       ::            rav=u.q.q.q.hic
@@ -3624,7 +3636,8 @@
       =<  abet
       ?~  q.q.q.hic
         cancel-request:den
-      (start-request:den u.q.q.q.hic)
+      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~&(%local-warp ~) `q.p.q.hic)
+      (start-request:den for u.q.q.q.hic)
     [mos ..^$]
   ::
       $went
@@ -3639,14 +3652,14 @@
           :-  hen
           :^  %pass  [(scot %p p.p.q.hic) (scot %p q.p.q.hic) t.q.q.hic]
             %c
+          ::TODO  ...so, this circumvents permission checks?
           [%warp [p.p.q.hic p.p.q.hic] ryf]
       ==
     ?>  ?=({$answer @ @ $~} q.q.hic)
     =+  syd=(slav %tas i.t.q.q.hic)
     =+  inx=(slav %ud i.t.t.q.q.hic)
     =^  mos  ruf
-      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~&(%local-west ~) `q.p.q.hic)
-      =+  den=((de now hen for ruf) p.q.hic syd)
+      =+  den=((de now hen ruf) p.q.hic syd)
       abet:(take-foreign-update:den inx ((hard (unit rand)) r.q.hic))
     [[[hen %give %mack ~] mos] ..^$]
   ::
@@ -3734,8 +3747,8 @@
     ?:  ?=($| -.m)  ~
     ?:  =(p.m his)  ~
     `p.m
-  =+  den=((de now [/scryduct ~] ?:(=(for `his) ~ for) ruf) [. .]:his syd)
-  =+  (aver:den u.run u.luk tyl)
+  =+  den=((de now [/scryduct ~] ruf) [. .]:his syd)
+  =+  (aver:den for u.run u.luk tyl)
   ?~  -               -
   ?~  u.-             -
   ?:  ?=($& -.u.u.-)  ``p.u.u.-
@@ -3760,7 +3773,7 @@
         |=  dojo
         dom
     =^  mos  ruf
-      =+  den=((de now hen ~ ruf) [. .]:our syd)
+      =+  den=((de now hen ruf) [. .]:our syd)
       abet:abet:(route:(me:ze:den [her sud] kan |) sat dat)
     [mos ..^$]
   ?:  ?=({$blab care @ @ *} tea)
@@ -3791,7 +3804,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [. .]:our syd)
+        =+  den=((de now hen ruf) [. .]:our syd)
         abet:(take-inserting:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3801,7 +3814,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [. .]:our syd)
+        =+  den=((de now hen ruf) [. .]:our syd)
         abet:(take-diffing:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3811,7 +3824,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [. .]:our syd)
+        =+  den=((de now hen ruf) [. .]:our syd)
         abet:(take-castify:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3821,7 +3834,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [. .]:our syd)
+        =+  den=((de now hen ruf) [. .]:our syd)
         abet:(take-mutating:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3830,7 +3843,7 @@
       =+  our=(slav %p i.t.tea)
       =+  syd=(slav %tas i.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [. .]:our syd)
+        =+  den=((de now hen ruf) [. .]:our syd)
         abet:(take-patch:den q.q.hin)
       [mos ..^$]
     ::
@@ -3839,7 +3852,7 @@
       =+  our=(slav %p i.t.tea)
       =+  syd=(slav %tas i.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [. .]:our syd)
+        =+  den=((de now hen ruf) [. .]:our syd)
         abet:(take-ergo:den q.q.hin)
       [mos ..^$]
     ::
@@ -3850,7 +3863,7 @@
       =*  syd  i.t.t.t.tea
       =+  lem=(slav %da i.t.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [our her] syd)
+        =+  den=((de now hen ruf) [our her] syd)
         abet:(take-foreign-plops:den ?~(lem ~ `lem) q.q.hin)
       [mos ..^$]
     ::
@@ -3866,7 +3879,7 @@
           ->+
       =*  pax  t.t.t.t.t.t.tea
       =^  mos  ruf
-        =+  den=((de now hen ~ ruf) [our her] syd)
+        =+  den=((de now hen ruf) [our her] syd)
         abet:(take-foreign-x:den car cas pax q.q.hin)
       [mos ..^$]
     ==

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -353,7 +353,7 @@
               {$writ p/riot}                            ::
           ==  ==                                        ::
               $:  $f                                    ::
-          $%  {$made p/@uvH q/gage:ford}                     ::
+          $%  {$made p/@uvH q/gage:ford}                ::
           ==  ==                                        ::
               $:  $t                                    ::
           $%  {$wake $~}                                ::  timer activate
@@ -1971,7 +1971,7 @@
   ::      and content
   ::  --  creating commits and content and adding them to the tree
   ::  --  finding which data needs to be sent over the network to keep the
-  ::  --  other urbit up-to-date
+  ::      other urbit up-to-date
   ::  --  reading from the file tree through different `++care` options
   ::  --  the `++me` core for merging.
   ::
@@ -3719,7 +3719,7 @@
       =<  abet
       ?~  q.q.q.hic
         cancel-request:den
-      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~&(%local-warp ~) `q.p.q.hic)
+      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~ `q.p.q.hic)
       (start-request:den for u.q.q.q.hic)
     [mos ..^$]
   ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2445,12 +2445,11 @@
       |=  {who/ship pax/path pes/regs}
       ^-  ?
       =+  rul=rul:(read-p-in pax pes)
-      =-  =(0 -)
-      %+  mix  ?=($black mod.rul)
+      =-  ?:(?=($black mod.rul) !- -)
       %-  ~(rep in who.rul)
-      |=  {w/whom h/?}
+      |=  {w/whom h/_|}
       ?:  h  &
-      ?:  ?=($& -.w)  =(w &+who)
+      ?:  ?=($& -.w)  =(p.w who)
       (~(has in (fall (~(get by cez) p.w) ~)) who)
     ::
     ::  Checks for existence of a node at an aeon.

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -78,7 +78,8 @@
 ::
 ++  dome
   $:  ank/ankh                                          ::  state
-      per/(map path rule)                               ::  permissions by path
+      per/(map path rule)                               ::  read perms per path
+      pew/(map path rule)                               ::  write perms per path
       let/aeon                                          ::  top id
       hit/(map aeon tako)                               ::  versions by id
       lab/(map @tas aeon)                               ::  labels

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -430,8 +430,8 @@
             dom=*dome
             dok=~
             mer=~
-            per=[[/ %black ~] ~ ~]
-            pew=[[/ %black ~] ~ ~]
+            per=~
+            pew=~
         ==
       :-  `hun.u.rom
       =+  jod=(fall (~(get by dos.u.rom) syd) *dojo)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3589,28 +3589,28 @@
   ::
       $drop
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.req q.req)
+      =+  den=((de now hen ruf) [. .]:our.req des.req)
       abet:drop-me:den
     [mos ..^$]
   ::
       $info
-    ?:  =(%$ q.req)
+    ?:  =(%$ des.req)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.req q.req)
-      abet:(edit:den now r.req)
+      =+  den=((de now hen ruf) [. .]:our.req des.req)
+      abet:(edit:den now dit.req)
     [mos ..^$]
   ::
       $init
     :_  %_    ..^$
             fat.ruf
-          ?<  (~(has by fat.ruf) p.req)
-          (~(put by fat.ruf) p.req [-(hun hen)]:[*room .])
+          ?<  (~(has by fat.ruf) our.req)
+          (~(put by fat.ruf) our.req [-(hun hen)]:[*room .])
         ==
-    =+  [bos=(sein:title p.req) can=(clan:title p.req)]
+    =+  [bos=(sein:title our.req) can=(clan:title our.req)]
     %-  zing  ^-  (list (list move))
-    :~  ?:  =(bos p.req)  ~
-        [hen %pass /init-merge %c %merg p.req %base bos %kids da+now %init]~
+    :~  ?:  =(bos our.req)  ~
+        [hen %pass /init-merge %c %merg our.req %base bos %kids da+now %init]~
     ::
         ~
     ==
@@ -3618,9 +3618,9 @@
       $into
     =.  hez.ruf  `hen
     :_  ..^$
-    =+  bem=(~(get by mon.ruf) p.req)
-    ?:  &(?=($~ bem) !=(%$ p.req))
-      ~|([%bad-mount-point-from-unix p.req] !!)
+    =+  bem=(~(get by mon.ruf) des.req)
+    ?:  &(?=($~ bem) !=(%$ des.req))
+      ~|([%bad-mount-point-from-unix des.req] !!)
     =+  ^-  bem/beam
         ?^  bem
           u.bem
@@ -3632,7 +3632,7 @@
     ?~  dos
       ~
     ?:  =(0 let.dom.u.dos)
-      =+  cos=(mode-to-soba ~ s.bem q.req r.req)
+      =+  cos=(mode-to-soba ~ s.bem all.req fis.req)
       =+  ^-  {one/(list {path miso}) two/(list {path miso})}
           %+  skid  cos
           |=  {a/path b/miso}
@@ -3644,66 +3644,68 @@
           [hen %pass /two %c %info p.bem q.bem %& two]
       ==
     =+  yak=(~(got by hut.ran.ruf) (~(got by hit.dom.u.dos) let.dom.u.dos))
-    =+  cos=(mode-to-soba q.yak (flop s.bem) q.req r.req)
+    =+  cos=(mode-to-soba q.yak (flop s.bem) all.req fis.req)
     [hen %pass /both %c %info p.bem q.bem %& cos]~
   ::
       $merg                                               ::  direct state up
-    ?:  =(%$ q.req)
+    ?:  =(%$ des.req)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.req q.req)
-      abet:abet:(start:(me:ze:den [r.req s.req] ~ &) t.req u.req)
+      =+  den=((de now hen ruf) [. .]:our.req des.req)
+      abet:abet:(start:(me:ze:den [her.req dem.req] ~ &) cas.req how.req)
     [mos ..^$]
   ::
       $mont
     =.  hez.ruf  ?^(hez.ruf hez.ruf `[[%$ %sync ~] ~])
-    =+  pot=(~(get by mon.ruf) p.req)
+    =+  pot=(~(get by mon.ruf) des.req)
     ?^  pot
       ~&  [%already-mounted pot]
       [~ ..^$]
+    =*  bem  bem.req
     =.  mon.ruf
-      (~(put by mon.ruf) p.req [p.q.req q.q.req r.q.req] s.q.req)
-    =+  yar=(~(get by fat.ruf) p.q.req)
+      (~(put by mon.ruf) des.req [p.bem q.bem r.bem] s.bem)
+    =+  yar=(~(get by fat.ruf) p.bem)
     ?~  yar
       [~ ..^$]
-    =+  dos=(~(get by dos.u.yar) q.q.req)
+    =+  dos=(~(get by dos.u.yar) q.bem)
     ?~  dos
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.req q.q.req)
-      abet:(mont:den p.req q.req)
+      =+  den=((de now hen ruf) [. .]:p.bem q.bem)
+      abet:(mont:den des.req bem)
     [mos ..^$]
   ::
       $dirk
     ?~  hez.ruf
       ~&  %no-sync-duct
       [~ ..^$]
-    ?.  (~(has by mon.ruf) p.req)
-      ~&  [%not-mounted p.req]
+    ?.  (~(has by mon.ruf) des.req)
+      ~&  [%not-mounted des.req]
       [~ ..^$]
-    :-  ~[[u.hez.ruf %give %dirk p.req]]
+    :-  ~[[u.hez.ruf %give %dirk des.req]]
         ..^$
   ::
       $ogre
     ?~  hez.ruf
       ~&  %no-sync-duct
       [~ ..^$]
-    ?@  p.req
-      ?.  (~(has by mon.ruf) p.req)
-        ~&  [%not-mounted p.req]
+    =*  pot  pot.req
+    ?@  pot
+      ?.  (~(has by mon.ruf) pot)
+        ~&  [%not-mounted pot]
         [~ ..^$]
-      :_  ..^$(mon.ruf (~(del by mon.ruf) p.req))
-      [u.hez.ruf %give %ogre p.req]~
+      :_  ..^$(mon.ruf (~(del by mon.ruf) pot))
+      [u.hez.ruf %give %ogre pot]~
     :_  %_    ..^$
             mon.ruf
           %-  molt
           %+  skip  ~(tap by mon.ruf)
-          (corl (cury test p.req) tail)
+          (corl (cury test pot) tail)
         ==
     %+  turn
-      (skim ~(tap by mon.ruf) (corl (cury test p.req) tail))
-    |=  {pot/term bem/beam}
-    [u.hez.ruf %give %ogre pot]
+      (skim ~(tap by mon.ruf) (corl (cury test pot) tail))
+    |=  {pon/term bem/beam}
+    [u.hez.ruf %give %ogre pon]
   ::
       $perm
     =^  mos  ruf
@@ -3716,13 +3718,13 @@
     =^  for  req
       ?:  ?=($warp -.req)
         [~ req]
-      :_  [%warp q.req r.req]
-      ?:  =(p.req p.q.req)  ~
-      `p.req
+      :_  [%warp wer.req rif.req]
+      ?:  =(who.req p.wer.req)  ~
+      `who.req
     ?>  ?=($warp -.req)
-    =*  rif  q.req
+    =*  rif  rif.req
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.req p.rif)
+      =+  den=((de now hen ruf) wer.req p.rif)
       =<  abet
       ?~  q.rif
         cancel-request:den
@@ -3734,21 +3736,23 @@
     !!
   ::
       $west
-    ?:  ?=({$question *} q.req)
-      =+  ryf=((hard riff) r.req)
+    =*  wer  wer.req
+    =*  pax  pax.req
+    ?:  ?=({$question *} pax)
+      =+  ryf=((hard riff) res.req)
       :_  ..^$
       :~  [hen %give %mack ~]
           :-  hen
-          :^  %pass  [(scot %p p.p.req) (scot %p q.p.req) t.q.req]
+          :^  %pass  [(scot %p p.wer) (scot %p q.wer) t.pax]
             %c
-          [%werp q.p.req [p.p.req p.p.req] ryf]
+          [%werp q.wer [p.wer p.wer] ryf]
       ==
-    ?>  ?=({$answer @ @ $~} q.req)
-    =+  syd=(slav %tas i.t.q.req)
-    =+  inx=(slav %ud i.t.t.q.req)
+    ?>  ?=({$answer @ @ $~} pax)
+    =+  syd=(slav %tas i.t.pax)
+    =+  inx=(slav %ud i.t.t.pax)
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.req syd)
-      abet:(take-foreign-update:den inx ((hard (unit rand)) r.req))
+      =+  den=((de now hen ruf) wer syd)
+      abet:(take-foreign-update:den inx ((hard (unit rand)) res.req))
     [[[hen %give %mack ~] mos] ..^$]
   ::
       $wegh

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3629,17 +3629,17 @@
       ?~  des  [[hen %give %croz rus]~ ..^^$]
       =+  per=(filter-rules per.q.i.des)
       =+  pew=(filter-rules pew.q.i.des)
-      $(des t.des, rus (~(put by rus) p.i.des per pew))
+      =?  rus  |(?=(^ per) ?=(^ pew))
+        (~(put by rus) p.i.des per pew)
+      $(des t.des)
     ::
     ++  filter-rules
       |=  pes/regs
       ^+  pes
       =-  (~(gas in *regs) -)
-      %+  murn  ~(tap by pes)
+      %+  skim  ~(tap by pes)
       |=  {p/path r/rule}
-      ^-  (unit (pair path rule))
-      ?.  (~(has in who.r) |+nom.req)  ~
-      `[p r]
+      (~(has in who.r) |+nom.req)
     --
   ::
       $drop

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -68,8 +68,8 @@
       dom/dome                                          ::  desk state
       dok/(unit dork)                                   ::  commit state
       mer/(unit mery)                                   ::  merge state
-      per/(map path rule)                               ::  read perms per path
-      pew/(map path rule)                               ::  write perms per path
+      per/regs                                          ::  read perms per path
+      pew/regs                                          ::  write perms per path
   ==
 ::
 ::  Desk state.
@@ -242,8 +242,8 @@
               dom/dome                                  ::  revision state
               dok/(unit dork)                           ::  outstanding diffs
               mer/(unit mery)                           ::  outstanding merges
-              per/(map path rule)                       ::  read perms per path
-              pew/(map path rule)                       ::  write perms per path
+              per/regs                                  ::  read perms per path
+              pew/regs                                  ::  write perms per path
           ==                                            ::
 ::
 ::  Foreign request manager.
@@ -831,7 +831,7 @@
     ==
   ::
   ++  put-perm
-    |=  {pes/(map path rule) pax/path new/(unit rule)}
+    |=  {pes/regs pax/path new/(unit rule)}
     ?~  new  (~(del by pes) pax)
     (~(put by pes) pax u.new)
   ::
@@ -845,8 +845,8 @@
     ==
   ::
   ++  forget-crew-in
-    |=  {nom/@ta rus/(map path rule)}
-    %-  ~(run by rus)
+    |=  {nom/@ta pes/regs}
+    %-  ~(run by pes)
     |=  r/rule
     r(who (~(del in who.r) |+nom))
   ::
@@ -2407,7 +2407,7 @@
       (read-p-in pax pew.red)
     ::
     ++  read-p-in
-      |=  {pax/path pes/(map path rule)}
+      |=  {pax/path pes/regs}
       ^-  dict
       =+  rul=(~(get by pes) pax)
       ?^  rul  [pax u.rul]
@@ -2442,7 +2442,7 @@
       (allowed-by w p pew.red)
     ::
     ++  allowed-by
-      |=  {who/ship pax/path pes/(map path rule)}
+      |=  {who/ship pax/path pes/regs}
       ^-  ?
       =+  rul=rul:(read-p-in pax pes)
       =-  =(0 -)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -412,9 +412,9 @@
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 |%
 ++  de                                                  ::  per desk
-  |=  {now/@da hen/duct raft}
+  |=  {now/@da hen/duct src/(unit ship) raft}
   |=  {{our/@p her/@p} syd/desk}
-  =*  ruf  +>+<+>
+  =*  ruf  +>+<+>+
   =+  ^-  {hun/(unit duct) rede}
       =+  rom=(~(get by fat.ruf) her)
       ?~  rom
@@ -3463,6 +3463,12 @@
         ((hard task:able) q.hic)
       ==
   ^+  [p=*(list move) q=..^$]
+  =/  src/(unit ship)
+    %+  roll  hen
+    |=  {wir/wire src/(unit ship)}
+    ?^  src  src
+    ?.  ?=({$a @ @ *} wir)  ~
+    `(slav %p i.t.t.wir)
   ?-    -.q.hic
       $boat
     :_  ..^$
@@ -3470,7 +3476,7 @@
   ::
       $drop
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen src ruf) [. .]:p.q.hic q.q.hic)
       abet:drop-me:den
     [mos ..^$]
   ::
@@ -3478,7 +3484,7 @@
     ?:  =(%$ q.q.hic)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen src ruf) [. .]:p.q.hic q.q.hic)
       abet:(edit:den now r.q.hic)
     [mos ..^$]
   ::
@@ -3532,7 +3538,7 @@
     ?:  =(%$ q.q.hic)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen src ruf) [. .]:p.q.hic q.q.hic)
       abet:abet:(start:(me:ze:den [r.q.hic s.q.hic] ~ &) t.q.hic u.q.hic)
     [mos ..^$]
   ::
@@ -3551,7 +3557,7 @@
     ?~  dos
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:p.q.q.hic q.q.q.hic)
+      =+  den=((de now hen src ruf) [. .]:p.q.q.hic q.q.q.hic)
       abet:(mont:den p.q.hic q.q.hic)
     [mos ..^$]
   ::
@@ -3588,7 +3594,7 @@
   ::
       $warp
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.q.hic p.q.q.hic)
+      =+  den=((de now hen src ruf) p.q.hic p.q.q.hic)
       ::  =-  ~?  ?=([~ %sing %w *] q.q.q.hic)
       ::        :*  %someones-warping
       ::            rav=u.q.q.q.hic
@@ -3619,7 +3625,7 @@
     =+  syd=(slav %tas i.t.q.q.hic)
     =+  inx=(slav %ud i.t.t.q.q.hic)
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.q.hic syd)
+      =+  den=((de now hen src ruf) p.q.hic syd)
       abet:(take-foreign-update:den inx ((hard (unit rand)) r.q.hic))
     [[[hen %give %mack ~] mos] ..^$]
   ::
@@ -3699,7 +3705,7 @@
     [~ ~]
   =+  run=((soft care) ren)
   ?~  run  [~ ~]
-  =+  den=((de now [/scryduct ~] ruf) [. .]:his syd)
+  =+  den=((de now [/scryduct ~] `his ruf) [. .]:his syd)
   =+  (aver:den u.run u.luk tyl)
   ?~  -               -
   ?~  u.-             -
@@ -3725,7 +3731,7 @@
         |=  dojo
         dom
     =^  mos  ruf
-      =+  den=((de now hen ruf) [. .]:our syd)
+      =+  den=((de now hen ~ ruf) [. .]:our syd)
       abet:abet:(route:(me:ze:den [her sud] kan |) sat dat)
     [mos ..^$]
   ?:  ?=({$blab care @ @ *} tea)
@@ -3756,7 +3762,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ruf) [. .]:our syd)
+        =+  den=((de now hen ~ ruf) [. .]:our syd)
         abet:(take-inserting:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3766,7 +3772,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ruf) [. .]:our syd)
+        =+  den=((de now hen ~ ruf) [. .]:our syd)
         abet:(take-diffing:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3776,7 +3782,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ruf) [. .]:our syd)
+        =+  den=((de now hen ~ ruf) [. .]:our syd)
         abet:(take-castify:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3786,7 +3792,7 @@
       =+  syd=(slav %tas i.t.t.tea)
       =+  wen=(slav %da i.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ruf) [. .]:our syd)
+        =+  den=((de now hen ~ ruf) [. .]:our syd)
         abet:(take-mutating:den wen q.q.hin)
       [mos ..^$]
     ::
@@ -3795,7 +3801,7 @@
       =+  our=(slav %p i.t.tea)
       =+  syd=(slav %tas i.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ruf) [. .]:our syd)
+        =+  den=((de now hen ~ ruf) [. .]:our syd)
         abet:(take-patch:den q.q.hin)
       [mos ..^$]
     ::
@@ -3804,7 +3810,7 @@
       =+  our=(slav %p i.t.tea)
       =+  syd=(slav %tas i.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ruf) [. .]:our syd)
+        =+  den=((de now hen ~ ruf) [. .]:our syd)
         abet:(take-ergo:den q.q.hin)
       [mos ..^$]
     ::
@@ -3815,7 +3821,7 @@
       =*  syd  i.t.t.t.tea
       =+  lem=(slav %da i.t.t.t.t.tea)
       =^  mos  ruf
-        =+  den=((de now hen ruf) [our her] syd)
+        =+  den=((de now hen ~ ruf) [our her] syd)
         abet:(take-foreign-plops:den ?~(lem ~ `lem) q.q.hin)
       [mos ..^$]
     ::
@@ -3831,7 +3837,7 @@
           ->+
       =*  pax  t.t.t.t.t.t.tea
       =^  mos  ruf
-        =+  den=((de now hen ruf) [our her] syd)
+        =+  den=((de now hen ~ ruf) [our her] syd)
         abet:(take-foreign-x:den car cas pax q.q.hin)
       [mos ..^$]
     ==

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2395,11 +2395,13 @@
         ?~  tak  |
         =+  yak=(tako-to-yaki u.tak)
         =+  len=(lent pax)
-        %+  levy  ~(tap by (~(del in ~(key by q.yak)) pax))
-        |=  p/path
-        ?&  =(pax (scag len p))
-            |(?=($z car) =(+(len) (lent p)))
-        ==
+        =-  (levy ~(tap in -) |=(p/path (allowed-by who p per.red)))
+        %+  roll  ~(tap in (~(del in ~(key by q.yak)) pax))
+        |=  {p/path s/(set path)}
+        ?.  =(pax (scag len p))  s
+        %-  ~(put in s)
+        ?:  ?=($z car)  p
+        (scag +(len) p)
       ==
     ::
     ++  may-write

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -61,13 +61,15 @@
 ::  Domestic desk state.
 ::
 ::  Includes subscriber list, dome (desk content), possible commit state (for
-::  local changes), and possible merge state (for incoming merges).
+::  local changes), possible merge state (for incoming merges), and permissions.
 ::
 ++  dojo
   $:  qyx/cult                                          ::  subscribers
       dom/dome                                          ::  desk state
       dok/(unit dork)                                   ::  commit state
       mer/(unit mery)                                   ::  merge state
+      per/(map path rule)                               ::  read perms per path
+      pew/(map path rule)                               ::  write perms per path
   ==
 ::
 ::  Desk state.
@@ -78,8 +80,6 @@
 ::
 ++  dome
   $:  ank/ankh                                          ::  state
-      per/(map path rule)                               ::  read perms per path
-      pew/(map path rule)                               ::  write perms per path
       let/aeon                                          ::  top id
       hit/(map aeon tako)                               ::  versions by id
       lab/(map @tas aeon)                               ::  labels
@@ -242,6 +242,8 @@
               dom/dome                                  ::  revision state
               dok/(unit dork)                           ::  outstanding diffs
               mer/(unit mery)                           ::  outstanding merges
+              per/(map path rule)                       ::  read perms per path
+              pew/(map path rule)                       ::  write perms per path
           ==                                            ::
 ::
 ::  Foreign request manager.
@@ -425,6 +427,8 @@
             dom=*dome
             dok=~
             mer=~
+            per=~
+            pew=~
         ==
       :-  `hun.u.rom
       =+  jod=(fall (~(get by dos.u.rom) syd) *dojo)
@@ -434,6 +438,8 @@
           dom=dom.jod
           dok=dok.jod
           mer=mer.jod
+          per=per.jod
+          pew=pew.jod
       ==
   =*  red  ->
   =|  mow/(list move)
@@ -444,7 +450,7 @@
         ?~  rom
           =+  rug=(~(put by rus:(fall (~(get by hoy.ruf) her) *rung)) syd red)
           ruf(hoy (~(put by hoy.ruf) her rug))
-        =+  dos=(~(put by dos.u.rom) syd [qyx dom dok mer])
+        =+  dos=(~(put by dos.u.rom) syd [qyx dom dok mer per pew])
         ruf(fat (~(put by fat.ruf) her [(need hun) dos]))
     (flop mow)
   ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -373,6 +373,7 @@
 ::
 ::  --  current time `now`
 ::  --  current duct `hen`
+::  --  foreign requester `for`, if any
 ::  --  local urbit `our`
 ::  --  target urbit `her`
 ::  --  target desk `syd`
@@ -412,7 +413,7 @@
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 |%
 ++  de                                                  ::  per desk
-  |=  {now/@da hen/duct src/(unit ship) raft}
+  |=  {now/@da hen/duct for/(unit ship) raft}
   |=  {{our/@p her/@p} syd/desk}
   =*  ruf  +>+<+>+
   =+  ^-  {hun/(unit duct) rede}
@@ -3463,12 +3464,6 @@
         ((hard task:able) q.hic)
       ==
   ^+  [p=*(list move) q=..^$]
-  =/  src/(unit ship)
-    %+  roll  hen
-    |=  {wir/wire src/(unit ship)}
-    ?^  src  src
-    ?.  ?=({$a @ @ *} wir)  ~
-    `(slav %p i.t.t.wir)
   ?-    -.q.hic
       $boat
     :_  ..^$
@@ -3476,7 +3471,7 @@
   ::
       $drop
     =^  mos  ruf
-      =+  den=((de now hen src ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen ~ ruf) [. .]:p.q.hic q.q.hic)
       abet:drop-me:den
     [mos ..^$]
   ::
@@ -3484,7 +3479,7 @@
     ?:  =(%$ q.q.hic)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen src ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen ~ ruf) [. .]:p.q.hic q.q.hic)
       abet:(edit:den now r.q.hic)
     [mos ..^$]
   ::
@@ -3538,7 +3533,7 @@
     ?:  =(%$ q.q.hic)
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen src ruf) [. .]:p.q.hic q.q.hic)
+      =+  den=((de now hen ~ ruf) [. .]:p.q.hic q.q.hic)
       abet:abet:(start:(me:ze:den [r.q.hic s.q.hic] ~ &) t.q.hic u.q.hic)
     [mos ..^$]
   ::
@@ -3557,7 +3552,7 @@
     ?~  dos
       [~ ..^$]
     =^  mos  ruf
-      =+  den=((de now hen src ruf) [. .]:p.q.q.hic q.q.q.hic)
+      =+  den=((de now hen ~ ruf) [. .]:p.q.q.hic q.q.q.hic)
       abet:(mont:den p.q.hic q.q.hic)
     [mos ..^$]
   ::
@@ -3594,7 +3589,8 @@
   ::
       $warp
     =^  mos  ruf
-      =+  den=((de now hen src ruf) p.q.hic p.q.q.hic)
+      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~&(%local-warp ~) `q.p.q.hic)
+      =+  den=((de now hen for ruf) p.q.hic p.q.q.hic)
       ::  =-  ~?  ?=([~ %sing %w *] q.q.q.hic)
       ::        :*  %someones-warping
       ::            rav=u.q.q.q.hic
@@ -3625,7 +3621,8 @@
     =+  syd=(slav %tas i.t.q.q.hic)
     =+  inx=(slav %ud i.t.t.q.q.hic)
     =^  mos  ruf
-      =+  den=((de now hen src ruf) p.q.hic syd)
+      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~&(%local-west ~) `q.p.q.hic)
+      =+  den=((de now hen for ruf) p.q.hic syd)
       abet:(take-foreign-update:den inx ((hard (unit rand)) r.q.hic))
     [[[hen %give %mack ~] mos] ..^$]
   ::
@@ -3705,7 +3702,15 @@
     [~ ~]
   =+  run=((soft care) ren)
   ?~  run  [~ ~]
-  =+  den=((de now [/scryduct ~] `his ruf) [. .]:his syd)
+  ::TODO  if it ever gets filled properly, pass in the full fur.
+  =/  for/(unit ship)
+    %-  ~(rep in (fall fur ~))
+    |=  {m/monk s/(unit ship)}
+    ?^  s  s
+    ?:  ?=($| -.m)  ~
+    ?:  =(p.m his)  ~
+    `p.m
+  =+  den=((de now [/scryduct ~] ?:(=(for `his) ~ for) ruf) [. .]:his syd)
   =+  (aver:den u.run u.luk tyl)
   ?~  -               -
   ?~  u.-             -

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -429,8 +429,8 @@
             dom=*dome
             dok=~
             mer=~
-            per=~
-            pew=~
+            per=[[/ %black ~] ~ ~]
+            pew=[[/ %black ~] ~ ~]
         ==
       :-  `hun.u.rom
       =+  jod=(fall (~(get by dos.u.rom) syd) *dojo)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2412,7 +2412,7 @@
       =+  rul=(~(get by pes) pax)
       ?^  rul  [pax u.rul]
       ?~  pax  [/ %white ~]
-      $(pax t.pax)
+      $(pax (scag (dec (lent pax)) `path`pax))
     ::
     ++  may-read
       |=  {who/ship car/care yon/aeon pax/path}

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3535,6 +3535,23 @@
       $boat
     :_  ..^$
     [hen %give %hill (turn ~(tap by mon.ruf) head)]~
+  ::.
+      $cred
+    =.  cez.ruf
+      ?~  cew.q.hic  (~(del by cez.ruf) nom.q.hic)
+      (~(put by cez.ruf) nom.q.hic cew.q.hic)
+    ::  wake all desks, a request may have been affected.
+    =|  mos/(list move)
+    =+  rom=(fall (~(get by fat.ruf) our.q.hic) *room)
+    =+  des=~(tap in ~(key by dos.rom))
+    |-
+    ?~  des  [[[hen %give %mack ~] mos] ..^^$]
+    =+  den=((de now hen ruf) [. .]:our.q.hic i.des)
+    =^  mor  ruf  abet:wake:den
+    $(des t.des, mos (weld mos mor))
+  ::
+      $crew
+    [[hen %give %cruz cez.ruf]~ ..^$]
   ::
       $drop
     =^  mos  ruf

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -43,13 +43,13 @@
 ::
 ::  Type of request.
 ::
-::  %d produces a set of desks, %u checks for existence, %v produces a ++dome of
-::  all desk data, %w with a time or label case gets the aeon at that case, %w
-::  with a number case is not recommended, %x gets file contents, %y gets a
-::  directory listing, and %z gets a recursive hash of the file contents and
-::  children.
+::  %d produces a set of desks, %p gets file permissions, %u checks for
+::  existence, %v produces a ++dome of all desk data, %w with a time or label
+::  case gets the aeon at that case, %w with a number case is not recommended,
+::  %x gets file contents, %y gets a directory listing, and %z gets a recursive
+::  hash of the file contents and children.
 ::
-:: ++  care  ?($d $u $v $w $x $y $z)
+:: ++  care  ?($d $p $u $v $w $x $y $z)
 ::
 ::  Keeps track of subscribers.
 ::
@@ -78,6 +78,7 @@
 ::
 ++  dome
   $:  ank/ankh                                          ::  state
+      per/(map path rule)                               ::  permissions by path
       let/aeon                                          ::  top id
       hit/(map aeon tako)                               ::  versions by id
       lab/(map @tas aeon)                               ::  labels
@@ -183,6 +184,7 @@
 ::  --  `mon` is a collection of mount points (mount point name to urbit
 ::      location).
 ::  --  `hez` is the unix duct that %ergo's should be sent to.
+::  --  `cez` is a collection of named permission groups.
 ::
 ++  raft                                                ::  filesystem
   $:  fat/(map ship room)                               ::  domestic
@@ -190,6 +192,7 @@
       ran/rang                                          ::  hashes
       mon/(map term beam)                               ::  mount points
       hez/(unit duct)                                   ::  sync duct
+      cez/(map @ta crew)                                ::  permission groups
   ==                                                    ::
 ::
 ::  Object store.

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -375,7 +375,6 @@
 ::
 ::  --  current time `now`
 ::  --  current duct `hen`
-::  --  foreign requester `for`, if any
 ::  --  local urbit `our`
 ::  --  target urbit `her`
 ::  --  target desk `syd`
@@ -3717,21 +3716,16 @@
       ?:  ?=($warp -.q.hic)
         [~ q.hic]
       :_  [%warp q.q.hic r.q.hic]
-      ?:  =(p.q.hic p.q.q.hic)  ~&([%huh-this-west-may-be-weird p.q.hic] ~)
+      ?:  =(p.q.hic p.q.q.hic)  ~
       `p.q.hic
     ?>  ?=($warp -.q.hic)
+    =*  rif  q.q.hic
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.q.hic p.q.q.hic)
-      ::  =-  ~?  ?=([~ %sing %w *] q.r.q.hic)
-      ::        :*  %someones-warping
-      ::            rav=u.q.r.q.hic
-      ::            mos=-<
-      ::        ==
-      ::      -
+      =+  den=((de now hen ruf) p.q.hic p.rif)
       =<  abet
-      ?~  q.q.q.hic
+      ?~  q.rif
         cancel-request:den
-      (start-request:den for u.q.q.q.hic)
+      (start-request:den for u.q.rif)
     [mos ..^$]
   ::
       $went
@@ -3809,14 +3803,26 @@
   ^+  ..^$
   ?-  -.old
     $4  ..^$(ruf ruf.old)
-    $3  =/  wov
+    $3  |^
+          =-  ^$(old [%4 -])
+          =+  ruf.old
+          :*  (~(run by fat) rom)
+              (~(run by hoy) run)
+              ran  mon  hez  ~
+          ==
+        ::
+        ++  wov
           |=  a/wove-3  ^-  wove
           [~ a]
-        =/  cul
+        ::
+        ++  cul
           |=  a/cult-3  ^-  cult
           %-  ~(gas by *cult)
-          (turn ~(tap by a) |=({p/wove-3 q/(set duct)} [(wov p) q]))
-        =/  rom
+          %+  turn  ~(tap by a)
+          |=  {p/wove-3 q/(set duct)}
+          [(wov p) q]
+        ::
+        ++  rom
           |=  room-3
           :-  hun
           %-  ~(urn by dos)
@@ -3824,14 +3830,14 @@
           =/  n/dojo  [(cul qyx) dom dok mer ~ ~]
           ?.  =(%kids d)  n
           n(per [[/ %black ~] ~ ~])
-        =/  run
+        ::
+        ++  run
           =/  red
             |=  rede-3
             =+  [[/ %black ~] ~ ~]
             [lim ref (cul qyx) dom dok mer - -]
           |=(a/rung-3 a(rus (~(run by rus.a) red)))
-        =+  ruf.old
-        $(old [%4 [(~(run by fat) rom) (~(run by hoy) run) ran mon hez ~]])
+        --
   ==
 ::
 ++  scry                                              ::  inspect

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2355,6 +2355,41 @@
         ?^(r.mun ~ !!) :: [~ %w !>([t.yak (forge-nori yak)])])-all
       (query(ank.dom ank:(descend-path:(zu ank.dom) r.mun)) p.mun) ::  dead code
     ::
+    ::
+    ++  may-read
+      |=  {who/ship car/care yon/aeon pax/path}
+      ^-  ?
+      ?+  car
+        (allowed-by who pax per.red)
+      ::
+          ?($y $z)
+        =+  tak=(~(get by hit.dom) yon)
+        ?~  tak  |
+        =+  yak=(tako-to-yaki u.tak)
+        =+  len=(lent pax)
+        %+  levy  ~(tap by (~(del in ~(key by q.yak)) pax))
+        |=  p/path
+        ?&  =(pax (scag len p))
+            |(?=($z car) =(+(len) (lent p)))
+        ==
+      ==
+    ::
+    ++  may-write
+      |=  {w/ship p/path}
+      (allowed-by w p pew.red)
+    ::
+    ++  allowed-by
+      |=  {who/ship pax/path pes/(map path rule)}
+      ^-  ?
+      =+  rul=rul:(read-p-in pax pes)
+      =-  =(0 -)
+      %+  mix  ?=($black mod.rul)
+      %-  ~(rep in who.rul)
+      |=  {w/whom h/?}
+      ?:  h  &
+      ?:  ?=($& -.w)  =(w &+who)
+      (~(has in (fall (~(get by cez) p.w) ~)) who)
+    ::
     ::  Checks for existence of a node at an aeon.
     ::
     ::  This checks for existence of content at the node, and does *not* look
@@ -2503,6 +2538,8 @@
     ++  read-at-aeon                                    ::    read-at-aeon:ze
       |=  {for/(unit ship) yon/aeon mun/mood}           ::  seek and read
       ^-  (unit (unit (each cage lobe)))
+      ?.  |(?=($~ for) (may-read u.for p.mun yon r.mun))
+        ~
       ?:  &(?=($w p.mun) !?=($ud -.q.mun))              ::  NB only her speed
         ?^(r.mun [~ ~] [~ ~ %& %aeon !>(yon)])
       ?:  ?=($d p.mun)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -806,6 +806,23 @@
   ++  perm
     |=  {pax/path rit/rite}
     ^+  +>
+    =/  mis/(set @ta)
+      %+  roll
+        =-  ~(tap in -)
+        ?-  -.rit
+          $r    who:(fall red.rit *rule)
+          $w    who:(fall wit.rit *rule)
+          $rw   (~(uni in who:(fall red.rit *rule)) who:(fall wit.rit *rule))
+        ==
+      |=  {w/whom s/(set @ta)}
+      ?:  |(?=($& -.w) (~(has by cez) p.w))  s
+      (~(put in s) p.w)
+    ?^  mis
+      =-  (emit hen %give %mack `[%leaf "No such group(s): {-}"]~)
+      %+  roll  ~(tap in `(set @ta)`mis)
+      |=  {g/@ta t/tape}
+      ?~  t  (trip g)
+      :(weld t ", " (trip g))
     =<  (emit hen %give %mack ~)
     ?-  -.rit
       $r    wake(per (put-perm per pax red.rit))

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1529,6 +1529,9 @@
         $d
       ~|  %totally-temporary-error-please-replace-me
       !!
+        $p
+      ~|  %requesting-foreign-permissions-is-invalid
+      !!
         $u
       ~|  %im-thinkin-its-prolly-a-bad-idea-to-request-rang-over-the-network
       !!
@@ -2327,9 +2330,10 @@
     ::  eliminate ++read and ++query
     ::
     ++  query                                           ::    query:ze
-      |=  ren/$?($u $v $x $y $z)                        ::  endpoint query
+      |=  ren/$?($p $u $v $x $y $z)                     ::  endpoint query
       ^-  (unit cage)
       ?-  ren
+        $p  !!
         $u  !!  ::  [~ %null [%atom %n] ~]
         $v  [~ %dome !>(dom)]
         $x  !!  ::  ?~(q.ank.dom ~ [~ q.u.q.ank.dom])
@@ -2355,12 +2359,35 @@
         ?^(r.mun ~ !!) :: [~ %w !>([t.yak (forge-nori yak)])])-all
       (query(ank.dom ank:(descend-path:(zu ank.dom) r.mun)) p.mun) ::  dead code
     ::
+    ::  Gets the permissions that apply to a particular node.
+    ::
+    ::  If the node has no permissions of its own, we use its parent's.
+    ::  If no permissions have been set for the entire tree above the node,
+    ::  we default to fully private (empty whitelist).
+    ::
+    ++  read-p
+      |=  pax/path
+      ^-  (unit (unit (each cage lobe)))
+      =-  [~ ~ %& %noun !>(-)]
+      :-  (read-p-in pax per.red)
+      (read-p-in pax pew.red)
+    ::
+    ++  read-p-in
+      |=  {pax/path pes/(map path rule)}
+      ^-  dict
+      =+  rul=(~(get by pes) pax)
+      ?^  rul  [pax u.rul]
+      ?~  pax  [/ %white ~]
+      $(pax t.pax)
     ::
     ++  may-read
       |=  {who/ship car/care yon/aeon pax/path}
       ^-  ?
       ?+  car
         (allowed-by who pax per.red)
+      ::
+          $p
+        =(who our)
       ::
           ?($y $z)
         =+  tak=(~(get by hit.dom) yon)
@@ -2549,6 +2576,8 @@
         ?^  r.mun
           ~&(%no-cd-path [~ ~])
         [~ ~ %& %noun !>(~(key by dos.u.rom))]
+      ?:  ?=($p p.mun)
+        (read-p r.mun)
       ?:  ?=($u p.mun)
         (read-u yon r.mun)
       ?:  ?=($v p.mun)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3815,8 +3815,13 @@
           %-  ~(gas by *cult)
           (turn ~(tap by a) |=({p/wove-3 q/(set duct)} [(wov p) q]))
         =/  rom
-          =+  doj=|=(dojo-3 [(cul qyx) dom dok mer ~ ~])
-          |=(a/room-3 a(dos (~(run by dos.a) doj)))
+          |=  room-3
+          :-  hun
+          %-  ~(urn by dos)
+          |=  {d/desk dojo-3}
+          =/  n/dojo  [(cul qyx) dom dok mer ~ ~]
+          ?.  =(%kids d)  n
+          n(per [[/ %black ~] ~ ~])
         =/  run
           =/  red
             |=  rede-3

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -329,7 +329,7 @@
       $:  $c                                            ::  to %clay
   $%  {$info p/@p q/@tas r/nori}                        ::  internal edit
       {$merg p/@p q/@tas r/@p s/@tas t/case u/germ}     ::  merge desks
-      {$warp p/sock q/riff}                             ::
+      {$warp p/ship q/sock r/riff}                      ::
   ==  ==                                                ::
       $:  $d                                            ::
   $%  {$flog p/{$crud p/@tas q/(list tank)}}            ::  to %dill
@@ -2777,7 +2777,7 @@
         %-  emit(wat.dat %ali)
         :*  hen  %pass
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %ali ~]
-            %c  %warp  [p.bob p.ali]  q.ali
+            %c  %warp  p.bob  [p.bob p.ali]  q.ali
             `[%sing %v cas.dat /]
         ==
       ::
@@ -3709,18 +3709,18 @@
   ::
       $warp
     =^  mos  ruf
-      =+  den=((de now hen ruf) p.q.hic p.q.q.hic)
-      ::  =-  ~?  ?=([~ %sing %w *] q.q.q.hic)
+      =+  den=((de now hen ruf) q.q.hic p.r.q.hic)
+      ::  =-  ~?  ?=([~ %sing %w *] q.r.q.hic)
       ::        :*  %someones-warping
-      ::            rav=u.q.q.q.hic
+      ::            rav=u.q.r.q.hic
       ::            mos=-<
       ::        ==
       ::      -
       =<  abet
-      ?~  q.q.q.hic
+      ?~  q.r.q.hic
         cancel-request:den
-      =+  for=?:(=(p.p.q.hic q.p.q.hic) ~ `q.p.q.hic)
-      (start-request:den for u.q.q.q.hic)
+      =+  for=?:(=(p.q.hic p.q.q.hic) ~ `p.q.hic)
+      (start-request:den for u.q.r.q.hic)
     [mos ..^$]
   ::
       $went
@@ -3735,8 +3735,7 @@
           :-  hen
           :^  %pass  [(scot %p p.p.q.hic) (scot %p q.p.q.hic) t.q.q.hic]
             %c
-          ::TODO  ...so, this circumvents permission checks?
-          [%warp [p.p.q.hic p.p.q.hic] ryf]
+          [%warp q.p.q.hic [p.p.q.hic p.p.q.hic] ryf]
       ==
     ?>  ?=({$answer @ @ $~} q.q.hic)
     =+  syd=(slav %tas i.t.q.q.hic)

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -80,6 +80,7 @@
   $%  {$mere p/(each (set path) (pair term tang))}      ::
       {$note p/@tD q/tank}                              ::
       {$writ p/riot:clay}                               ::
+      {$mack p/(unit tang)}                             ::
   ==                                                    ::
 ++  sign-dill                                           ::
   $%  {$blit p/(list blit)}                             ::
@@ -281,6 +282,7 @@
                   (sync %home our %base)
                 (init-sync %home our %base)
         =.  +>  ?.  ?=(?($duke $king $czar) can)  +>
+                ::  make kids desk publicly readable, so syncs work.
                 (show %kids):(sync %kids our %base)
         =.  +>  autoload
         =.  +>  peer
@@ -407,6 +409,10 @@
         ::
             {$c $writ *}
           init
+        ::
+            {$c $mack *}
+          ?~  p.sih  +>.$
+          (mean >%dill-clay-nack< u.p.sih)
         ::
             {$d $blit *}
           (done +.sih)

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -48,6 +48,7 @@
 ++  note-clay                                           ::
   $%  {$merg p/@p q/@tas r/@p s/@tas t/case u/germ:clay}::  merge desks
       {$warp p/sock q/riff:clay}                        ::  wait for clay hack
+      {$perm p/ship q/desk r/path s/rite:clay}          ::  change permissions
   ==                                                    ::
 ++  note-dill                                           ::  note to self, odd
   $%  {$crud p/@tas q/(list tank)}                      ::
@@ -280,7 +281,7 @@
                   (sync %home our %base)
                 (init-sync %home our %base)
         =.  +>  ?.  ?=(?($duke $king $czar) can)  +>
-                (sync %kids our %base)
+                (show %kids):(sync %kids our %base)
         =.  +>  autoload
         =.  +>  peer
         |-  ^+  +>+
@@ -314,6 +315,16 @@
         %_    .
             moz
           :_(moz [hen %pass ~ %g %deal [our our] ram %peer /drum])
+        ==
+      ::
+      ++  show                                          ::  permit reads on desk
+        |=  des/desk
+        %_    +>.$
+            moz
+          :_  moz
+          :*  hen  %pass  /show  %c  %perm  our
+              des  /  r+`[%black ~]
+          ==
         ==
       ::
       ++  sync

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -47,7 +47,7 @@
   ==                                                    ::
 ++  note-clay                                           ::
   $%  {$merg p/@p q/@tas r/@p s/@tas t/case u/germ:clay}::  merge desks
-      {$warp p/sock q/riff:clay}                       ::  wait for clay hack
+      {$warp p/ship q/sock r/riff:clay}                 ::  wait for clay hack
   ==                                                    ::
 ++  note-dill                                           ::  note to self, odd
   $%  {$crud p/@tas q/(list tank)}                      ::
@@ -297,7 +297,7 @@
               %pass
               /
               %c
-              [%warp [our our] %base `[%sing %y [%ud 1] /]]
+              [%warp our [our our] %base `[%sing %y [%ud 1] /]]
           ==
         ==
       ::

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -47,7 +47,7 @@
   ==                                                    ::
 ++  note-clay                                           ::
   $%  {$merg p/@p q/@tas r/@p s/@tas t/case u/germ:clay}::  merge desks
-      {$warp p/ship q/sock r/riff:clay}                 ::  wait for clay hack
+      {$warp p/sock q/riff:clay}                        ::  wait for clay hack
   ==                                                    ::
 ++  note-dill                                           ::  note to self, odd
   $%  {$crud p/@tas q/(list tank)}                      ::
@@ -297,7 +297,7 @@
               %pass
               /
               %c
-              [%warp our [our our] %base `[%sing %y [%ud 1] /]]
+              [%warp [our our] %base `[%sing %y [%ud 1] /]]
           ==
         ==
       ::

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -12,7 +12,7 @@
 ++  move  {p/duct q/(wind note gift:able)}              ::  local move
 ++  note                                                ::  out request $->
           $%  $:  $c                                    ::  to %clay
-          $%  {$warp p/ship q/sock r/riff:clay}         ::
+          $%  {$warp p/sock q/riff:clay}                ::
           ==  ==                                        ::
               $:  $f                                    ::  to %ford
           $%  {$exec p/@p q/(unit bilk:ford)}          ::
@@ -294,7 +294,7 @@
     |=  {ren/care:clay bem/beam ask/?}
     :: ~&  warp+[(en-beam bem) ask]
     :+  %pass  [(scot %p our) ren (en-beam bem)]
-    [%c [%warp our [our p.bem] q.bem ?.(ask ~ `[%next ren r.bem (flop s.bem)])]]
+    [%c [%warp [our p.bem] q.bem ?.(ask ~ `[%next ren r.bem (flop s.bem)])]]
   ::
   ::
   ++  zo
@@ -321,7 +321,7 @@
       |=  {van/vane ren/care:clay bem/beam}  
       ^-  (wind note gift:able)
       ?+  van  ~|(stub-cancel+van !!)
-        $c  [%pass (camp-wire +<) van [%warp our [our p.bem] q.bem ~]]
+        $c  [%pass (camp-wire +<) van [%warp [our p.bem] q.bem ~]]
         $g  [%pass (camp-wire +<) van [%deal [our p.bem] q.bem [%pull ~]]]
       ==
     ::
@@ -351,7 +351,7 @@
         ::
             $c
           :+  %pass  (camp-wire +<.$)
-          [%c [%warp our [our p.bem] q.bem [~ %sing ren r.bem (flop s.bem)]]]
+          [%c [%warp [our p.bem] q.bem [~ %sing ren r.bem (flop s.bem)]]]
         ==
       ==
     ::

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -12,7 +12,7 @@
 ++  move  {p/duct q/(wind note gift:able)}              ::  local move
 ++  note                                                ::  out request $->
           $%  $:  $c                                    ::  to %clay
-          $%  {$warp p/sock q/riff:clay}               ::
+          $%  {$warp p/ship q/sock r/riff:clay}         ::
           ==  ==                                        ::
               $:  $f                                    ::  to %ford
           $%  {$exec p/@p q/(unit bilk:ford)}          ::
@@ -294,7 +294,7 @@
     |=  {ren/care:clay bem/beam ask/?}
     :: ~&  warp+[(en-beam bem) ask]
     :+  %pass  [(scot %p our) ren (en-beam bem)]
-    [%c [%warp [our p.bem] q.bem ?.(ask ~ `[%next ren r.bem (flop s.bem)])]]
+    [%c [%warp our [our p.bem] q.bem ?.(ask ~ `[%next ren r.bem (flop s.bem)])]]
   ::
   ::
   ++  zo
@@ -321,7 +321,7 @@
       |=  {van/vane ren/care:clay bem/beam}  
       ^-  (wind note gift:able)
       ?+  van  ~|(stub-cancel+van !!)
-        $c  [%pass (camp-wire +<) van [%warp [our p.bem] q.bem ~]]
+        $c  [%pass (camp-wire +<) van [%warp our [our p.bem] q.bem ~]]
         $g  [%pass (camp-wire +<) van [%deal [our p.bem] q.bem [%pull ~]]]
       ==
     ::
@@ -351,7 +351,7 @@
         ::
             $c
           :+  %pass  (camp-wire +<.$)
-          [%c [%warp [our p.bem] q.bem [~ %sing ren r.bem (flop s.bem)]]]
+          [%c [%warp our [our p.bem] q.bem [~ %sing ren r.bem (flop s.bem)]]]
         ==
       ==
     ::

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1225,6 +1225,8 @@
                ~
         $cash  `%a
         $conf  `%g
+        $cred  `%c
+        $crew  `%c
         $deal  `%g
         $exec  `%f
         $flog  `%d
@@ -1234,6 +1236,7 @@
         $mont  `%c
         $nuke  `%a
         $ogre  `%c
+        $perm  `%c
         $serv  `%e
         $them  `%e
         $wait  `%b

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1227,6 +1227,7 @@
         $conf  `%g
         $cred  `%c
         $crew  `%c
+        $crow  `%c
         $deal  `%g
         $exec  `%f
         $flog  `%d

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -505,6 +505,7 @@
         {$mult p/mool}                                  ::  next version of any
         {$many p/? q/moat}                              ::  track range
     ==                                                  ::
+  ++  regs  (map path rule)                             ::  rules for paths
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist
   ++  rite                                              ::  new permissions
     $%  {$r red/(unit rule)}                            ::  for read

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -397,8 +397,8 @@
       ==                                                ::
     ++  task                                            ::  in request ->$
       $%  {$boat $~}                                    ::  pier rebooted
-          {$crew $~}                                    ::  permission groups
           {$cred nom/@ta cew/crew}                      ::  set permission group
+          {$crew $~}                                    ::  permission groups
           {$drop p/@p q/desk}                           ::  cancel pending merge
           {$info p/@p q/desk r/nori}                    ::  internal edit
           {$init p/@p}                                  ::  report install
@@ -407,12 +407,7 @@
           {$mont p/desk q/beam}                         ::  mount to unix
           {$dirk p/desk}                                ::  mark mount dirty
           {$ogre p/$@(desk beam)}                       ::  delete mount point
-          $:  $perm                                     ::  change permissions
-              des/desk                                  ::  target desk
-              pax/path                                  ::  target node
-              rit/rite                                  ::  read, write or both
-              rul/(unit rule)                           ::  new rule
-          ==                                            ::
+          {$perm des/desk pax/path rit/rite}            ::  change permissions
           {$warp p/sock q/riff}                         ::  file request
           {$wegh $~}                                    ::  report memory
           {$went p/sack q/path r/@ud s/coop}            ::  response confirm
@@ -506,7 +501,11 @@
         {$many p/? q/moat}                              ::  track range
     ==                                                  ::
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist
-  ++  rite  ?($r $w $rw)                                ::  permission for
+  ++  rite                                              ::  new permissions
+    $%  {$r red/(unit rule)}                            ::  for read
+        {$w wit/(unit rule)}                            ::  for write
+        {$rw red/(unit rule) wit/(unit rule)}           ::  for read and write
+    ==                                                  ::
   ++  riot  (unit rant)                                 ::  response+complete
   ++  rule  {mod/?($black $white) who/(set whom)}       ::  node permission
   ++  rump  {p/care q/case r/@tas s/path}               ::  relative path

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -408,7 +408,8 @@
           {$dirk p/desk}                                ::  mark mount dirty
           {$ogre p/$@(desk beam)}                       ::  delete mount point
           {$perm our/ship des/desk pax/path rit/rite}   ::  change permissions
-          {$warp p/ship q/sock r/riff}                  ::  file request.
+          {$warp p/sock q/riff}                         ::  internal file req
+          {$werp p/ship q/sock r/riff}                  ::  external file req
           {$wegh $~}                                    ::  report memory
           {$went p/sack q/path r/@ud s/coop}            ::  response confirm
           {$west p/sack q/path r/*}                     ::  network request

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -399,20 +399,24 @@
       $%  {$boat $~}                                    ::  pier rebooted
           {$cred our/ship nom/@ta cew/crew}             ::  set permission group
           {$crew our/ship}                              ::  permission groups
-          {$drop p/@p q/desk}                           ::  cancel pending merge
-          {$info p/@p q/desk r/nori}                    ::  internal edit
-          {$init p/@p}                                  ::  report install
-          {$into p/desk q/? r/mode}                     ::  external edit
-          {$merg p/@p q/desk r/@p s/desk t/case u/germ} ::  merge desks
-          {$mont p/desk q/beam}                         ::  mount to unix
-          {$dirk p/desk}                                ::  mark mount dirty
-          {$ogre p/$@(desk beam)}                       ::  delete mount point
+          {$drop our/@p des/desk}                       ::  cancel pending merge
+          {$info our/@p des/desk dit/nori}              ::  internal edit
+          {$init our/@p}                                ::  report install
+          {$into des/desk all/? fis/mode}               ::  external edit
+          $:  $merg                                     ::  merge desks
+              our/@p  des/desk                          ::  target
+              her/@p  dem/desk  cas/case                ::  source
+              how/germ                                  ::  method
+          ==                                            ::
+          {$mont des/desk bem/beam}                     ::  mount to unix
+          {$dirk des/desk}                              ::  mark mount dirty
+          {$ogre pot/$@(desk beam)}                     ::  delete mount point
           {$perm our/ship des/desk pax/path rit/rite}   ::  change permissions
-          {$warp p/sock q/riff}                         ::  internal file req
-          {$werp p/ship q/sock r/riff}                  ::  external file req
+          {$warp wer/sock rif/riff}                     ::  internal file req
+          {$werp who/ship wer/sock rif/riff}            ::  external file req
           {$wegh $~}                                    ::  report memory
-          {$went p/sack q/path r/@ud s/coop}            ::  response confirm
-          {$west p/sack q/path r/*}                     ::  network request
+          {$went wer/sack pax/path num/@ud ack/coop}    ::  response confirm
+          {$west wer/sack pax/path res/*}               ::  network request
       ==                                                ::
     --  ::able
   ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -407,7 +407,7 @@
           {$mont p/desk q/beam}                         ::  mount to unix
           {$dirk p/desk}                                ::  mark mount dirty
           {$ogre p/$@(desk beam)}                       ::  delete mount point
-          {$perm des/desk pax/path rit/rite}            ::  change permissions
+          {$perm our/ship des/desk pax/path rit/rite}   ::  change permissions
           {$warp p/sock q/riff}                         ::  file request
           {$wegh $~}                                    ::  report memory
           {$went p/sack q/path r/@ud s/coop}            ::  response confirm

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -381,7 +381,7 @@
   ++  able  ^?
     |%
     ++  gift                                            ::  out result <-$
-      $%  {$cruz cez/(map @tas crew)}                   ::  permission groups
+      $%  {$cruz cez/(map @ta crew)}                    ::  permission groups
           {$dirk p/@tas}                                ::  mark mount dirty
           {$ergo p/@tas q/mode}                         ::  version update
           {$hill p/(list @tas)}                         ::  mount points
@@ -397,8 +397,8 @@
       ==                                                ::
     ++  task                                            ::  in request ->$
       $%  {$boat $~}                                    ::  pier rebooted
-          {$cred nom/@ta cew/crew}                      ::  set permission group
-          {$crew $~}                                    ::  permission groups
+          {$cred our/ship nom/@ta cew/crew}             ::  set permission group
+          {$crew our/ship}                              ::  permission groups
           {$drop p/@p q/desk}                           ::  cancel pending merge
           {$info p/@p q/desk r/nori}                    ::  internal edit
           {$init p/@p}                                  ::  report install

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -381,7 +381,8 @@
   ++  able  ^?
     |%
     ++  gift                                            ::  out result <-$
-      $%  {$dirk p/@tas}                                ::  mark mount dirty
+      $%  {$cruz cez/(map @tas crew)}                   ::  permission groups
+          {$dirk p/@tas}                                ::  mark mount dirty
           {$ergo p/@tas q/mode}                         ::  version update
           {$hill p/(list @tas)}                         ::  mount points
           {$mack p/(unit tang)}                         ::  ack
@@ -389,12 +390,15 @@
           {$mere p/(each (set path) (pair term tang))}  ::  merge result
           {$note p/@tD q/tank}                          ::  debug message
           {$ogre p/@tas}                                ::  delete mount point
+          {$rule own/? rul/rule}                        ::  node permission
           {$send p/lane:ames q/@}                       ::  transmit packet
           {$writ p/riot}                                ::  response
           {$wris p/case p/(set path)}                   ::  responses
       ==                                                ::
     ++  task                                            ::  in request ->$
       $%  {$boat $~}                                    ::  pier rebooted
+          {$crew $~}                                    ::  permission groups
+          {$cred nom/@ta cew/crew}                      ::  set permission group
           {$drop p/@p q/desk}                           ::  cancel pending merge
           {$info p/@p q/desk r/nori}                    ::  internal edit
           {$init p/@p}                                  ::  report install
@@ -403,6 +407,7 @@
           {$mont p/desk q/beam}                         ::  mount to unix
           {$dirk p/desk}                                ::  mark mount dirty
           {$ogre p/$@(desk beam)}                       ::  delete mount point
+          {$perm des/desk pax/path rul/(unit rule)}     ::  change permissions
           {$warp p/sock q/riff}                         ::  file request
           {$wegh $~}                                    ::  report memory
           {$went p/sack q/path r/@ud s/coop}            ::  response confirm
@@ -423,13 +428,14 @@
     $%  {$delta p/lobe q/{p/mark q/lobe} r/page}        ::  delta on q
         {$direct p/lobe q/page}                         ::  immediate
     ==                                                  ::
-  ++  care  ?($d $u $v $w $x $y $z)                     ::  clay submode
+  ++  care  ?($d $p $u $v $w $x $y $z)                  ::  clay submode
   ++  case                                              ::  ship desk case spur
     $%  {$da p/@da}                                     ::  date
         {$tas p/@tas}                                   ::  label
         {$ud p/@ud}                                     ::  number
     ==                                                  ::
   ++  coop  (unit ares)                                 ::  e2e ack
+  ++  crew  (set ship)                                  ::  permissions group
   ++  dome                                              ::  project state
     $:  ank/ankh                                        ::  state
         let/@ud                                         ::  top id
@@ -495,6 +501,7 @@
     ==                                                  ::
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist
   ++  riot  (unit rant)                                 ::  response+complete
+  ++  rule  {mod/?($black $white) who/(set whom)}       ::  node permission
   ++  rump  {p/care q/case r/@tas s/path}               ::  relative path
   ++  saba  {p/ship q/@tas r/moar s/dome}               ::  patch+merge
   ++  soba  (list {p/path q/miso})                      ::  delta
@@ -507,6 +514,7 @@
         {$| p/(list a) q/(list a)}                      ::  p -> q[chunk]
     ==                                                  ::
   ++  urge  |*(a/mold (list (unce a)))                  ::  list change
+  ++  whom  (each ship @ta)                             ::  ship or named crew
   ++  yaki                                              ::  commit
     $:  p/(list tako)                                   ::  parents
         q/(map path lobe)                               ::  namespace

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -408,7 +408,7 @@
           {$dirk p/desk}                                ::  mark mount dirty
           {$ogre p/$@(desk beam)}                       ::  delete mount point
           {$perm our/ship des/desk pax/path rit/rite}   ::  change permissions
-          {$warp p/sock q/riff}                         ::  file request
+          {$warp p/ship q/sock r/riff}                  ::  file request.
           {$wegh $~}                                    ::  report memory
           {$went p/sack q/path r/@ud s/coop}            ::  response confirm
           {$west p/sack q/path r/*}                     ::  network request

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -390,7 +390,7 @@
           {$mere p/(each (set path) (pair term tang))}  ::  merge result
           {$note p/@tD q/tank}                          ::  debug message
           {$ogre p/@tas}                                ::  delete mount point
-          {$rule src/path rul/rule}                     ::  node permission
+          {$rule red/dict wit/dict}                     ::  node r+w permissions
           {$send p/lane:ames q/@}                       ::  transmit packet
           {$writ p/riot}                                ::  response
           {$wris p/case p/(set (pair care path))}       ::  many changes
@@ -407,7 +407,12 @@
           {$mont p/desk q/beam}                         ::  mount to unix
           {$dirk p/desk}                                ::  mark mount dirty
           {$ogre p/$@(desk beam)}                       ::  delete mount point
-          {$perm des/desk pax/path rul/(unit rule)}     ::  change permissions
+          $:  $perm                                     ::  change permissions
+              des/desk                                  ::  target desk
+              pax/path                                  ::  target node
+              rit/rite                                  ::  read, write or both
+              rul/(unit rule)                           ::  new rule
+          ==                                            ::
           {$warp p/sock q/riff}                         ::  file request
           {$wegh $~}                                    ::  report memory
           {$went p/sack q/path r/@ud s/coop}            ::  response confirm
@@ -436,6 +441,7 @@
     ==                                                  ::
   ++  coop  (unit ares)                                 ::  e2e ack
   ++  crew  (set ship)                                  ::  permissions group
+  ++  dict  {src/path rul/rule}                         ::  effective permission
   ++  dome                                              ::  project state
     $:  ank/ankh                                        ::  state
         let/@ud                                         ::  top id
@@ -500,6 +506,7 @@
         {$many p/? q/moat}                              ::  track range
     ==                                                  ::
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist
+  ++  rite  ?($r $w $rw)                                ::  permission for
   ++  riot  (unit rant)                                 ::  response+complete
   ++  rule  {mod/?($black $white) who/(set whom)}       ::  node permission
   ++  rump  {p/care q/case r/@tas s/path}               ::  relative path

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -381,7 +381,8 @@
   ++  able  ^?
     |%
     ++  gift                                            ::  out result <-$
-      $%  {$cruz cez/(map @ta crew)}                    ::  permission groups
+      $%  {$croz rus/(map desk {r/regs w/regs})}        ::  rules for group
+          {$cruz cez/(map @ta crew)}                    ::  permission groups
           {$dirk p/@tas}                                ::  mark mount dirty
           {$ergo p/@tas q/mode}                         ::  version update
           {$hill p/(list @tas)}                         ::  mount points
@@ -399,6 +400,7 @@
       $%  {$boat $~}                                    ::  pier rebooted
           {$cred our/ship nom/@ta cew/crew}             ::  set permission group
           {$crew our/ship}                              ::  permission groups
+          {$crow our/ship nom/@ta}                      ::  group usage
           {$drop our/@p des/desk}                       ::  cancel pending merge
           {$info our/@p des/desk dit/nori}              ::  internal edit
           {$init our/@p}                                ::  report install

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -390,7 +390,7 @@
           {$mere p/(each (set path) (pair term tang))}  ::  merge result
           {$note p/@tD q/tank}                          ::  debug message
           {$ogre p/@tas}                                ::  delete mount point
-          {$rule own/? rul/rule}                        ::  node permission
+          {$rule src/path rul/rule}                     ::  node permission
           {$send p/lane:ames q/@}                       ::  transmit packet
           {$writ p/riot}                                ::  response
           {$wris p/case p/(set (pair care path))}       ::  many changes


### PR DESCRIPTION
As discussed internally, permissions for the filesystem.

Permissions are set for all revisions of a node. If a node doesn't have permissions set, those of the parent node are used. If no permissions are set all the way up to root, we default to fully private.

The clay interface sees some additions to support basic permissions management.

`++task`:
- `{$cred our/ship nom/@ta cew/crew}` for setting permission groups.
- `{$crew our/ship}` for getting permission groups.
- `{$perm our/ship des/desk pax/path rit/rite}` for setting permissions for a node.
- A `%p` `++care` for reading permissions set for a node on a local desk.

`++gift`:
- `{$cruz cez/(map @ta crew)}`, the response to `%crew` requests.
- `{$rule red/dict wit/dict}`, the response to `%p` file requests.

~And a notable change that was required for making permission checks actually functional:  
The interface for `%warp` file request now includes a `ship` which has to be set to the requesting ship.  
When doing a `%warp` for local data, you just set it to `our`, as you do for many other tasks. When doing a `%west` for foreign data, the target ship automatically turns it into a `%warp` with the original sender specified.~  
Read requests from foreign ships come in as `%west`s. They now get re-sent to the local clay as `%werp`s, which get dealt with as `%warp`s that require permission checks. No checks are done for write requests, because those only originate locally right now.

Eventually, the above will be more elegantly solved from within arvo itself, passing vanes a pair of recipients and responsible ships for each incoming event. Not to mention making a global `our` available once the new boot sequence lands. Changing this to make use of that shouldn't be difficult.

Aside, having to take original requester into account when deduping requests likely completely obliterates any use that still saw. We're fine to keep it in, but at this point it might be costing more performance than it'll ever gain us.

Need to do more thorough testing and implement a state adapter, but it boots (off an updated pill at least) and seems to work as advertised so far, so I'd say that's good enough for review/discussion.