### PR TITLE
Use ++mold instead of ++gate in ++cask and ++hypo.

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -12651,7 +12651,7 @@
          ==                                            ::
 ++  desk  @tas                                          ::  ship desk case spur
 ++  cage  (cask vase)                                   ::  global metadata
-++  cask  |*(a/gate (pair mark a))                      ::  global data
+++  cask  |*(a/mold (pair mark a))                      ::  global data
 ++  cuff                                                ::  permissions
           $:  p/(unit (set monk))                       ::  can be read by
               q/(set monk)                              ::  caused or created by
@@ -12659,7 +12659,7 @@
 ++  curd  {p/@tas q/*}                                  ::  typeless card
 ++  dock  (pair @p term)                                ::  message target
 ++  duct  (list wire)                                   ::  causal history
-++  hypo  |*(a/gate (pair type a))                      ::  type associated
+++  hypo  |*(a/mold (pair type a))                      ::  type associated
 ++  hobo  |*  a/gate                                    ::  task wrapper
           $?  $%  {$soft p/*}                           ::
               ==                                        ::


### PR DESCRIPTION
After looking at `++pair` I agree with Anton that these should be `++mold`.
All of the vanes compile with these changes.