### PR TITLE
Hall additions and changes to support New Web DMs

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -316,11 +316,13 @@
       ?-  -.act
         ::  circle configuration
         $create  (action-create +.act)
+        $design  (action-design +.act)
         $source  (action-source +.act)
         $depict  (action-depict +.act)
         $filter  (action-filter +.act)
         $permit  (action-permit +.act)
         $delete  (action-delete +.act)
+        $usage   (action-usage +.act)
         ::  messaging
         $convey  (action-convey +.act)
         $phrase  (action-phrase +.act)
@@ -384,11 +386,20 @@
         %^  impact  nom  %new
         :*  [[[our.bol nom] ~] ~ ~]
             des
+            ~
             *filter
             :-  typ
             ?.  ?=(?($village $journal) typ)  ~
             [our.bol ~ ~]
         ==
+      (ta-evil (crip "{(trip nom)}: already exists"))
+    ::
+    ++  action-design
+      :>  creates a story with the specified config.
+      ::
+      |=  {nom/name cof/config}
+      ?.  (~(has in stories) nom)
+        (impact nom %new cof)
       (ta-evil (crip "{(trip nom)}: already exists"))
     ::
     ++  action-delete
@@ -437,6 +448,15 @@
       ?~  soy
         (ta-evil (crip "no story {(trip nom)}"))
       so-done:(~(so-sources so nom ~ u.soy) sub srs)
+    ::
+    ++  action-usage
+      :>  add or remove usage tags.
+      ::
+      |=  {nom/name add/? tas/tags}
+      =+  soy=(~(get by stories) nom)
+      ?~  soy
+        (ta-evil (crip "no story {(trip nom)}"))
+      so-done:(~(so-usage so nom ~ u.soy) add tas)
     ::
     :>  #  %messaging
     +|
@@ -1101,6 +1121,17 @@
       ^+  +>
       ?:  =(cap cap.shape)  +>
       (so-delta-our %config so-cir %caption cap)
+    ::
+    ++  so-usage
+      :>  add or remove usage tags.
+      ::
+      |=  {add/? tas/tags}
+      ^+  +>
+      =/  sas/tags
+        %.  tag.shape
+        ?:(add ~(dif in tas) ~(int in tas))
+      ?~  sas  +>.$
+      (so-delta-our %config so-cir %usage add sas)
     ::
     ++  so-filter
       :>    change message rules

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -110,6 +110,13 @@
       $%  {$repeat cir/circle ses/(list serial)}        :<  messaging wire
           {$circle nom/name src/source}                 :<  subscription wire
       ==                                                ::
+    ::
+    ++  old-state
+      (cork state |=(a/state a(stories (~(run by stories.a) old-story))))
+    ++  old-story
+      (cork story |=(a/story a(shape *old-config, mirrors (~(run by mirrors.a) old-config))))
+    ++  old-config
+      {src/(set source) cap/cord fit/filter con/control}
     --
 ::
 :>  #
@@ -125,12 +132,15 @@
 ++  prep
   :>  adapts state.
   ::
-  |=  old/(unit state)
+  |=  old/(unit old-state)
   ^-  (quip move _..prep)
   ?~  old
     %-  pre-bake
     ta-done:ta-init:ta
-  [~ ..prep(+<+ u.old)]
+  =-  [~ ..prep(+<+ `state`u.old(stories -))]
+  %-  ~(run by stories.u.old)
+  |=  soy/old-story
+  (story soy(shape [src cap ~ fit con]:shape.soy))
 ::
 :>  #  %engines
 :>    main cores.

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1392,14 +1392,6 @@
       =/  sus/(set ship)
         %.  sis.con.shape
         ?:(add ~(dif in sis) ~(int in sis))
-      =.  +>.$
-        ::  if banishing: notify only those affected.
-        ::  if inviting: notify all targets.
-        =?  sis  !inv  sus
-        =-  (so-act [%phrase - [%inv inv so-cir]~])
-        %-  ~(rep in `(set ship)`sis)
-        |=  {s/ship a/audience}
-        (~(put in a) [s %inbox])
       ?~  sus  +>.$
       ::  if banished, remove their presences.
       =?  +>.$  !inv

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1180,7 +1180,11 @@
         ::
         |=  {inv/? nom/name sis/(set ship)}
         ^+  ..sh-work
-        (sh-act %permit nom inv sis)
+        =.  ..sh-work  (sh-act %permit nom inv sis)
+        =-  (sh-act %phrase - [%inv inv [self nom]]~)
+        %-  ~(rep in sis)
+        |=  {s/ship a/audience}
+        (~(put in a) [s %inbox])
       ::
       ++  filter
         |=  {nom/name cus/? utf/?}

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -105,6 +105,11 @@
           {$help $~}                                    :<  print usage info
       ==                                                ::
     ++  glyphs  `wall`~[">=+-" "}),." "\"'`^" "$%&@"]   :<  circle char pool '
+    ::
+    ++  old-state
+      (cork state |=(a/state a(mirrors (~(run by mirrors.a) old-config))))
+    ++  old-config
+      {src/(set source) cap/cord fit/filter con/control}
     --
 ::
 :>  #
@@ -121,11 +126,14 @@
 ++  prep
   :>  adapts state
   ::
-  |=  old/(unit state)
+  |=  old/(unit old-state)
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
-  [~ ..prep(+<+ u.old)]
+  =-  [~ ..prep(+<+ `state`u.old(mirrors -))]
+  %-  ~(run by mirrors.u.old)
+  |=  old-config
+  [src cap ~ fit con]
 ::
 :>  #
 :>  #  %utility

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1828,6 +1828,7 @@
         $(dif [%filter fit.cof.dif])
       ?:  ?=($remove -.dif)
         (sh-note (weld "rip " (~(cr-show cr cir) ~)))
+      ?:  ?=($usage -.dif)  +>
       %-  sh-note
       %+  weld
         (weld ~(cr-phat cr cir) ": ")

--- a/lib/hall-json.hoon
+++ b/lib/hall-json.hoon
@@ -178,6 +178,7 @@
       $full     (conf cof.a)
       $source   (pairs add+b+add.a src+(sorc src.a) ~)
       $caption  s+cap.a
+      $usage    (pairs add+b+add.a tas+(sa tas.a cord) ~)
       $filter   (filt fit.a)
       $secure   s+sec.a
       $permit   (pairs add+b+add.a sis+(sa sis.a ship) ~)
@@ -229,6 +230,7 @@
     %-  pairs  :~
       src+(sa src.a sorc)
       cap+s+cap.a
+      tag+(sa tag.a cord)
       fit+(filt fit.a)
       con+(cont con.a)
     ==
@@ -425,6 +427,7 @@
     %-  of  :~
       full+conf
       source+(ot add+bo src+sorc ~)
+      usage+(ot add+bo tas+(as so) ~)
       caption+so
       filter+filt
       secure+secu
@@ -469,6 +472,7 @@
     %-  ot  :~
       src+(as sorc)
       cap+so
+      tag+(as so)
       fit+filt
       con+cont
     ==

--- a/lib/hall.hoon
+++ b/lib/hall.hoon
@@ -127,6 +127,15 @@
     $filter   cof(fit fit.dif)
     $remove   cof
   ::
+      $usage
+    %=  cof
+        tag
+      %.  tas.dif
+      ?:  add.dif
+        ~(uni in tag.cof)
+      ~(dif in tag.cof)
+    ==
+  ::
       $source
     %=  cof
         src

--- a/mar/hall/action.hoon
+++ b/mar/hall/action.hoon
@@ -16,11 +16,13 @@
     ^-  action:hall
     =-  (need ((of -) a))
     :~  create+(ot nom+so des+so sec+secu ~)
+        design+(ot nom+so cof+conf ~)
         delete+(ot nom+so why+(mu so) ~)
         depict+(ot nom+so des+so ~)
         filter+(ot nom+so fit+filt ~)
         permit+(ot nom+so inv+bo sis+(as (su fed:ag)) ~)
         source+(ot nom+so sub+bo srs+(as sorc) ~)
+        usage+(ot nom+so add+bo tas+(as so) ~)
         ::
         convey+(ar thot)
         phrase+(ot aud+audi ses+(ar spec:dejs:hall-json) ~)
@@ -46,11 +48,13 @@
     %-  pairs
     ?-  -.act
       $create  ~[nom+s+nom.act des+s+des.act sec+s+sec.act]
+      $design  ~[nom+s+nom.act cof+(conf cof.act)]
       $delete  ~[nom+s+nom.act why+(mabe why.act cord:enjs)]
       $depict  ~[nom+s+nom.act des+s+des.act]
       $filter  ~[nom+s+nom.act fit+(filt fit.act)]
       $permit  ~[nom+s+nom.act inv+b+inv.act sis+(sa sis.act ship)]
       $source  ~[nom+s+nom.act sub+b+sub.act srs+(sa srs.act sorc)]
+      $usage   ~[nom+s+nom.act add+b+add.act tas+(sa tas.act cord:enjs)]
       ::
       $phrase  ~[aud+(audi aud.act) ses+a+(turn ses.act spec:enjs)]
       ::

--- a/sur/hall.hoon
+++ b/sur/hall.hoon
@@ -16,6 +16,7 @@
 ::TODO  rename
 ++  name  term                                          :<  circle name
 ++  nick  cord                                          :<  local nickname
+++  tags  (set knot)                                    :<  usage tags
 ::
 :>  #
 :>  #  %query-models
@@ -110,6 +111,7 @@
   $%  {$full cof/config}                                :<  set w/o side-effects
       {$source add/? src/source}                        :<  add/rem sources
       {$caption cap/cord}                               :<  changed description
+      {$usage add/? tas/tags}                           :<  add/rem usage tags
       {$filter fit/filter}                              :<  changed filter
       {$secure sec/security}                            :<  changed security
       {$permit add/? sis/(set ship)}                    :<  add/rem to b/w-list
@@ -136,11 +138,13 @@
 ++  action                                              :>  user action
   $%  ::  circle configuration                          ::
       {$create nom/name des/cord sec/security}          :<  create circle
+      {$design nom/name cof/config}                     :<  create with config
       {$delete nom/name why/(unit cord)}                :<  delete + announce
       {$depict nom/name des/cord}                       :<  change description
       {$filter nom/name fit/filter}                     :<  change message rules
       {$permit nom/name inv/? sis/(set ship)}           :<  invite/banish
       {$source nom/name sub/? srs/(set source)}         :<  un/sub to/from src
+      {$usage nom/name add/? tas/tags}                  :<  add/rem usage tags
       ::  messaging                                     ::
       {$convey tos/(list thought)}                      :<  post exact
       {$phrase aud/audience ses/(list speech)}          :<  post easy
@@ -178,6 +182,7 @@
 ++  config                                              :>  circle config
   $:  src/(set source)                                  :<  active sources
       cap/cord                                          :<  description
+      tag/tags                                          :<  usage tags
       fit/filter                                        :<  message rules
       con/control                                       :<  restrictions
   ==                                                    ::


### PR DESCRIPTION
These changes were requested for the current work on a new web UI. In particular, these will allow the client to deal with DM groups more elegantly.

- Adds a `tag/(set @ta)` "usage tags" to circle configuration, which clients can use so store arbitrary usage metadata.
  - To set these during creation, issue a `%design` action, which creates a circle with the specified `config` structure.
  - To change these for existing circles, use a `%usage` actions to add or remove any number of tags.
- When updating permissions, `%inv`ite messages are no longer sent automatically. The client can decide when it is and isn't appropriate to send these itself. Closes #606.

cc @c-johnson @vvisigoth