### PR TITLE
Update crutch for kiln

### DIFF
--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -67,7 +67,7 @@
           {$dirk wire @tas}                             ::
           {$ogre wire $@(@tas beam)}                    ::
           {$merg wire @p @tas @p @tas case germ}        ::
-          {$perm wire ship desk path rite:clay}         ::
+          {$perm wire ship desk path rite}              ::
           {$poke wire dock pear}                        ::
           {$wipe wire @p $~}                            ::
           {$wait wire @da}                              ::
@@ -86,6 +86,13 @@
           q/path
           r/cage
       ==
+    ++  rite                                            ::tmp
+      $%  {$r red/(unit rule)}
+          {$w wit/(unit rule)}
+          {$rw red/(unit rule) wit/(unit rule)}
+      ==
+    ++  rule  {mod/?($black $white) who/(set whom)}     ::tmp
+    ++  whom  (each ship @ta)                           ::tmp
     --
 |_  moz/(list move)
 ++  abet                                                ::  resolve


### PR DESCRIPTION
Ensures that updating live to current master doesn't kill the kiln. As suggested [here](https://github.com/urbit/arvo/pull/610#issuecomment-365730101).

These should be removed once an update has actually happened, but are safe to stay in until any of the involved structures change.