### PR TITLE
Revert changes to hall circle configs (and thus the hall protocol)

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -117,7 +117,7 @@
 :>  #
 :>    functional cores and arms.
 ::
-|_  {bol/bowl:gall $1 state}
+|_  {bol/bowl:gall $2 state}
 ::
 :>  #  %transition
 :>    prep transition
@@ -127,15 +127,15 @@
   ::
   =>  |%
       ++  states
-        ?(state-0 $%({$1 s/state}))
+        ?(state $%({$1 s/state-1} {$2 s/state}))
       ::
-      ++  state-0
-        (cork state |=(a/state a(stories (~(run by stories.a) story-0))))
-      ++  story-0
+      ++  state-1
+        (cork state |=(a/state a(stories (~(run by stories.a) story-1))))
+      ++  story-1
         %+  cork  story
-        |=(a/story a(shape *config-0, mirrors (~(run by mirrors.a) config-0)))
-      ++  config-0
-        {src/(set source) cap/cord fit/filter con/control}
+        |=(a/story a(shape *config-1, mirrors (~(run by mirrors.a) config-1)))
+      ++  config-1
+        {src/(set source) cap/cord tag/(set knot) fit/filter con/control}
       --
   =|  mos/(list move)
   |=  old/(unit states)
@@ -144,15 +144,18 @@
     %-  pre-bake
     ta-done:ta-init:ta
   ?-  -.u.old
-      $1
+      $2
     [mos ..prep(+<+ u.old)]
   ::
-      ?($~ ^)  ::  $0
-    =-  $(old `[%1 u.old(stories -)])
-    %-  ~(run by stories.u.old)
-    |=  soy/story-0
+      $1
+    =-  $(old `[%2 s.u.old(stories -)])
+    %-  ~(run by stories.s.u.old)
+    |=  soy/story-1
     ^-  story
-    (story soy(shape [src cap ~ fit con]:shape.soy))
+    (story soy(shape [src cap fit con]:shape.soy))
+  ::
+      ?($~ ^)  ::  $0
+    $(old `[%2 u.old])
   ==
 ::
 :>  #  %engines

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -339,13 +339,11 @@
       ?-  -.act
         ::  circle configuration
         $create  (action-create +.act)
-        $design  (action-design +.act)
         $source  (action-source +.act)
         $depict  (action-depict +.act)
         $filter  (action-filter +.act)
         $permit  (action-permit +.act)
         $delete  (action-delete +.act)
-        $usage   (action-usage +.act)
         ::  messaging
         $convey  (action-convey +.act)
         $phrase  (action-phrase +.act)
@@ -409,20 +407,11 @@
         %^  impact  nom  %new
         :*  [[[our.bol nom] ~] ~ ~]
             des
-            ~
             *filter
             :-  typ
             ?.  ?=(?($village $journal) typ)  ~
             [our.bol ~ ~]
         ==
-      (ta-evil (crip "{(trip nom)}: already exists"))
-    ::
-    ++  action-design
-      :>  creates a story with the specified config.
-      ::
-      |=  {nom/name cof/config}
-      ?.  (~(has in stories) nom)
-        (impact nom %new cof)
       (ta-evil (crip "{(trip nom)}: already exists"))
     ::
     ++  action-delete
@@ -471,15 +460,6 @@
       ?~  soy
         (ta-evil (crip "no story {(trip nom)}"))
       so-done:(~(so-sources so nom ~ u.soy) sub srs)
-    ::
-    ++  action-usage
-      :>  add or remove usage tags.
-      ::
-      |=  {nom/name add/? tas/tags}
-      =+  soy=(~(get by stories) nom)
-      ?~  soy
-        (ta-evil (crip "no story {(trip nom)}"))
-      so-done:(~(so-usage so nom ~ u.soy) add tas)
     ::
     :>  #  %messaging
     +|
@@ -1145,17 +1125,6 @@
       ^+  +>
       ?:  =(cap cap.shape)  +>
       (so-delta-our %config so-cir %caption cap)
-    ::
-    ++  so-usage
-      :>  add or remove usage tags.
-      ::
-      |=  {add/? tas/tags}
-      ^+  +>
-      =/  sas/tags
-        %.  tag.shape
-        ?:(add ~(dif in tas) ~(int in tas))
-      ?~  sas  +>.$
-      (so-delta-our %config so-cir %usage add sas)
     ::
     ++  so-filter
       :>    change message rules

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1852,7 +1852,6 @@
         $(dif [%filter fit.cof.dif])
       ?:  ?=($remove -.dif)
         (sh-note (weld "rip " (~(cr-show cr cir) ~)))
-      ?:  ?=($usage -.dif)  +>
       %-  sh-note
       %+  weld
         (weld ~(cr-phat cr cir) ": ")

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -112,7 +112,7 @@
 :>  #
 :>    functional cores and arms.
 ::
-|_  {bol/bowl:gall $1 state}
+|_  {bol/bowl:gall $2 state}
 ::
 :>  #  %transition
 :>    prep transition
@@ -123,12 +123,12 @@
   ::
   =>  |%
       ++  states
-        ?(state-0 $%({$1 s/state}))
+        ?(state $%({$1 s/state-1} {$2 s/state}))
       ::
-      ++  state-0
-        (cork state |=(a/state a(mirrors (~(run by mirrors.a) config-0))))
-      ++  config-0
-        {src/(set source) cap/cord fit/filter con/control}
+      ++  state-1
+        (cork state |=(a/state a(mirrors (~(run by mirrors.a) config-1))))
+      ++  config-1
+        {src/(set source) cap/cord tag/(set knot) fit/filter con/control}
       --
   =|  mos/(list move)
   |=  old/(unit states)
@@ -137,14 +137,18 @@
     ta-done:ta-init:ta
   ?+  -.u.old
       ::  $0
-    =+  ole=(state-0 u.old)
-    =-  $(old `[%1 ole(mirrors -)])
-    %-  ~(run by mirrors.ole)
-    |=  config-0
-    [src cap ~ fit con]
+    $(old `[%2 u.old])
+  ::
+      $2
+    [mos ..prep(+<+ [%2 (state +.u.old)])]
   ::
       $1
-    [mos ..prep(+<+ [%1 (state +.u.old)])]
+    ::  we hard-cast here because it find-errors on s.u.old otherwise?
+    =+  ole=(state-1 +.u.old)
+    =-  $(old `[%2 ole(mirrors -)])
+    %-  ~(run by mirrors.ole)
+    |=  config-1
+    [src cap fit con]
   ==
 ::
 :>  #

--- a/lib/hall-json.hoon
+++ b/lib/hall-json.hoon
@@ -178,7 +178,6 @@
       $full     (conf cof.a)
       $source   (pairs add+b+add.a src+(sorc src.a) ~)
       $caption  s+cap.a
-      $usage    (pairs add+b+add.a tas+(sa tas.a cord) ~)
       $filter   (filt fit.a)
       $secure   s+sec.a
       $permit   (pairs add+b+add.a sis+(sa sis.a ship) ~)
@@ -230,7 +229,6 @@
     %-  pairs  :~
       src+(sa src.a sorc)
       cap+s+cap.a
-      tag+(sa tag.a cord)
       fit+(filt fit.a)
       con+(cont con.a)
     ==
@@ -427,7 +425,6 @@
     %-  of  :~
       full+conf
       source+(ot add+bo src+sorc ~)
-      usage+(ot add+bo tas+(as so) ~)
       caption+so
       filter+filt
       secure+secu
@@ -472,7 +469,6 @@
     %-  ot  :~
       src+(as sorc)
       cap+so
-      tag+(as so)
       fit+filt
       con+cont
     ==

--- a/lib/hall.hoon
+++ b/lib/hall.hoon
@@ -127,15 +127,6 @@
     $filter   cof(fit fit.dif)
     $remove   cof
   ::
-      $usage
-    %=  cof
-        tag
-      %.  tas.dif
-      ?:  add.dif
-        ~(uni in tag.cof)
-      ~(dif in tag.cof)
-    ==
-  ::
       $source
     %=  cof
         src

--- a/mar/hall/action.hoon
+++ b/mar/hall/action.hoon
@@ -16,13 +16,11 @@
     ^-  action:hall
     =-  (need ((of -) a))
     :~  create+(ot nom+so des+so sec+secu ~)
-        design+(ot nom+so cof+conf ~)
         delete+(ot nom+so why+(mu so) ~)
         depict+(ot nom+so des+so ~)
         filter+(ot nom+so fit+filt ~)
         permit+(ot nom+so inv+bo sis+(as (su fed:ag)) ~)
         source+(ot nom+so sub+bo srs+(as sorc) ~)
-        usage+(ot nom+so add+bo tas+(as so) ~)
         ::
         convey+(ar thot)
         phrase+(ot aud+audi ses+(ar spec:dejs:hall-json) ~)
@@ -48,13 +46,11 @@
     %-  pairs
     ?-  -.act
       $create  ~[nom+s+nom.act des+s+des.act sec+s+sec.act]
-      $design  ~[nom+s+nom.act cof+(conf cof.act)]
       $delete  ~[nom+s+nom.act why+(mabe why.act cord:enjs)]
       $depict  ~[nom+s+nom.act des+s+des.act]
       $filter  ~[nom+s+nom.act fit+(filt fit.act)]
       $permit  ~[nom+s+nom.act inv+b+inv.act sis+(sa sis.act ship)]
       $source  ~[nom+s+nom.act sub+b+sub.act srs+(sa srs.act sorc)]
-      $usage   ~[nom+s+nom.act add+b+add.act tas+(sa tas.act cord:enjs)]
       ::
       $phrase  ~[aud+(audi aud.act) ses+a+(turn ses.act spec:enjs)]
       ::

--- a/sur/hall.hoon
+++ b/sur/hall.hoon
@@ -16,7 +16,6 @@
 ::TODO  rename
 ++  name  term                                          :<  circle name
 ++  nick  cord                                          :<  local nickname
-++  tags  (set knot)                                    :<  usage tags
 ::
 :>  #
 :>  #  %query-models
@@ -111,7 +110,6 @@
   $%  {$full cof/config}                                :<  set w/o side-effects
       {$source add/? src/source}                        :<  add/rem sources
       {$caption cap/cord}                               :<  changed description
-      {$usage add/? tas/tags}                           :<  add/rem usage tags
       {$filter fit/filter}                              :<  changed filter
       {$secure sec/security}                            :<  changed security
       {$permit add/? sis/(set ship)}                    :<  add/rem to b/w-list
@@ -138,13 +136,11 @@
 ++  action                                              :>  user action
   $%  ::  circle configuration                          ::
       {$create nom/name des/cord sec/security}          :<  create circle
-      {$design nom/name cof/config}                     :<  create with config
       {$delete nom/name why/(unit cord)}                :<  delete + announce
       {$depict nom/name des/cord}                       :<  change description
       {$filter nom/name fit/filter}                     :<  change message rules
       {$permit nom/name inv/? sis/(set ship)}           :<  invite/banish
       {$source nom/name sub/? srs/(set source)}         :<  un/sub to/from src
-      {$usage nom/name add/? tas/tags}                  :<  add/rem usage tags
       ::  messaging                                     ::
       {$convey tos/(list thought)}                      :<  post exact
       {$phrase aud/audience ses/(list speech)}          :<  post easy
@@ -182,7 +178,6 @@
 ++  config                                              :>  circle config
   $:  src/(set source)                                  :<  active sources
       cap/cord                                          :<  description
-      tag/tags                                          :<  usage tags
       fit/filter                                        :<  message rules
       con/control                                       :<  restrictions
   ==                                                    ::


### PR DESCRIPTION
The stars are currently drowning in `%diff-bad-ack` messages. They're trying to send out urbit-meta updates so subscribers, but not all of those subscribers are running the latest arvo with the recent hall changes. This results in a mismatch in the expected message type.

In its current state, the network clearly isn't ready to receive userspace protocol updates. Not all ships are getting/running updates (see also #509 and #611), and comets weren't in the first place. There is currently no mechanism for implementing application interface versioning that would allow this to be overcome elegantly, so I think our safest bet here is to just keep interfaces consistent for now.

The changes this reverts come from #621. These were made to support the currently still in development Collections application/web interface, so nothing on the livenet depends on them. After this PR, up-to-date ships will be able to chat with out-of-date ships again.