### PR TITLE
Pre-breach cleanup

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -2192,9 +2192,9 @@
     ::  only auto-federate channels for now.
     ?.  ?=($channel sec.con.shape.s)  ~
     :+  ~  n
-    ::  share no more than 2k messages at once, for performance reasons.
-    :+  ?:  (lte count.s 2.000)  grams.s
-        (slag (sub count.s 2.000) grams.s)
+    ::  share no more than the last 100, for performance reasons.
+    :+  ?:  (lte count.s 100)  grams.s
+        (slag (sub count.s 100) grams.s)
       [shape.s mirrors.s]
     [locals.s remotes.s]
   ::

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -117,7 +117,7 @@
 :>  #
 :>    functional cores and arms.
 ::
-|_  {bol/bowl:gall $2 state}
+|_  {bol/bowl:gall $0 state}
 ::
 :>  #  %transition
 :>    prep transition
@@ -127,15 +127,7 @@
   ::
   =>  |%
       ++  states
-        ?(state $%({$1 s/state-1} {$2 s/state}))
-      ::
-      ++  state-1
-        (cork state |=(a/state a(stories (~(run by stories.a) story-1))))
-      ++  story-1
-        %+  cork  story
-        |=(a/story a(shape *config-1, mirrors (~(run by mirrors.a) config-1)))
-      ++  config-1
-        {src/(set source) cap/cord tag/(set knot) fit/filter con/control}
+        $%({$0 s/state})
       --
   =|  mos/(list move)
   |=  old/(unit states)
@@ -144,18 +136,8 @@
     %-  pre-bake
     ta-done:ta-init:ta
   ?-  -.u.old
-      $2
+      $0
     [mos ..prep(+<+ u.old)]
-  ::
-      $1
-    =-  $(old `[%2 s.u.old(stories -)])
-    %-  ~(run by stories.s.u.old)
-    |=  soy/story-1
-    ^-  story
-    (story soy(shape [src cap fit con]:shape.soy))
-  ::
-      ?($~ ^)  ::  $0
-    $(old `[%2 u.old])
   ==
 ::
 :>  #  %engines

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -342,11 +342,13 @@
       ?-  -.act
         ::  circle configuration
         $create  (action-create +.act)
+        $design  (action-design +.act)
         $source  (action-source +.act)
         $depict  (action-depict +.act)
         $filter  (action-filter +.act)
         $permit  (action-permit +.act)
         $delete  (action-delete +.act)
+        $usage   (action-usage +.act)
         ::  messaging
         $convey  (action-convey +.act)
         $phrase  (action-phrase +.act)
@@ -410,11 +412,20 @@
         %^  impact  nom  %new
         :*  [[[our.bol nom] ~] ~ ~]
             des
+            ~
             *filter
             :-  typ
             ?.  ?=(?($village $journal) typ)  ~
             [our.bol ~ ~]
         ==
+      (ta-evil (crip "{(trip nom)}: already exists"))
+    ::
+    ++  action-design
+      :>  creates a story with the specified config.
+      ::
+      |=  {nom/name cof/config}
+      ?.  (~(has in stories) nom)
+        (impact nom %new cof)
       (ta-evil (crip "{(trip nom)}: already exists"))
     ::
     ++  action-delete
@@ -463,6 +474,15 @@
       ?~  soy
         (ta-evil (crip "no story {(trip nom)}"))
       so-done:(~(so-sources so nom ~ u.soy) sub srs)
+    ::
+    ++  action-usage
+      :>  add or remove usage tags.
+      ::
+      |=  {nom/name add/? tas/tags}
+      =+  soy=(~(get by stories) nom)
+      ?~  soy
+        (ta-evil (crip "no story {(trip nom)}"))
+      so-done:(~(so-usage so nom ~ u.soy) add tas)
     ::
     :>  #  %messaging
     +|
@@ -1128,6 +1148,17 @@
       ^+  +>
       ?:  =(cap cap.shape)  +>
       (so-delta-our %config so-cir %caption cap)
+    ::
+    ++  so-usage
+      :>  add or remove usage tags.
+      ::
+      |=  {add/? tas/tags}
+      ^+  +>
+      =/  sas/tags
+        %.  tag.shape
+        ?:(add ~(dif in tas) ~(int in tas))
+      ?~  sas  +>.$
+      (so-delta-our %config so-cir %usage add sas)
     ::
     ++  so-filter
       :>    change message rules

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -112,7 +112,7 @@
 :>  #
 :>    functional cores and arms.
 ::
-|_  {bol/bowl:gall $2 state}
+|_  {bol/bowl:gall $0 state}
 ::
 :>  #  %transition
 :>    prep transition
@@ -123,32 +123,16 @@
   ::
   =>  |%
       ++  states
-        ?(state $%({$1 s/state-1} {$2 s/state}))
-      ::
-      ++  state-1
-        (cork state |=(a/state a(mirrors (~(run by mirrors.a) config-1))))
-      ++  config-1
-        {src/(set source) cap/cord tag/(set knot) fit/filter con/control}
+        $%({$0 s/state})
       --
   =|  mos/(list move)
   |=  old/(unit states)
   ^-  (quip move _..prep)
   ?~  old
     ta-done:ta-init:ta
-  ?+  -.u.old
-      ::  $0
-    $(old `[%2 u.old])
-  ::
-      $2
-    [mos ..prep(+<+ [%2 (state +.u.old)])]
-  ::
-      $1
-    ::  we hard-cast here because it find-errors on s.u.old otherwise?
-    =+  ole=(state-1 +.u.old)
-    =-  $(old `[%2 ole(mirrors -)])
-    %-  ~(run by mirrors.ole)
-    |=  config-1
-    [src cap fit con]
+  ?-  -.u.old
+      $0
+    [mos ..prep(+<+ u.old)]
   ==
 ::
 :>  #

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -1856,6 +1856,7 @@
         $(dif [%filter fit.cof.dif])
       ?:  ?=($remove -.dif)
         (sh-note (weld "rip " (~(cr-show cr cir) ~)))
+      ?:  ?=($usage -.dif)  +>
       %-  sh-note
       %+  weld
         (weld ~(cr-phat cr cir) ": ")

--- a/lib/hall-json.hoon
+++ b/lib/hall-json.hoon
@@ -178,6 +178,7 @@
       $full     (conf cof.a)
       $source   (pairs add+b+add.a src+(sorc src.a) ~)
       $caption  s+cap.a
+      $usage    (pairs add+b+add.a tas+(sa tas.a cord) ~)
       $filter   (filt fit.a)
       $secure   s+sec.a
       $permit   (pairs add+b+add.a sis+(sa sis.a ship) ~)
@@ -229,6 +230,7 @@
     %-  pairs  :~
       src+(sa src.a sorc)
       cap+s+cap.a
+      tag+(sa tag.a cord)
       fit+(filt fit.a)
       con+(cont con.a)
     ==
@@ -425,6 +427,7 @@
     %-  of  :~
       full+conf
       source+(ot add+bo src+sorc ~)
+      usage+(ot add+bo tas+(as so) ~)
       caption+so
       filter+filt
       secure+secu
@@ -469,6 +472,7 @@
     %-  ot  :~
       src+(as sorc)
       cap+so
+      tag+(as so)
       fit+filt
       con+cont
     ==

--- a/lib/hall.hoon
+++ b/lib/hall.hoon
@@ -127,6 +127,15 @@
     $filter   cof(fit fit.dif)
     $remove   cof
   ::
+      $usage
+    %=  cof
+        tag
+      %.  tas.dif
+      ?:  add.dif
+        ~(uni in tag.cof)
+      ~(dif in tag.cof)
+    ==
+  ::
       $source
     %=  cof
         src

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -80,19 +80,6 @@
           {$helm-reset $~}                              ::
       ==                                                ::
     ++  move  (pair bone card)                          ::  user-level move
-    ++  riot                                            ::tmp  up-to-date riot
-      %-  unit
-      $:  p/{p/?($d $p $u $v $w $x $y $z) q/case r/desk}
-          q/path
-          r/cage
-      ==
-    ++  rite                                            ::tmp
-      $%  {$r red/(unit rule)}
-          {$w wit/(unit rule)}
-          {$rw red/(unit rule) wit/(unit rule)}
-      ==
-    ++  rule  {mod/?($black $white) who/(set whom)}     ::tmp
-    ++  whom  (each ship @ta)                           ::tmp
     --
 |_  moz/(list move)
 ++  abet                                                ::  resolve

--- a/mar/hall/action.hoon
+++ b/mar/hall/action.hoon
@@ -16,11 +16,13 @@
     ^-  action:hall
     =-  (need ((of -) a))
     :~  create+(ot nom+so des+so sec+secu ~)
+        design+(ot nom+so cof+conf ~)
         delete+(ot nom+so why+(mu so) ~)
         depict+(ot nom+so des+so ~)
         filter+(ot nom+so fit+filt ~)
         permit+(ot nom+so inv+bo sis+(as (su fed:ag)) ~)
         source+(ot nom+so sub+bo srs+(as sorc) ~)
+        usage+(ot nom+so add+bo tas+(as so) ~)
         ::
         convey+(ar thot)
         phrase+(ot aud+audi ses+(ar spec:dejs:hall-json) ~)
@@ -46,11 +48,13 @@
     %-  pairs
     ?-  -.act
       $create  ~[nom+s+nom.act des+s+des.act sec+s+sec.act]
+      $design  ~[nom+s+nom.act cof+(conf cof.act)]
       $delete  ~[nom+s+nom.act why+(mabe why.act cord:enjs)]
       $depict  ~[nom+s+nom.act des+s+des.act]
       $filter  ~[nom+s+nom.act fit+(filt fit.act)]
       $permit  ~[nom+s+nom.act inv+b+inv.act sis+(sa sis.act ship)]
       $source  ~[nom+s+nom.act sub+b+sub.act srs+(sa srs.act sorc)]
+      $usage   ~[nom+s+nom.act add+b+add.act tas+(sa tas.act cord:enjs)]
       ::
       $phrase  ~[aud+(audi aud.act) ses+a+(turn ses.act spec:enjs)]
       ::

--- a/sur/hall.hoon
+++ b/sur/hall.hoon
@@ -16,6 +16,7 @@
 ::TODO  rename
 ++  name  term                                          :<  circle name
 ++  nick  cord                                          :<  local nickname
+++  tags  (set knot)                                    :<  usage tags
 ::
 :>  #
 :>  #  %query-models
@@ -110,6 +111,7 @@
   $%  {$full cof/config}                                :<  set w/o side-effects
       {$source add/? src/source}                        :<  add/rem sources
       {$caption cap/cord}                               :<  changed description
+      {$usage add/? tas/tags}                           :<  add/rem usage tags
       {$filter fit/filter}                              :<  changed filter
       {$secure sec/security}                            :<  changed security
       {$permit add/? sis/(set ship)}                    :<  add/rem to b/w-list
@@ -136,11 +138,13 @@
 ++  action                                              :>  user action
   $%  ::  circle configuration                          ::
       {$create nom/name des/cord sec/security}          :<  create circle
+      {$design nom/name cof/config}                     :<  create with config
       {$delete nom/name why/(unit cord)}                :<  delete + announce
       {$depict nom/name des/cord}                       :<  change description
       {$filter nom/name fit/filter}                     :<  change message rules
       {$permit nom/name inv/? sis/(set ship)}           :<  invite/banish
       {$source nom/name sub/? srs/(set source)}         :<  un/sub to/from src
+      {$usage nom/name add/? tas/tags}                  :<  add/rem usage tags
       ::  messaging                                     ::
       {$convey tos/(list thought)}                      :<  post exact
       {$phrase aud/audience ses/(list speech)}          :<  post easy
@@ -178,6 +182,7 @@
 ++  config                                              :>  circle config
   $:  src/(set source)                                  :<  active sources
       cap/cord                                          :<  description
+      tag/tags                                          :<  usage tags
       fit/filter                                        :<  message rules
       con/control                                       :<  restrictions
   ==                                                    ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3571,7 +3571,7 @@
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 =|                                                    ::  instrument state
-    $:  $4                                            ::  vane version
+    $:  $0                                            ::  vane version
         ruf/raft                                      ::  revision tree
     ==                                                ::
 |=  {now/@da eny/@ ski/sley}                          ::  activate
@@ -3832,72 +3832,12 @@
 ::
 ++  load
   =>  |%
-      +=  wove-3  rove
-      ++  cult-3  (jug wove-3 duct)
-      ++  dojo-3
-        $:  qyx/cult-3
-            dom/dome
-            dok/(unit dork)
-            mer/(unit mery)
-        ==
-      ++  rede-3
-        $:  lim/@da
-            ref/(unit rind)
-            qyx/cult-3
-            dom/dome
-            dok/(unit dork)
-            mer/(unit mery)
-        ==
-      ++  room-3  (cork room |=(a/room a(dos (~(run by dos.a) dojo-3))))
-      ++  rung-3  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-3))))
-      ++  raft-3
-        $:  fat/(map ship room-3)
-            hoy/(map ship rung-3)
-            ran/rang
-            mon/(map term beam)
-            hez/(unit duct)
-        ==
-      ++  axle    $%({$3 ruf/raft-3} {$4 ruf/raft})
+      ++  axle  $%({$0 ruf/raft})
       --
   |=  old/axle
   ^+  ..^$
   ?-  -.old
-    $4  ..^$(ruf ruf.old)
-    $3  |^
-          =-  ^$(old [%4 -])
-          =+  ruf.old
-          :*  (~(run by fat) rom)
-              (~(run by hoy) run)
-              ran  mon  hez  ~
-          ==
-        ::
-        ++  wov
-          |=  a/wove-3  ^-  wove
-          [~ a]
-        ::
-        ++  cul
-          |=  a/cult-3  ^-  cult
-          %-  ~(gas by *cult)
-          %+  turn  ~(tap by a)
-          |=  {p/wove-3 q/(set duct)}
-          [(wov p) q]
-        ::
-        ++  rom
-          |=  room-3
-          :-  hun
-          %-  ~(urn by dos)
-          |=  {d/desk dojo-3}
-          =/  n/dojo  [(cul qyx) dom dok mer ~ ~]
-          ?.  =(%kids d)  n
-          n(per [[/ %black ~] ~ ~])
-        ::
-        ++  run
-          =/  red
-            |=  rede-3
-            =+  [[/ %black ~] ~ ~]
-            [lim ref (cul qyx) dom dok mer - -]
-          |=(a/rung-3 a(rus (~(run by rus.a) red)))
-        --
+    $0  ..^$(ruf ruf.old)
   ==
 ::
 ++  scry                                              ::  inspect
@@ -3929,7 +3869,7 @@
   ?:  ?=($& -.u.u.-)  ``p.u.u.-
   ~
 ::
-++  stay  [%4 ruf]
+++  stay  [%0 ruf]
 ++  take                                              ::  accept response
   |=  {tea/wire hen/duct hin/(hypo sign)}
   ^+  [p=*(list move) q=..^$]

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -7,15 +7,9 @@
 ++  gill  (pair ship term)                              ::  general contact
 --                                                      ::
 =>  |%                                                  ::  console protocol
-++  all-axle  ?(old-axle axle)                          ::
-++  old-axle                                            ::  all dill state
-  $:  $2                                                ::
-      ore/(unit ship)                                   ::  identity once set
-      hey/(unit duct)                                   ::  default duct
-      dug/(map duct axon)                               ::  conversations
-  ==                                                    ::
+++  all-axle  ?(axle)                                   ::
 ++  axle                                                ::
-  $:  $3                                                ::
+  $:  $0                                                ::
       ore/(unit ship)                                   ::  identity once set
       hey/(unit duct)                                   ::  default duct
       dug/(map duct axon)                               ::  conversations
@@ -520,8 +514,6 @@
 ::
 ++  load                                                ::  trivial
   |=  old/all-axle
-  ?:  ?=($2 -.old)
-    $(old [%3 ore hey dug ~ ~ ~ ~ ~ ~]:old)
   ..^$(all old)
   ::  |=  old=*   ::  diable
   ::  ..^$(ore.all `~zod)

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -85,7 +85,7 @@
 --                                                      ::
 |%                                                      ::  models
 ++  bolo                                                ::  eyre state
-  $:  $6                                                ::  version
+  $:  $0                                                ::  version
       gub/@t                                            ::  random identity
       hov/(unit ship)                                   ::  master for remote
       top/beam                                          ::  ford serve prefix
@@ -2025,15 +2025,10 @@
   ~
 ::
 ++  load                                                ::  take previous state
-  =+  driv-5=_=>(*driv [cor=p req=req.q])
-  =+  bolo-5={$5 _=+(*bolo +.-(sec (~(run by sec.-) driv-5)))}
-  =+  bolo-4={$4 _%*(+ *bolo-5 lyv *(map duct ^))}
   ::|=  *  %.  (bolo +<)
-  |=  old/?(bolo bolo-5 bolo-4)  ^+  ..^$
+  |=  old/?(bolo)  ^+  ..^$
   ?-  -.old
-    $6  ..^$(+>- old)
-    $5  $(old [%6 +.old(sec (~(run by sec.old) |=(driv-5 [cor & req])))])
-    $4  $(old [%5 +.old(lyv ~)])          :: minor leak
+    $0  ..^$(+>- old)
   ==
 ::
 ++  scry

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -33,7 +33,7 @@
 --                                                      ::
 |%                                                      ::  structures
 ++  axle                                                ::  all %ford state
-  $:  $2                                                ::  version for update
+  $:  $0                                                ::  version for update
       pol/(map ship baby)                               ::
   ==                                                    ::
 ++  baby                                                ::  state by ship

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -31,27 +31,11 @@
 --                                                      ::
 |%  ::::::::::::::::::::::::::::::::::::::::::::::::::::::    %gall state
     ::::::::::::::::::::::::::::::::::::::::::::::::::::::
-++  axle-n  ?(axle-1 axle-2 axle-3 axle-4)              ::  upgrade path
-++  axle-1  {$1 pol/(map ship mast-1)}                  ::
-++  mast-1                                              ::
-  (cork mast-2 |=(mast-2 +<(bum (~(run by bum) seat-1)))) ::
-++  seat-1                                              ::
-  (cork seat-2 |=(seat-2 +<+))                          ::
-++  axle-2  {$2 pol/(map ship mast-2)}                  ::
-++  mast-2  (cork mast-3 |=(mast-3 +<+))                ::
-++  seat-2  seat-3                                      ::
-++  axle-3  {$3 pol/(map ship mast-3)}                  ::
-++  mast-3                                              ::
-  (cork mast-4 |=(mast-4 +<(bum (~(run by bum) seat-3)))) ::
-++  seat-3                                              ::
-  (cork seat-4 |=(seat-4 +<+))                          ::
-++  axle-4  axle                                        ::
-++  mast-4  mast                                        ::
-++  seat-4  seat                                        ::  
+++  axle-n  ?(axle)                                     ::  upgrade path
     ::::::::::::::::::::::::::::::::::::::::::::::::::::::  state proper
     ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ++  axle                                                ::  all state
-  $:  $4                                                ::  state version
+  $:  $0                                                ::  state version
       pol/(map ship mast)                               ::  apps by ship
   ==                                                    ::
 ++  gest                                                ::  subscriber data
@@ -1311,29 +1295,7 @@
   |=  old/axle-n
   ^+  ..^$
   ?-  -.old
-      $4  ..^$(all old)
-      $3
-    %=  $
-      old  ^-  axle-4
-           =>  |=(seat-3 `seat-4`[*misvale-data +<])
-           =>  |=(mast-3 +<(bum (~(run by bum) +>)))
-           old(- %4, pol (~(run by pol.old) .))
-    ==
-  ::
-      $2
-    %=  $
-      old  ^-  axle-3
-           =>  |=(mast-2 [*(unit duct) +<])
-           old(- %3, pol (~(run by pol.old) .))
-    ==
-  ::
-      $1
-    %=  $
-      old  ^-  axle-2
-           =>  |=(seat-1 `seat-2`[*worm +<])
-           =>  |=(mast-1 +<(bum (~(run by bum) +>)))
-           old(- %2, pol (~(run by pol.old) .))
-    ==
+      $0  ..^$(all old)
   ==
 ::
 ++  scry


### PR DESCRIPTION
- Make federation more performant by just sending 100 messages of backlog initially. (short-term fix for #582 in a federation context)
- Put #621 back in.
- Clean up app (hall, talk) and vane (clay, dill, eyre, ford, gall) states and state adapters to be state version `%0` again.
- Remove deprecated code in kiln.