### PR TITLE
Talk now only loads in messages from the last five days on first boot.

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -227,7 +227,7 @@
       server
     ::
       %+  welp  /circle/[inbox]/grams/config/group
-      ?.  =(0 last)
+      ?.  =(0 count)
         [(scot %ud last) ~]
       =+  history-days=~d5
       [(scot %da (sub now.bol history-days)) ~]

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -229,7 +229,8 @@
       %+  welp  /circle/[inbox]/grams/config/group
       ?.  =(0 last)
         [(scot %ud last) ~]
-      [(scot %da (sub now.bol ~d5)) ~]
+      =+  history-days=~d5
+      [(scot %da (sub now.bol history-days)) ~]
   ==
 ::
 :>  #

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -29,9 +29,10 @@
     |%
     ++  state                                           :>  application state
       $:  ::  messaging state                           ::
-          count/@ud                                     :<  (lent grams)
           grams/(list telegram)                         :<  all history
           known/(map serial @ud)                        :<  messages heard
+          last/@ud                                      :<  last heard
+          count/@ud                                     :<  (lent grams)
           sources/(set circle)                          :<  our subscriptions
           ::  circle details                            ::
           remotes/(map circle group)                    :<  remote presences
@@ -226,7 +227,9 @@
       server
     ::
       %+  welp  /circle/[inbox]/grams/config/group
-      ?:(=(0 count) ~ [(scot %ud count) ~])
+      ?.  =(0 last)
+        [(scot %ud last) ~]
+      [(scot %da (sub now.bol ~d5)) ~]
   ==
 ::
 :>  #
@@ -367,7 +370,7 @@
         ~&([%unexpected-circle-rumor -.rum] +>)
     ::
         $gram
-      (ta-learn gam.nev.rum)
+      (ta-open nev.rum)
     ::
         $config
       =+  cur=(fall (~(get by mirrors) cir.rum) *config)
@@ -453,15 +456,16 @@
     ::
     |=  nes/(list envelope)
     ^+  +>
-    (ta-lesson (turn nes tail))
+    ?~  nes  +>
+    $(nes t.nes, +> (ta-open i.nes))
   ::
-  ++  ta-lesson
-    :>  learn all telegrams in a list.
+  ++  ta-open
+    :>  learn message from an envelope.
     ::
-    |=  gaz/(list telegram)
+    |=  nev/envelope
     ^+  +>
-    ?~  gaz  +>
-    $(gaz t.gaz, +> (ta-learn i.gaz))
+    =?  last  (gth num.nev last)  num.nev
+    (ta-learn gam.nev)
   ::
   ++  ta-learn
     :>    save/update message
@@ -2458,7 +2462,7 @@
     ==
   ?:  =(a 'reset')
     ~&  'full reset incoming, hold on to your cli...'
-    :_  +>(grams ~, known ~, count 0)
+    :_  +>(grams ~, known ~, count 0, last 0)
     :~  [ost.bol %pull /server/client server ~]
         [ost.bol %pull /server/inbox server ~]
         peer-client


### PR DESCRIPTION
Makes moons suffer less when connecting to old planets.

Had this queued up for a while, apparently never made it into a PR.