### PR TITLE
amend #589 to reduce =| mold namespace pollution

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -277,7 +277,7 @@
   :>  input if it fits or a default value if it doesn't.
   :>
   :>  examples: * @ud ,[p=time q=?(%a %b)]
-  _|=(* +<)
+  _|~(* +<)
 ::
 ++  pair
   :>    dual tuple


### PR DESCRIPTION
This should fix womb, which has a |=(mold (unit (... +<))) that
pulls ++unit from the wrong place.