### PR TITLE
fixes and documents ++spin/++spun (forwardport #385)

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -640,17 +640,17 @@
 ++  spin                                                :>  stateful turn
   :>
   :>  a: list
-  :>  b: gate from list-item and state to product and new state
-  :>  c: state
+  :>  b: state
+  :>  c: gate from list-item and state to product and new state
   ~/  %spin
-  |*  [a=(list) b=_|=(^ [** +<+]) c=*]
-  =>  .(b `$-([_?>(?=(^ a) i.a) _c] [* _c])`b)
-  =/  acc=(list _-:(b))  ~
+  |*  [a=(list) b=* c=_|=(^ [** +<+])]
+  =>  .(c `$-([_?>(?=(^ a) i.a) _b] [* _b])`c)
+  =/  acc=(list _-:(c))  ~
   :>  transformed list and updated state
-  |-  ^-  (pair _acc _c)
+  |-  ^-  (pair _acc _b)
   ?~  a
-    [(flop acc) c]
-  =^  res  c  (b i.a c)
+    [(flop acc) b]
+  =^  res  b  (c i.a b)
   $(acc [res acc], a t.a)
 ::
 ++  spun                                                :>  internal spin
@@ -660,7 +660,7 @@
   ~/  %spun
   |*  [a=(list) b=_|=(^ [** +<+])]
   :>  transformed list
-  p:(spin a b +<+.b)
+  p:(spin a +<+.b b)
 ::
 ++  swag                                                ::  slice
   |*  {{a/@ b/@} c/(list)}

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -637,23 +637,30 @@
   ^+  t.a
   [i.a $(a (skim t.a |=(c/_i.a !(b c i.a))))]
 ::
-++  spin
-  |*  {a/(list) b/_|=({* *} [** +<+]) c/*}
-  ::  ?<  ?=($-([_?<(?=($~ a) i.a) _c] [* _c]) b)
-  |-
+++  spin                                                :>  stateful turn
+  :>
+  :>  a: list
+  :>  b: gate from list-item and state to product and new state
+  :>  c: state
+  ~/  %spin
+  |*  [a=(list) b=_|=(^ [** +<+]) c=*]
+  =>  .(b `$-([_?>(?=(^ a) i.a) _c] [* _c])`b)
+  =/  acc=(list _-:(b))  ~
+  :>  transformed list and updated state
+  |-  ^-  (pair _acc _c)
   ?~  a
-    ~
-  =+  v=(b i.a c)
-  [i=-.v t=$(a t.a, c +.v)]
+    [(flop acc) c]
+  =^  res  c  (b i.a c)
+  $(acc [res acc], a t.a)
 ::
-++  spun
-  |*  {a/(list) b/_|=({* *} [** +<+])}
-  =|  c/_+<+.b
-  |-
-  ?~  a
-    ~
-  =+  v=(b i.a c)
-  [i=-.v t=$(a t.a, c +.v)]
+++  spun                                                :>  internal spin
+  :>
+  :>  a: list
+  :>  b: gate from list-item and state to product and new state
+  ~/  %spun
+  |*  [a=(list) b=_|=(^ [** +<+])]
+  :>  transformed list
+  p:(spin a b +<+.b)
 ::
 ++  swag                                                ::  slice
   |*  {{a/@ b/@} c/(list)}


### PR DESCRIPTION
This forwardports #385, with a few additional changes:

- doccords (are these in the correct style? clear descriptions?)
- corrected typecast
- changed `++spin` argument order

The previously commented-out typecast reliably dumps core. Here's a representative backtrace: https://gist.github.com/joemfb/2884e2edf0e910beac630bef5b0c1ad0

I haven't been able to create a reproduction smaller than this:

```
|*  [a=(list) b=_|=(^ [** +<+]) c=*]
?<  ?=($-([_?<(?=($~ a) i.a) _c] [* _c]) b)
a
```

While that obviously shouldn't crash a ship (somehow not being virtualized?), I think fishing for a core like that is supposed to crash in the Hoon sense. I've switched to the common `=>  %=` typecast style.

As for the argument order, I think it's best for the gate to be last, particularly when it comes to wide form hoons.

Ex:

```
> (spin (ly 3 3 3 ~) ~(. og eny) |=([a=@ b=_og] (rads:b a)))
[p=~[2 2 0] q=<4.wmp {a/@uvJ <54.tyv 119.aiq 30.hhq 1.jmk $143>}>]
> (spun (ly 3 3 3 ~) |=([a=@ b=_~(. og eny)] (rads:b a)))
~[1 2 0]
```

These gates are unused, so there shouldn't be a problem pushing this out live.

/cc @chc4 