### PR TITLE
Get last x messages from hall

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1210,6 +1210,7 @@
               ?=(^ tal.u.ran.src)
             ::
               ?-  -.u.tal.u.ran.src
+                $sd   &
                 $da   (gte now.bol +.u.tal.u.ran.src)
                 $ud   ?&  ?=(^ seq)
                           (gte u.seq +.u.tal.u.ran.src)
@@ -1230,7 +1231,13 @@
       ::  fill in empty ranges to select all grams.
       =.  ran
         ?~  ran  `[[%ud 0] `[%ud count]]
-        ?~  tal.u.ran  `[hed.u.ran `[%ud count]]
+        =*  hed  hed.u.ran
+        =?  hed  ?=($sd -.hed)
+          [%ud (sub count (min count (abs:si +.hed)))]
+        ?~  tal.u.ran  `[hed `[%ud count]]
+        =*  tal  u.tal.u.ran
+        =?  tal  ?=($sd -.tal)
+          [%ud (sub count (min count (abs:si +.tal)))]
         ran
       ::  never fails, but compiler needs it.
       ?>  &(?=(^ ran) ?=(^ tal.u.ran))
@@ -1240,12 +1247,14 @@
       ?:  ?-  -.u.tal.u.ran                             ::  after the end
             $ud  (lth +.u.tal.u.ran num)
             $da  (lth +.u.tal.u.ran wen.i.gaz)
+            $sd  !!  ::  caught above
           ==
         ::  if past the river, we're done searching.
         zeg
       ?:  ?-  -.hed.u.ran                               ::  before the start
             $ud  (lth num +.hed.u.ran)
             $da  (lth wen.i.gaz +.hed.u.ran)
+            $sd  !!  ::  caught above
           ==
         ::  if before the river, continue onward.
         $(num +(num), gaz t.gaz)
@@ -1266,6 +1275,7 @@
       ?~  ran  [& |]
       =/  min
         ?-  -.hed.u.ran
+          $sd  &  ::  relative is always in.
           $ud  (gth count +.hed.u.ran)
           $da  (gth now.bol +.hed.u.ran)
         ==
@@ -1273,6 +1283,7 @@
         [min |]
       =-  [&(min -) !-]
       ?-  -.u.tal.u.ran
+        $sd  |  ::  relative is always done.
         $ud  (gte +(+.u.tal.u.ran) count)
         $da  (gte +.u.tal.u.ran now.bol)
       ==

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1228,7 +1228,8 @@
       |=  ran/range
       ^-  (list telegram)
       =+  [num=0 gaz=grams zeg=*(list telegram)]
-      ::  fill in empty ranges to select all grams.
+      ::  fill in empty ranges to select all grams,
+      ::  and calculate absolutes for relative places.
       =.  ran
         ?~  ran  `[[%ud 0] `[%ud count]]
         =*  hed  hed.u.ran
@@ -1241,24 +1242,26 @@
         ran
       ::  never fails, but compiler needs it.
       ?>  &(?=(^ ran) ?=(^ tal.u.ran))
+      =*  hed  hed.u.ran
+      =*  tal  u.tal.u.ran
       %-  flop
       |-  ^-  (list telegram)
       ?~  gaz  zeg
-      ?:  ?-  -.u.tal.u.ran                             ::  after the end
-            $ud  (lth +.u.tal.u.ran num)
-            $da  (lth +.u.tal.u.ran wen.i.gaz)
+      ?:  ?-  -.tal                                     ::  after the end
             $sd  !!  ::  caught above
+            $ud  (lth +.tal num)
+            $da  (lth +.tal wen.i.gaz)
           ==
-        ::  if past the river, we're done searching.
+        ::  if past the range, we're done searching.
         zeg
-      ?:  ?-  -.hed.u.ran                               ::  before the start
-            $ud  (lth num +.hed.u.ran)
-            $da  (lth wen.i.gaz +.hed.u.ran)
+      ?:  ?-  -.hed                                     ::  before the start
             $sd  !!  ::  caught above
+            $ud  (lth num +.hed)
+            $da  (lth wen.i.gaz +.hed)
           ==
-        ::  if before the river, continue onward.
+        ::  if before the range, continue onward.
         $(num +(num), gaz t.gaz)
-      ::  if in the river, add this gram and continue.
+      ::  if in the range, add this gram and continue.
       $(num +(num), gaz t.gaz, zeg [i.gaz zeg])
     ::
     ++  so-in-range
@@ -1274,18 +1277,20 @@
       ^-  {in/? done/?}
       ?~  ran  [& |]
       =/  min
-        ?-  -.hed.u.ran
+        =*  hed  hed.u.ran
+        ?-  -.hed
           $sd  &  ::  relative is always in.
-          $ud  (gth count +.hed.u.ran)
-          $da  (gth now.bol +.hed.u.ran)
+          $ud  (gth count +.hed)
+          $da  (gth now.bol +.hed)
         ==
       ?~  tal.u.ran
         [min |]
       =-  [&(min -) !-]
-      ?-  -.u.tal.u.ran
+      =*  tal  u.tal.u.ran
+      ?-  -.tal
         $sd  |  ::  relative is always done.
-        $ud  (gte +(+.u.tal.u.ran) count)
-        $da  (gte +.u.tal.u.ran now.bol)
+        $ud  (gte +(+.tal) count)
+        $da  (gte +.tal now.bol)
       ==
     ::
     :>  #

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -700,7 +700,7 @@
         ;~  pose
           (cold [%da now.bol] (jest 'now'))
           (stag %da (drat hed))
-          (stag %ud dem:ag)
+          placer
         ==
       ::
       ++  rang                                          :<  subscription range

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -229,8 +229,8 @@
       %+  welp  /circle/[inbox]/grams/config/group
       ?.  =(0 count)
         [(scot %ud last) ~]
-      =+  history-days=~d5
-      [(scot %da (sub now.bol history-days)) ~]
+      =+  history-msgs=200
+      [(cat 3 '-' (scot %ud history-msgs)) ~]
   ==
 ::
 :>  #

--- a/lib/hall.hoon
+++ b/lib/hall.hoon
@@ -66,10 +66,20 @@
   |=  ran/range
   ^-  path
   ?~  ran  ~
-  %+  welp
-    /(scot -.hed.u.ran +.hed.u.ran)
+  :-  (place-to-knot hed.u.ran)
   ?~  tal.u.ran  ~
-  /(scot -.u.tal.u.ran +.u.tal.u.ran)
+  [(place-to-knot u.tal.u.ran) ~]
+::
+++  place-to-knot
+  :>    msg pointer to path component
+  :>
+  :>  turns a place structure into a knot for use in
+  :>  subscription paths.
+  ::
+  |=  pla/place
+  ^-  knot
+  ?.  ?=($sd -.pla)  (scot -.pla +.pla)
+  (cat 3 '-' (scot %ud (abs:si +.pla)))
 ::
 ++  path-to-range
   :>    path to msg range
@@ -80,18 +90,27 @@
   |=  pax/path
   ^-  range
   ?~  pax  ~
+  =/  hes/(unit place)  (rush i.pax placer)
   ::  skip past non-number parts of path.
-  ?:  ?=({$~ $~} [(slaw %da i.pax) (slaw %ud i.pax)])
-    $(pax t.pax)
-  :+  ~
-    =+  hed=(slaw %da i.pax)
-    ?^  hed  [%da u.hed]
-    [%ud (slav %ud i.pax)]
+  ?~  hes  $(pax t.pax)
+  :+  ~  u.hes
   ?~  t.pax  ~
-  :-  ~
-  =+  tal=(slaw %da i.t.pax)
-  ?^  tal  [%da u.tal]
-  [%ud (slav %ud i.t.pax)]
+  (rush i.t.pax placer)
+::
+++  placer
+  :>  parse a range place
+  ;~  pose
+    (stag %ud dem:ag)
+  ::
+    =-  (stag %da (sear - crub:so))
+    |=  a/dime
+    ^-  (unit @da)
+    ?:(?=($da p.a) `q.a ~)
+  ::
+    %+  stag  %sd
+    %+  cook  (cury new:si |)
+    ;~(pfix hep dem:ag)
+  ==
 ::
 ++  change-glyphs                                       :<  ...
   ::

--- a/sur/hall.hoon
+++ b/sur/hall.hoon
@@ -55,6 +55,7 @@
 ++  place                                               :>  range indicators
   $%  {$da @da}                                         :<  date
       {$ud @ud}                                         :<  message number
+      {$sd @sd}                                         :<  previous messages
   ==                                                    ::
 ++  prize                                               :>  query result
   $%  {$client prize-client}                            :<  /client


### PR DESCRIPTION
With this change, it becomes possible to specify a relative range in hall subscriptions to refer to the last x messages.

For example:  
`/circle/inbox/grams/-5` gets the last 5 messages from the inbox, and updates on all that follow.  
`/circle/inbox/grams/-5/-0` gets the last 5 messages from the inbox, nothing more.  
`/circle/inbox/grams/0/-5` gets all messages from the inbox, up to but not including the last five.

Subscriptions with a relative range start are always active, they will receive updates until their range end is reached.  
Subscriptions with a relative range end end immediately.

Tested this to update cleanly from the previous hall version, and to not cause connectivity issues when talking to out-of-date versions.  
Subscriptions to older ships that make use of this new functionality/interface actually go through somehow, but count as rangeless subscriptions. Once the out-of-date ship updates, the subscriptions get seen and dealt with as appropriate.

Closes #643.  
cc @vvisigoth