### PR TITLE
Make +test only run arms starting with ++test-

### DIFF
--- a/gen/test.hoon
+++ b/gen/test.hoon
@@ -20,7 +20,8 @@
   ?.  matches
     ~
   ?-  -.q.b
-    %&  (run-test [p.b pax] eny p.q.b)
+    %&  ?.  =((end 3 5 p.b) 'test-')  ~
+        (run-test [p.b pax] eny p.q.b)
     %|  ^$(pax [p.b pax], a p.q.b)
   ==
 ::

--- a/gen/test.hoon
+++ b/gen/test.hoon
@@ -20,9 +20,15 @@
   ?.  matches
     ~
   ?-  -.q.b
-    %&  ?.  =((end 3 5 p.b) 'test-')  ~
-        (run-test [p.b pax] eny p.q.b)
-    %|  ^$(pax [p.b pax], a p.q.b)
+      %&
+    ?.  ?|  =((end 3 5 p.b) 'test-')
+            =((end 3 6 p.b) 'check-')
+        ==
+      ~
+    (run-test [p.b pax] eny p.q.b)
+  ::
+      %|
+    ^$(pax [p.b pax], a p.q.b)
   ==
 ::
 ++  run-test


### PR DESCRIPTION
My expectation was that this is how it worked, because the testing documentation mentions that testing arms start with `++test-` (or `++check`, not sure why). This isn't the case though, as adding a `++helper` into the main core causes it to try running that as a test anyway and crashing.

This PR makes sure that only arms starting with `++test-` are actually run when doing tests.