### PR TITLE
clean up and accelerate +test framework

### DIFF
--- a/gen/test.hoon
+++ b/gen/test.hoon
@@ -21,10 +21,6 @@
     ~
   ?-  -.q.b
       %&
-    ?.  ?|  =((end 3 5 p.b) 'test-')
-            =((end 3 6 p.b) 'check-')
-        ==
-      ~
     (run-test [p.b pax] eny p.q.b)
   ::
       %|

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -51,12 +51,15 @@
   =+  arms=(sort (sloe p.v) aor)
   %+  turn  arms
   |=  arm/term
+  ::REVIEW fewer asserts? recouple the nock and eat the runtime compile cost?
+  ?>  (~(nest ut (~(peek ut p.v) %free 6)) & p:!>((init-test)))
+  =/  call  (~(mint ut p.v) p:!>(*wall) [%limb arm])
+  ?>  (~(nest ut p:!>(*wall)) & p.call)
+  ::
   :-  arm
   :-  %&
-  |=  eny=@uvJ
-  =+  context=(slop !>((init-test eny)) v)
-  =/  r  (slap context [%cnsg [arm ~] [%$ 3] [[%$ 2] ~]])
-  ((hard (list tape)) q.r)
+  |=  eny=@uvJ  ^-  wall
+  ((hard wall) .*(q.v(+6 (init-test eny)) q.call))
 ::
 :>  #  %per-test
 :>    data initialized on a per-test basis.

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -22,7 +22,7 @@
   :>    combine the current file and subdirectory.
   :>
   :>  this merges the file {base} with its child files {recur}.
-  |=  [base=vase recur=(map @ta tests:tester)]
+  |=  [base=vase recur=(map @ta tests)]
   ^-  tests
   =+  a=(gen-tests base)
   =+  b=(test-map-to-test-list recur)
@@ -33,15 +33,15 @@
 ++  test-map-to-test-list
   :>    translates ford output to something we can work with.
   :>
-  :>  ford gives us a `(map @ta tests:tester)`, but we actually
+  :>  ford gives us a `(map @ta tests)`, but we actually
   :>  want something like ++tests.
-  |=  a=(map @ta tests:tester)
+  |=  a=(map @ta tests)
   ::  todo: i'd like to sort this, but ++sort has -find.a problems much like
   ::  ++weld does above!?
   ^-  tests
   %+  turn
     (to-list:dct:new-hoon a)
-  |=  {key/@ta value/tests:tester}
+  |=  {key/@ta value/tests}
   [key [%| value]]
 ::
 ++  gen-tests

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -44,12 +44,18 @@
   |=  {key/@ta value/tests}
   [key [%| value]]
 ::
+++  has-test-prefix
+  |=  a=term  ^-  ?
+  ?|  =((end 3 5 a) 'test-')
+      =((end 3 6 a) 'check-')
+  ==
+::
 ++  gen-tests
   :>  creates a {tests} list out of a vase of a test suite
   |=  v=vase
   ^-  tests
   =+  arms=(sort (sloe p.v) aor)
-  %+  turn  arms
+  %+  turn  (skim arms has-test-prefix)
   |=  arm/term
   ::REVIEW fewer asserts? recouple the nock and eat the runtime compile cost?
   ?>  (~(nest ut (~(peek ut p.v) %free 6)) & p:!>((init-test)))

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -61,11 +61,7 @@
 :>  #  %per-test
 :>    data initialized on a per-test basis.
 ::
-++  init-test
-  |=  {cookie/@uvJ}
-  ~(. tester `(list tape)`~ cookie 10 0)
-::
-++  tester-type  _(init-test `@uvJ`0)
+++  init-test  |=({eny/@uvJ} %*(. tester eny eny, check-iterations 10))
 ::
 ++  tester
   |_  $:  error-lines=(list tape)                     :<  output messages

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -56,7 +56,7 @@
   |=  eny=@uvJ
   =+  context=(slop !>((init-test eny)) v)
   =/  r  (slap context [%cnsg [arm ~] [%$ 3] [[%$ 2] ~]])
-  ((hard (list tape)) q:(slap r [%limb %results]))
+  ((hard (list tape)) q.r)
 ::
 :>  #  %per-test
 :>    data initialized on a per-test basis.
@@ -64,8 +64,7 @@
 ++  init-test  |=({eny/@uvJ} %*(. tester eny eny, check-iterations 10))
 ::
 ++  tester
-  |_  $:  error-lines=(list tape)                     :<  output messages
-          eny=@uvJ                                    :<  entropy
+  |_  $:  eny=@uvJ                                    :<  entropy
           check-iterations=@u                         :<  # of check trials
           current-iteration=@u                        :<  current iteration
       ==
@@ -76,27 +75,21 @@
   +|
   +-  check
     |*  [generator=$-(@uvJ *) test=$-(* ?)]
-    |-
-    ^+  +>.$
+    |-  ^-  wall
     ?:  (gth current-iteration check-iterations)
-      +>.$
+      ~
     ::  todo: wrap generator in mule so it can crash.
     =+  sample=(generator eny)
     ::  todo: wrap test in mule so it can crash.
-    =+  ret=(test sample)
-    ?:  ret
+    ?:  (test sample)
       %=  $
         eny    (shaf %huh eny)                        ::  xxx: better random?
         current-iteration  (add current-iteration 1)
       ==
-    =+  case=(add 1 current-iteration)
-    =+  case-plural=?:(=(case 1) "case" "cases")
-    %=  +>.$
-      error-lines  :*
-        "falsified after {(noah !>(case))} {case-plural} by '{(noah !>(sample))}'"
-        error-lines
-      ==
-    ==
+    =/  case  +(current-iteration)
+    =/  pl  ?+(case "" %1 "s")
+    ::XXX sample is a noun
+    ["falsified after {<case>} case{pl} by '{<`*`sample>}', seed {<eny>}"]~
   ::
   ::  todo: a generate function that takes an arbitrary span.
   ::
@@ -136,25 +129,11 @@
   ::  todo: unit testing libraries have a lot more to them than just eq.
   ++  expect-eq
     |*  [a=* b=*]
-    ^+  +>
+    ^-  wall
     ?:  =(a b)
-      +>.$
-    %=  +>.$
-      error-lines  :*
-        "actual:   '{(noah !>(a))}'"
+      ~
+    :~  "actual:   '{(noah !>(a))}'"
         "expected: '{(noah !>(b))}'"
-        error-lines
-      ==
     ==
-  ::
-  :>  #
-  :>  #  %output
-  :>  #
-  :>    called by the test harness
-  ::
-  ++  results
-    :>  returns results.
-    ^-  (list tape)
-    error-lines
   --
 --

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -137,12 +137,13 @@
   +|
   ::  todo: unit testing libraries have a lot more to them than just eq.
   ++  expect-eq
-    |*  [a=* b=*]
+    |=  a=vase
     ^-  wall
-    ?:  =(a b)
+    ?@  q.a  ["ex-expected-pair: '{(text a)}'"]~
+    ?:  =(-.q.a +.q.a)
       ~
-    :~  "actual:   '{(noah !>(a))}'"
-        "expected: '{(noah !>(b))}'"
+    :~  "expected: '{(text (slot 2 a))}'"
+        "actual:   '{(text (slot 3 a))}'"
     ==
   :>  #
   :>  #  %formatting

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -139,15 +139,14 @@
   +|
   ::  todo: unit testing libraries have a lot more to them than just eq.
   ++  expect-eq
-    |*  [a=* b=* c=tape]
+    |*  [a=* b=*]
     ^+  +>
     ?:  =(a b)
       +>.$
     %=  +>.$
       error-lines  :*
-        "failure: '{c}'"
-        "  actual:   '{(noah !>(a))}'"
-        "  expected: '{(noah !>(b))}'"
+        "actual:   '{(noah !>(a))}'"
+        "expected: '{(noah !>(b))}'"
         error-lines
       ==
     ==

--- a/lib/tester.hoon
+++ b/lib/tester.hoon
@@ -135,5 +135,15 @@
     :~  "actual:   '{(noah !>(a))}'"
         "expected: '{(noah !>(b))}'"
     ==
+  :>  #
+  :>  #  %formatting
+  :>  #
+  :>    test result presentation
+  +|
+  ++  category
+    |=  [a=tape b=wall]
+    ?:  =(~ b)  ~  :: test OK
+    :-  "in: '{a}'"
+    (turn b |=(c=tape "  {c}"))
   --
 --

--- a/tests/new-hoon/ls.hoon
+++ b/tests/new-hoon/ls.hoon
@@ -2,241 +2,241 @@
 =,  ls:new-hoon
 |_  _tester:tester
 ++  test-head
-  (expect-eq (head [1 ~]) 1)
+  (expect-eq !>([1 (head [1 ~])]))
 ::
 ++  test-last
-  (expect-eq (last:ls [1 2 ~]) 2)
+  (expect-eq !>([2 (last:ls [1 2 ~])]))
 ::
 ++  test-tail
-  (expect-eq (tail [1 2 3 ~]) [2 3 ~])
+  (expect-eq !>([[2 3 ~] (tail [1 2 3 ~])]))
 ::
 ++  test-init
-  (expect-eq (init [1 2 3 ~]) [1 2 ~])
+  (expect-eq !>([[1 2 ~] (init [1 2 3 ~])]))
 ::
 ++  test-size
-  (expect-eq (size ['a' 'b' 'c' ~]) 3)
+  (expect-eq !>([3 (size ['a' 'b' 'c' ~])]))
 ::
 ++  test-map
-  (expect-eq (map:ls [1 2 ~] |=(a/@ (add 1 a))) [2 3 ~])
+  (expect-eq !>([[2 3 ~] (map:ls [1 2 ~] |=(a/@ (add 1 a)))]))
 ::
 ++  test-reverse
-  (expect-eq (reverse [1 2 3 ~]) [3 2 1 ~])
+  (expect-eq !>([[3 2 1 ~] (reverse [1 2 3 ~])]))
 ::
 ++  test-intersperse
-  (expect-eq (intersperse 1 [5 5 5 ~]) [5 1 5 1 5 ~])
+  (expect-eq !>([[5 1 5 1 5 ~] (intersperse 1 [5 5 5 ~])]))
 ::
 ++  test-intercalate
-  %+    expect-eq
-    (intercalate "," ["one" "two" "three" ~])
-  ["one,two,three"]
+  %-  expect-eq  !>
+  :-  ["one,two,three"]
+  (intercalate "," ["one" "two" "three" ~])
 ::
 ++  test-transpose
-  %+  expect-eq
-    (transpose ~[~[1 2 3] ~[4 5 6]])
-  ~[~[1 4] ~[2 5] ~[3 6]]
+  %-  expect-eq  !>
+  :-  ~[~[1 4] ~[2 5] ~[3 6]]
+  (transpose ~[~[1 2 3] ~[4 5 6]])
 ::
 ++  test-foldl
-  (expect-eq (foldl [1 2 3 ~] 3 |=({a/@ b/@} (add a b))) 9)
+  (expect-eq !>([9 (foldl [1 2 3 ~] 3 |=({a/@ b/@} (add a b)))]))
 ::
 ++  test-foldr
-  (expect-eq (foldr [1 2 3 ~] 1 |=({a/@ b/@} (add a b))) 7)
+  (expect-eq !>([7 (foldr [1 2 3 ~] 1 |=({a/@ b/@} (add a b)))]))
 ::
 ++  test-concat
-  (expect-eq (concat ~[~[1 2] ~[3 4]]) ~[1 2 3 4])
+  (expect-eq !>([~[1 2 3 4] (concat ~[~[1 2] ~[3 4]])]))
 ::
 ++  test-weld
-  (expect-eq (weld:ls ~[1 2 3] ~["one" "two"]) ~[1 2 3 "one" "two"])
+  (expect-eq !>([~[1 2 3 "one" "two"] (weld:ls ~[1 2 3] ~["one" "two"])]))
 ::
 ++  test-any-true
-  (expect-eq (any [1 2 3 ~] |=(a/@ =(a 2))) %.y)
+  (expect-eq !>([%.y (any [1 2 3 ~] |=(a/@ =(a 2)))]))
 ::
 ++  test-any-false
-  (expect-eq (any [1 2 3 ~] |=(a/@ =(a 8))) %.n)
+  (expect-eq !>([%.n (any [1 2 3 ~] |=(a/@ =(a 8)))]))
 ::
 ++  test-all-true
-  (expect-eq (all [1 1 1 ~] |=(a/@ =(a 1))) %.y)
+  (expect-eq !>([%.y (all [1 1 1 ~] |=(a/@ =(a 1)))]))
 ::
 ++  test-all-false
-  (expect-eq (all [1 3 1 ~] |=(a/@ =(a 1))) %.n)
+  (expect-eq !>([%.n (all [1 3 1 ~] |=(a/@ =(a 1)))]))
 ::
 ++  test-scanl
-  %+  expect-eq
-    (scanl ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
-  ~[0 1 3 6]
+  %-  expect-eq  !>
+  :-  ~[0 1 3 6]
+  (scanl ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
 ::
 ++  test-scanl1
-  %+  expect-eq
-    (scanl1 ~[1 2 3] |=({a/@ b/@} (add a b)))
-  ~[1 3 6]
+  %-  expect-eq  !>
+  :-  ~[1 3 6]
+  (scanl1 ~[1 2 3] |=({a/@ b/@} (add a b)))
 ::
 ++  test-scanr
-  %+  expect-eq
-    (scanr ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
-  ~[6 5 3 0]
+  %-  expect-eq  !>
+  :-  ~[6 5 3 0]
+  (scanr ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
 ::
 ++  test-scanr1
-  %+  expect-eq
-    (scanr1 ~[1 2 3] |=({a/@ b/@} (add a b)))
-  ~[6 5 3]
+  %-  expect-eq  !>
+  :-  ~[6 5 3]
+  (scanr1 ~[1 2 3] |=({a/@ b/@} (add a b)))
 ::
 ++  test-map-foldl
-  %+  expect-eq
-    (map-foldl ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
-  [7 ~[2 3 5]]
+  %-  expect-eq  !>
+  :-  [7 ~[2 3 5]]
+  (map-foldl ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
 ::
 ++  test-map-foldr
-  %+  expect-eq
-    (map-foldr ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
-  [7 ~[7 5 2]]
+  %-  expect-eq  !>
+  :-  [7 ~[7 5 2]]
+  (map-foldr ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
 ::
 ++  test-unfoldr
-  %+  expect-eq
-    (unfoldr 5 |=(a/@ ?:(=(a 0) ~ `[a (dec a)])))
-  [5 4 3 2 1 ~]
+  %-  expect-eq  !>
+  :-  [5 4 3 2 1 ~]
+  (unfoldr 5 |=(a/@ ?:(=(a 0) ~ `[a (dec a)])))
 ::
 ++  test-take
-  %+  expect-eq
-    (take 3 ~[1 2 3 4 5])
-  [1 2 3 ~]
+  %-  expect-eq  !>
+  :-  [1 2 3 ~]
+  (take 3 ~[1 2 3 4 5])
 ::
 ++  test-drop
-  %+  expect-eq
-    (drop:ls 3 ~[1 2 3 4 5])
-  [4 5 ~]
+  %-  expect-eq  !>
+  :-  [4 5 ~]
+  (drop:ls 3 ~[1 2 3 4 5])
 ::
 ++  test-split-at
-  %+  expect-eq
-    (split-at 3 ~[1 2 3 4 5])
-  [[1 2 3 ~] [4 5 ~]]
+  %-  expect-eq  !>
+  :-  [[1 2 3 ~] [4 5 ~]]
+  (split-at 3 ~[1 2 3 4 5])
 ::
 ++  test-take-while
-  %+  expect-eq
-    (take-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
-  [1 2 ~]
+  %-  expect-eq  !>
+  :-  [1 2 ~]
+  (take-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
 ::
 ++  test-drop-while
-  %+  expect-eq
-    (drop-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
-  [3 4 5 ~]
+  %-  expect-eq  !>
+  :-  [3 4 5 ~]
+  (drop-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
 ::
 ++  test-drop-while-end
-  %+  expect-eq
-    (drop-while-end ~[5 5 1 5 5] |=(a/@ =(a 5)))
-  [5 5 1 ~]
+  %-  expect-eq  !>
+  :-  [5 5 1 ~]
+  (drop-while-end ~[5 5 1 5 5] |=(a/@ =(a 5)))
 ::
 ++  test-split-on
-  %+  expect-eq
-    (split-on ~[1 2 3 4 1 2 3 4] |=(a/@ (lth a 3)))
-  [[1 2 ~] [3 4 1 2 3 4 ~]]
+  %-  expect-eq  !>
+  :-  [[1 2 ~] [3 4 1 2 3 4 ~]]
+  (split-on ~[1 2 3 4 1 2 3 4] |=(a/@ (lth a 3)))
 ::
 ++  test-break
-  %+  expect-eq
-    (break ~[1 2 3 4 1 2 3 4] |=(a/@ (gth a 3)))
-  [[1 2 3 ~] [4 1 2 3 4 ~]]
+  %-  expect-eq  !>
+  :-  [[1 2 3 ~] [4 1 2 3 4 ~]]
+  (break ~[1 2 3 4 1 2 3 4] |=(a/@ (gth a 3)))
 ::
 ++  test-strip-prefix
-  %+  expect-eq
-    (strip-prefix "foo" "foobar")
-  [~ "bar"]
+  %-  expect-eq  !>
+  :-  [~ "bar"]
+  (strip-prefix "foo" "foobar")
 ::
 ++  test-inits
-  %+  expect-eq
-    (inits "abc")
-  ["a" "ab" "abc" ~]
+  %-  expect-eq  !>
+  :-  ["a" "ab" "abc" ~]
+  (inits "abc")
 ::
 ++  test-tails
-  %+  expect-eq
-    (tails "abc")
-  ["abc" "bc" "c" ~]
+  %-  expect-eq  !>
+  :-  ["abc" "bc" "c" ~]
+  (tails "abc")
 ::
 ++  test-is-prefix-of
-  %+  expect-eq
-    (is-prefix-of "foo" "foobar")
-  %.y
+  %-  expect-eq  !>
+  :-  %.y
+  (is-prefix-of "foo" "foobar")
 ::
 ++  test-is-suffix-of
-  %+  expect-eq
-    (is-suffix-of "bar" "foobar")
-  %.y
+  %-  expect-eq  !>
+  :-  %.y
+  (is-suffix-of "bar" "foobar")
 ::
 ++  test-is-infix-of
-  %+  expect-eq
-    (is-infix-of "ob" "foobar")
-  %.y
+  %-  expect-eq  !>
+  :-  %.y
+  (is-infix-of "ob" "foobar")
 ::
 ++  test-elem
-  %+  expect-eq
-    (elem 5 [1 2 3 4 5 ~])
-  %.y
+  %-  expect-eq  !>
+  :-  %.y
+  (elem 5 [1 2 3 4 5 ~])
 ::
 ++  test-lookup
-  %+  expect-eq
-    (lookup "two" [["one" 1] ["two" 2] ["three" 3] ~])
-  [~ 2]
+  %-  expect-eq  !>
+  :-  [~ 2]
+  (lookup "two" [["one" 1] ["two" 2] ["three" 3] ~])
 ::
 ++  test-find
-  %+  expect-eq
-    (find:ls [3 2 1 5 1 2 3 ~] |=(a/@ (gth a 3)))
-  [~ 5]
+  %-  expect-eq  !>
+  :-  [~ 5]
+  (find:ls [3 2 1 5 1 2 3 ~] |=(a/@ (gth a 3)))
 ::
 ++  test-filter
-  %+  expect-eq
-    (filter [1 2 1 2 1 ~] |=(a/@ =(a 2)))
-  [1 1 1 ~]
+  %-  expect-eq  !>
+  :-  [1 1 1 ~]
+  (filter [1 2 1 2 1 ~] |=(a/@ =(a 2)))
 ::
 ++  test-partition
-  %+  expect-eq
-    (partition [1 2 1 2 1 ~] |=(a/@ =(a 2)))
-  [[2 2 ~] [1 1 1 ~]]
+  %-  expect-eq  !>
+  :-  [[2 2 ~] [1 1 1 ~]]
+  (partition [1 2 1 2 1 ~] |=(a/@ =(a 2)))
 ::
 ++  test-elem-index
-  %+  expect-eq
-    (elem-index 2 [1 2 3 4 ~])
-  `1
+  %-  expect-eq  !>
+  :-  `1
+  (elem-index 2 [1 2 3 4 ~])
 ::
 ++  test-elem-indices
-  %+  expect-eq
-    (elem-indices 2 [1 2 1 2 ~])
-  [1 3 ~]
+  %-  expect-eq  !>
+  :-  [1 3 ~]
+  (elem-indices 2 [1 2 1 2 ~])
 ::
 ++  test-find-index
-  %+  expect-eq
-    (find-index [1 2 3 ~] |=(a/@ =(a 2)))
-  `1
+  %-  expect-eq  !>
+  :-  `1
+  (find-index [1 2 3 ~] |=(a/@ =(a 2)))
 ::
 ++  test-find-indices
-  %+  expect-eq
-    (find-indices [1 2 1 2 ~] |=(a/@ =(a 2)))
-  [1 3 ~]
+  %-  expect-eq  !>
+  :-  [1 3 ~]
+  (find-indices [1 2 1 2 ~] |=(a/@ =(a 2)))
 ::
 ++  test-zip
-  %+  expect-eq
-    (zip [[1 2 3 ~] [4 5 6 ~] [7 8 9 ~] ~])
-  [[1 4 7 ~] [2 5 8 ~] [3 6 9 ~] ~]
+  %-  expect-eq  !>
+  :-  [[1 4 7 ~] [2 5 8 ~] [3 6 9 ~] ~]
+  (zip [[1 2 3 ~] [4 5 6 ~] [7 8 9 ~] ~])
 ::
 ++  test-unique
-  %+  expect-eq
-    (unique [1 2 3 1 2 3 ~])
-  [1 2 3 ~]
+  %-  expect-eq  !>
+  :-  [1 2 3 ~]
+  (unique [1 2 3 1 2 3 ~])
 ::
 ++  test-delete
-  %+  expect-eq
-    (delete 2 [1 2 3 2 ~])
-  [1 3 2 ~]
+  %-  expect-eq  !>
+  :-  [1 3 2 ~]
+  (delete 2 [1 2 3 2 ~])
 ::
 ++  test-delete-firsts
-  %+  expect-eq
-    (delete-firsts [1 2 2 2 3 4 5 ~] [2 2 5 ~])
-  [1 2 3 4 ~]
+  %-  expect-eq  !>
+  :-  [1 2 3 4 ~]
+  (delete-firsts [1 2 2 2 3 4 5 ~] [2 2 5 ~])
 ::
 ++  test-union
-  %+  expect-eq
-    (union [1 2 3 ~] [4 2 5 ~])
-  [1 2 3 4 5 ~]
+  %-  expect-eq  !>
+  :-  [1 2 3 4 5 ~]
+  (union [1 2 3 ~] [4 2 5 ~])
 ::
 ++  test-intersect
-  %+  expect-eq
-    (intersect [5 6 6 7 8 ~] [9 8 8 6 ~])
-  [6 6 8 ~]
+  %-  expect-eq  !>
+  :-  [6 6 8 ~]
+  (intersect [5 6 6 7 8 ~] [9 8 8 6 ~])
 --
 

--- a/tests/new-hoon/ls.hoon
+++ b/tests/new-hoon/ls.hoon
@@ -2,279 +2,241 @@
 =,  ls:new-hoon
 |_  tester-type:tester
 ++  test-head
-  (expect-eq (head [1 ~]) 1 "head")
+  (expect-eq (head [1 ~]) 1)
 ::
 ++  test-last
-  (expect-eq (last:ls [1 2 ~]) 2 "last")
+  (expect-eq (last:ls [1 2 ~]) 2)
 ::
 ++  test-tail
-  (expect-eq (tail [1 2 3 ~]) [2 3 ~] "tail")
+  (expect-eq (tail [1 2 3 ~]) [2 3 ~])
 ::
 ++  test-init
-  (expect-eq (init [1 2 3 ~]) [1 2 ~] "init")
+  (expect-eq (init [1 2 3 ~]) [1 2 ~])
 ::
 ++  test-size
-  (expect-eq (size ['a' 'b' 'c' ~]) 3 "size")
+  (expect-eq (size ['a' 'b' 'c' ~]) 3)
 ::
 ++  test-map
-  (expect-eq (map:ls [1 2 ~] |=(a/@ (add 1 a))) [2 3 ~] "map")
+  (expect-eq (map:ls [1 2 ~] |=(a/@ (add 1 a))) [2 3 ~])
 ::
 ++  test-reverse
-  (expect-eq (reverse [1 2 3 ~]) [3 2 1 ~] "reverse")
+  (expect-eq (reverse [1 2 3 ~]) [3 2 1 ~])
 ::
 ++  test-intersperse
-  (expect-eq (intersperse 1 [5 5 5 ~]) [5 1 5 1 5 ~] "intersperse")
+  (expect-eq (intersperse 1 [5 5 5 ~]) [5 1 5 1 5 ~])
 ::
 ++  test-intercalate
-  %^  expect-eq
-  (intercalate "," ["one" "two" "three" ~])
+  %+    expect-eq
+    (intercalate "," ["one" "two" "three" ~])
   ["one,two,three"]
-  "intercalate"
 ::
 ++  test-transpose
-  %^  expect-eq
-  (transpose ~[~[1 2 3] ~[4 5 6]])
+  %+  expect-eq
+    (transpose ~[~[1 2 3] ~[4 5 6]])
   ~[~[1 4] ~[2 5] ~[3 6]]
-  "transpose"
 ::
 ++  test-foldl
-  (expect-eq (foldl [1 2 3 ~] 3 |=({a/@ b/@} (add a b))) 9 "foldl")
+  (expect-eq (foldl [1 2 3 ~] 3 |=({a/@ b/@} (add a b))) 9)
 ::
 ++  test-foldr
-  (expect-eq (foldr [1 2 3 ~] 1 |=({a/@ b/@} (add a b))) 7 "foldr")
+  (expect-eq (foldr [1 2 3 ~] 1 |=({a/@ b/@} (add a b))) 7)
 ::
 ++  test-concat
-  (expect-eq (concat ~[~[1 2] ~[3 4]]) ~[1 2 3 4] "concat")
+  (expect-eq (concat ~[~[1 2] ~[3 4]]) ~[1 2 3 4])
 ::
 ++  test-weld
-  (expect-eq (weld:ls ~[1 2 3] ~["one" "two"]) ~[1 2 3 "one" "two"] "weld")
+  (expect-eq (weld:ls ~[1 2 3] ~["one" "two"]) ~[1 2 3 "one" "two"])
 ::
 ++  test-any-true
-  (expect-eq (any [1 2 3 ~] |=(a/@ =(a 2))) %.y "any true")
+  (expect-eq (any [1 2 3 ~] |=(a/@ =(a 2))) %.y)
 ::
 ++  test-any-false
-  (expect-eq (any [1 2 3 ~] |=(a/@ =(a 8))) %.n "any false")
+  (expect-eq (any [1 2 3 ~] |=(a/@ =(a 8))) %.n)
 ::
 ++  test-all-true
-  (expect-eq (all [1 1 1 ~] |=(a/@ =(a 1))) %.y "all true")
+  (expect-eq (all [1 1 1 ~] |=(a/@ =(a 1))) %.y)
 ::
 ++  test-all-false
-  (expect-eq (all [1 3 1 ~] |=(a/@ =(a 1))) %.n "all false")
+  (expect-eq (all [1 3 1 ~] |=(a/@ =(a 1))) %.n)
 ::
 ++  test-scanl
-  %^  expect-eq
-  (scanl ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
+  %+  expect-eq
+    (scanl ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
   ~[0 1 3 6]
-  "scanl"
 ::
 ++  test-scanl1
-  %^  expect-eq
-  (scanl1 ~[1 2 3] |=({a/@ b/@} (add a b)))
+  %+  expect-eq
+    (scanl1 ~[1 2 3] |=({a/@ b/@} (add a b)))
   ~[1 3 6]
-  "scanl1"
 ::
 ++  test-scanr
-  %^  expect-eq
-  (scanr ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
+  %+  expect-eq
+    (scanr ~[1 2 3] 0 |=({a/@ b/@} (add a b)))
   ~[6 5 3 0]
-  "scanr"
 ::
 ++  test-scanr1
-  %^  expect-eq
-  (scanr1 ~[1 2 3] |=({a/@ b/@} (add a b)))
+  %+  expect-eq
+    (scanr1 ~[1 2 3] |=({a/@ b/@} (add a b)))
   ~[6 5 3]
-  "scanr1"
 ::
 ++  test-map-foldl
-  %^  expect-eq
-  (map-foldl ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
+  %+  expect-eq
+    (map-foldl ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
   [7 ~[2 3 5]]
-  "map-foldl"
 ::
 ++  test-map-foldr
-  %^  expect-eq
-  (map-foldr ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
+  %+  expect-eq
+    (map-foldr ~[1 2 3] 1 |=({a/@ b/@} [(add a b) (add 1 a)]))
   [7 ~[7 5 2]]
-  "map-foldr"
 ::
 ++  test-unfoldr
-  %^  expect-eq
-  (unfoldr 5 |=(a/@ ?:(=(a 0) ~ `[a (dec a)])))
+  %+  expect-eq
+    (unfoldr 5 |=(a/@ ?:(=(a 0) ~ `[a (dec a)])))
   [5 4 3 2 1 ~]
-  "unfoldr"
 ::
 ++  test-take
-  %^  expect-eq
-  (take 3 ~[1 2 3 4 5])
+  %+  expect-eq
+    (take 3 ~[1 2 3 4 5])
   [1 2 3 ~]
-  "take"
 ::
 ++  test-drop
-  %^  expect-eq
-  (drop:ls 3 ~[1 2 3 4 5])
+  %+  expect-eq
+    (drop:ls 3 ~[1 2 3 4 5])
   [4 5 ~]
-  "drop"
 ::
 ++  test-split-at
-  %^  expect-eq
-  (split-at 3 ~[1 2 3 4 5])
+  %+  expect-eq
+    (split-at 3 ~[1 2 3 4 5])
   [[1 2 3 ~] [4 5 ~]]
-  "split-at"
 ::
 ++  test-take-while
-  %^  expect-eq
-  (take-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
+  %+  expect-eq
+    (take-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
   [1 2 ~]
-  "take-while"
 ::
 ++  test-drop-while
-  %^  expect-eq
-  (drop-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
+  %+  expect-eq
+    (drop-while ~[1 2 3 4 5] |=(a/@ (lth a 3)))
   [3 4 5 ~]
-  "drop-while"
 ::
 ++  test-drop-while-end
-  %^  expect-eq
-  (drop-while-end ~[5 5 1 5 5] |=(a/@ =(a 5)))
+  %+  expect-eq
+    (drop-while-end ~[5 5 1 5 5] |=(a/@ =(a 5)))
   [5 5 1 ~]
-  "drop-while-end"
 ::
 ++  test-split-on
-  %^  expect-eq
-  (split-on ~[1 2 3 4 1 2 3 4] |=(a/@ (lth a 3)))
+  %+  expect-eq
+    (split-on ~[1 2 3 4 1 2 3 4] |=(a/@ (lth a 3)))
   [[1 2 ~] [3 4 1 2 3 4 ~]]
-  "split-on"
 ::
 ++  test-break
-  %^  expect-eq
-  (break ~[1 2 3 4 1 2 3 4] |=(a/@ (gth a 3)))
+  %+  expect-eq
+    (break ~[1 2 3 4 1 2 3 4] |=(a/@ (gth a 3)))
   [[1 2 3 ~] [4 1 2 3 4 ~]]
-  "break"
 ::
 ++  test-strip-prefix
-  %^  expect-eq
-  (strip-prefix "foo" "foobar")
+  %+  expect-eq
+    (strip-prefix "foo" "foobar")
   [~ "bar"]
-  "break"
 ::
 ++  test-inits
-  %^  expect-eq
-  (inits "abc")
+  %+  expect-eq
+    (inits "abc")
   ["a" "ab" "abc" ~]
-  "inits"
 ::
 ++  test-tails
-  %^  expect-eq
-  (tails "abc")
+  %+  expect-eq
+    (tails "abc")
   ["abc" "bc" "c" ~]
-  "tails"
 ::
 ++  test-is-prefix-of
-  %^  expect-eq
-  (is-prefix-of "foo" "foobar")
+  %+  expect-eq
+    (is-prefix-of "foo" "foobar")
   %.y
-  "is-prefix-of"
 ::
 ++  test-is-suffix-of
-  %^  expect-eq
-  (is-suffix-of "bar" "foobar")
+  %+  expect-eq
+    (is-suffix-of "bar" "foobar")
   %.y
-  "is-suffix-of"
 ::
 ++  test-is-infix-of
-  %^  expect-eq
-  (is-infix-of "ob" "foobar")
+  %+  expect-eq
+    (is-infix-of "ob" "foobar")
   %.y
-  "is-infix-of"
 ::
 ++  test-elem
-  %^  expect-eq
-  (elem 5 [1 2 3 4 5 ~])
+  %+  expect-eq
+    (elem 5 [1 2 3 4 5 ~])
   %.y
-  "elem"
 ::
 ++  test-lookup
-  %^  expect-eq
-  (lookup "two" [["one" 1] ["two" 2] ["three" 3] ~])
+  %+  expect-eq
+    (lookup "two" [["one" 1] ["two" 2] ["three" 3] ~])
   [~ 2]
-  "lookup"
 ::
 ++  test-find
-  %^  expect-eq
-  (find:ls [3 2 1 5 1 2 3 ~] |=(a/@ (gth a 3)))
+  %+  expect-eq
+    (find:ls [3 2 1 5 1 2 3 ~] |=(a/@ (gth a 3)))
   [~ 5]
-  "find"
 ::
 ++  test-filter
-  %^  expect-eq
-  (filter [1 2 1 2 1 ~] |=(a/@ =(a 2)))
+  %+  expect-eq
+    (filter [1 2 1 2 1 ~] |=(a/@ =(a 2)))
   [1 1 1 ~]
-  "filter"
 ::
 ++  test-partition
-  %^  expect-eq
-  (partition [1 2 1 2 1 ~] |=(a/@ =(a 2)))
+  %+  expect-eq
+    (partition [1 2 1 2 1 ~] |=(a/@ =(a 2)))
   [[2 2 ~] [1 1 1 ~]]
-  "partition"
 ::
 ++  test-elem-index
-  %^  expect-eq
-  (elem-index 2 [1 2 3 4 ~])
+  %+  expect-eq
+    (elem-index 2 [1 2 3 4 ~])
   `1
-  "elem-index"
 ::
 ++  test-elem-indices
-  %^  expect-eq
-  (elem-indices 2 [1 2 1 2 ~])
+  %+  expect-eq
+    (elem-indices 2 [1 2 1 2 ~])
   [1 3 ~]
-  "elem-indices"
 ::
 ++  test-find-index
-  %^  expect-eq
-  (find-index [1 2 3 ~] |=(a/@ =(a 2)))
+  %+  expect-eq
+    (find-index [1 2 3 ~] |=(a/@ =(a 2)))
   `1
-  "find-index"
 ::
 ++  test-find-indices
-  %^  expect-eq
-  (find-indices [1 2 1 2 ~] |=(a/@ =(a 2)))
+  %+  expect-eq
+    (find-indices [1 2 1 2 ~] |=(a/@ =(a 2)))
   [1 3 ~]
-  "find-indices"
 ::
 ++  test-zip
-  %^  expect-eq
-  (zip [[1 2 3 ~] [4 5 6 ~] [7 8 9 ~] ~])
+  %+  expect-eq
+    (zip [[1 2 3 ~] [4 5 6 ~] [7 8 9 ~] ~])
   [[1 4 7 ~] [2 5 8 ~] [3 6 9 ~] ~]
-  "zip"
 ::
 ++  test-unique
-  %^  expect-eq
-  (unique [1 2 3 1 2 3 ~])
+  %+  expect-eq
+    (unique [1 2 3 1 2 3 ~])
   [1 2 3 ~]
-  "unique"
 ::
 ++  test-delete
-  %^  expect-eq
-  (delete 2 [1 2 3 2 ~])
+  %+  expect-eq
+    (delete 2 [1 2 3 2 ~])
   [1 3 2 ~]
-  "delete"
 ::
 ++  test-delete-firsts
-  %^  expect-eq
-  (delete-firsts [1 2 2 2 3 4 5 ~] [2 2 5 ~])
+  %+  expect-eq
+    (delete-firsts [1 2 2 2 3 4 5 ~] [2 2 5 ~])
   [1 2 3 4 ~]
-  "delete-firsts"
 ::
 ++  test-union
-  %^  expect-eq
-  (union [1 2 3 ~] [4 2 5 ~])
+  %+  expect-eq
+    (union [1 2 3 ~] [4 2 5 ~])
   [1 2 3 4 5 ~]
-  "union"
 ::
 ++  test-intersect
-  %^  expect-eq
-  (intersect [5 6 6 7 8 ~] [9 8 8 6 ~])
+  %+  expect-eq
+    (intersect [5 6 6 7 8 ~] [9 8 8 6 ~])
   [6 6 8 ~]
-  "intersect"
 --
 

--- a/tests/new-hoon/ls.hoon
+++ b/tests/new-hoon/ls.hoon
@@ -1,6 +1,6 @@
 /+  new-hoon, tester
 =,  ls:new-hoon
-|_  tester-type:tester
+|_  _tester:tester
 ++  test-head
   (expect-eq (head [1 ~]) 1)
 ::

--- a/tests/new-hoon/mp.hoon
+++ b/tests/new-hoon/mp.hoon
@@ -2,7 +2,7 @@
 =,  dct:new-hoon
 =+  four=(from-list [[1 "one"] [2 "two"] [3 "three"] [4 "four"] ~])
 =+  three=(from-list [[1 "one"] [2 "two"] [3 "three"] ~])
-|_  tester-type:tester
+|_  _tester:tester
 ++  test-empty
   (expect-eq (empty four) %.n)
 ::

--- a/tests/new-hoon/mp.hoon
+++ b/tests/new-hoon/mp.hoon
@@ -4,106 +4,87 @@
 =+  three=(from-list [[1 "one"] [2 "two"] [3 "three"] ~])
 |_  tester-type:tester
 ++  test-empty
-  (expect-eq (empty four) %.n "empty")
+  (expect-eq (empty four) %.n)
 ::
 ++  test-size
-  (expect-eq (size four) 4 "size")
+  (expect-eq (size four) 4)
 ::
 ++  test-member
-  (expect-eq (member four 4) %.y "member")
+  (expect-eq (member four 4) %.y)
 ::
 ++  test-put-with
   =+  ints=(from-list [["one" 1] ["two" 2] ["three" 3] ["four" 4] ~])
-  %^  expect-eq
-  (put-with ints "three" 2 add)
+  %+  expect-eq
+    (put-with ints "three" 2 add)
   (from-list [["one" 1] ["two" 2] ["three" 5] ["four" 4] ~])
-  "put-with"
 ::
 ++  test-put-with-key
-  %^  expect-eq
-  (put-with-key four 4 "four" |=({a/@ud b/tape c/tape} (weld (scow %ud a) b)))
+  %+  expect-eq
+    (put-with-key four 4 "four" |=({a/@ud b/tape c/tape} (weld (scow %ud a) b)))
   (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "4four"] ~])
-  "put-with-key"
 ::
 ++  test-put-lookup-with-key
-  %^  expect-eq
-    %-  put-lookup-with-key  :^
-      four
+  %+  expect-eq
+    %^  put-lookup-with-key  four
       4
-      "five"
-      |=({key/@ud old/tape new/tape} new)
+    :-  "five"
+    |=({key/@ud old/tape new/tape} new)
   :-  `"four"
-    (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "five"] ~])
-  "put-lookup-with-key"
+  (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "five"] ~])
 ::
 ++  test-delete
-  %^  expect-eq
-  (delete four 4)
+  %+  expect-eq
+    (delete four 4)
   three
-  "delete"
 ::
 ++  test-adjust
-  %^  expect-eq
-    %^  adjust
-    four
-    3
+  %+  expect-eq
+    %^  adjust  four
+      3
     |=(a/tape (weld "this" a))
   (from-list [[1 "one"] [2 "two"] [3 "thisthree"] [4 "four"] ~])
-  "adjust"
 ::
 ++  test-adjust-with-key
-  %^  expect-eq
-    %^  adjust-with-key
-    four
-    3
+  %+  expect-eq
+    %^  adjust-with-key  four
+      3
     |=({a/@ud b/tape} (weld (scow %ud a) b))
   (from-list [[1 "one"] [2 "two"] [3 "3three"] [4 "four"] ~])
-  "adjust-with-key"
 ::
 ++  test-update
-  %^  expect-eq
-    %^  update
-    four
-    3
+  %+  expect-eq
+    %^  update  four
+      3
     |=(a/tape `(maybe tape)`~)
   (from-list [[1 "one"] [2 "two"] [4 "four"] ~])
-  "update"
 ::
 ++  test-update-with-key
-  %^  expect-eq
-    %^  update-with-key
-    four
-    3
+  %+  expect-eq
+    %^  update-with-key  four
+      3
     |=({a/@u b/tape} `(maybe tape)`[~ (weld (scow %ud a) b)])
   (from-list [[1 "one"] [2 "two"] [3 "3three"] [4 "four"] ~])
-  "update-with-key"
 ::
 ++  test-alter-as-add
-  %^  expect-eq
-    %^  alter
-    four
-    5
+  %+  expect-eq
+    %^  alter  four
+      5
     |=(a/(maybe tape) `(maybe tape)`[~ "five"])
   (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "four"] [5 "five"] ~])
-  "alter (as add)"
 ::
 ++  test-alter-as-delete
-  %^  expect-eq
-    %^  alter
-    four
-    2
+  %+  expect-eq
+    %^  alter  four
+      2
     |=(a/(maybe tape) `(maybe tape)`~)
   (from-list [[1 "one"] [3 "three"] [4 "four"] ~])
-  "alter (as delete)"
 ::
 ++  test-alter-as-change
-  %^  expect-eq
-    %^  alter
-    four
-    2
+  %+  expect-eq
+    %^  alter  four
+      2
     |=(a/(maybe tape) `(maybe tape)`[~ "dos"])
   (from-list [[1 "one"] [2 "dos"] [3 "three"] [4 "four"] ~])
-  "alter (as change)"
 ::
 ++  check-alter
   ::  check random dicts of 50 items with 40 random operations done on them
@@ -133,228 +114,192 @@
   $(i +(i))
 ::
 ++  test-union
-  %^  expect-eq
+  %+  expect-eq
     %+  union
-    (from-list [[1 "left"] [2 "left"] ~])
+      (from-list [[1 "left"] [2 "left"] ~])
     (from-list [[2 "right"] [3 "right"] ~])
   (from-list [[1 "left"] [2 "left"] [3 "right"] ~])
-  "union"
 ::
 ++  test-union-with
-  %^  expect-eq
-    %^  union-with
-    (from-list [[1 "left"] [2 "left"] ~])
-    (from-list [[2 "right"] [3 "right"] ~])
+  %+  expect-eq
+    %^    union-with
+        (from-list [[1 "left"] [2 "left"] ~])
+      (from-list [[2 "right"] [3 "right"] ~])
     |=({a/tape b/tape} (weld a b))
   (from-list [[1 "left"] [2 "leftright"] [3 "right"] ~])
-  "union-with"
 ::
 ++  test-union-with-key
-  %^  expect-eq
-    %^  union-with-key
-    (from-list [[1 "left"] [2 "left"] ~])
-    (from-list [[2 "right"] [3 "right"] ~])
+  %+  expect-eq
+    %^    union-with-key
+        (from-list [[1 "left"] [2 "left"] ~])
+      (from-list [[2 "right"] [3 "right"] ~])
     |=({a/@ud b/tape c/tape} :(weld `tape`(scow %ud a) b c))
   (from-list [[1 "left"] [2 "2leftright"] [3 "right"] ~])
-  "union-with-key"
 ::
 ++  test-map
-  %^  expect-eq
-    %+  map:dct
-    three
-    crip
+  %+  expect-eq
+    (map:dct three crip)
   (from-list [[1 'one'] [2 'two'] [3 'three'] ~])
-  "map"
 ::
 ++  test-map-with-key
-  %^  expect-eq
-    %+  map-with-key
-    three
+  %+  expect-eq
+    %+  map-with-key  three
     |=({a/@u b/tape} (weld (scow %ud a) b))
   (from-list [[1 "1one"] [2 "2two"] [3 "3three"] ~])
-  "map-with-key"
 ::
 ++  test-map-fold
-  %^  expect-eq
-    %^  map-fold
-    three
-    "Everything: "
+  %+  expect-eq
+    %^  map-fold  three
+      "Everything:"
     |=  {accumulator/tape value/tape}
-    [(weld accumulator value) (weld value "X")]
-  :-  "Everything: twoonethree"
-    (from-list [[1 "oneX"] [2 "twoX"] [3 "threeX"] ~])
-  "map-fold"
+    [:(weld accumulator " " value) (weld value "X")]
+  :-  "Everything: two one three"
+  (from-list [[1 "oneX"] [2 "twoX"] [3 "threeX"] ~])
 ::
 ++  test-map-keys
-  %^  expect-eq
-    %+  map-keys
-    three
-    |=  a/@u
-    (add a 10)
+  %+  expect-eq
+    %+  map-keys  three
+    |=(a/@u (add a 10))
   (from-list [[11 "one"] [12 "two"] [13 "three"] ~])
-  "map-keys"
 ::
 ++  test-map-keys-with
-  %^  expect-eq
-    %^  map-keys-with
-    three
-    |=(a/@u 42)
+  %+  expect-eq
+    %^  map-keys-with  three
+      |=(a/@u 42)
     weld
   (from-list [[42 "twothreeone"] ~])
-  "map-keys-with"
 ::
 ++  test-fold
-  %^  expect-eq
-    %^  fold
-    three
-    "Everything: "
+  %+  expect-eq
+    %^  fold  three
+      "Everything: "
     ::  todo: this works but replacing with just ++weld causes an out of loom.
     |=  {accumulator/tape value/tape}
     ^-  tape
     (weld accumulator value)
   "Everything: twoonethree"
-  "map-fold"
 ::
 ++  test-fold-with-keys
-  %^  expect-eq
-    %^  fold-with-keys
-    three
-    "Everything: "
+  %+  expect-eq
+    %^  fold-with-keys  three
+      "Everything: "
     |=  {accumulator/tape key/@u value/tape}
     ^-  tape
     :(weld accumulator (scow %ud key) value)
   "Everything: 2two1one3three"
-  "map-fold-with-keys"
 ::
 ++  test-elems
-  %^  expect-eq
-  (elems three)
+  %+  expect-eq
+    (elems three)
   ["two" "three" "one" ~]
-  "elems"
 ::
 ++  test-keys
-  %^  expect-eq
-  (keys three)
+  %+  expect-eq
+    (keys three)
   [2 3 1 ~]
-  "keys"
 ::
 ++  test-keys-set
-  %^  expect-eq
-  (keys-set three)
+  %+  expect-eq
+    (keys-set three)
   (si:nl [2 3 1 ~])
-  "keys-set"
 ::
 ++  test-from-set
-  %^  expect-eq
-    %+  from-set
-    (si:nl [1 2 3 ~])
-    |=  a/@u
-    (scow %ud a)
+  %+  expect-eq
+    %+  from-set 
+      (si:nl [1 2 3 ~])
+    |=(a/@u (scow %ud a))
   (from-list [[1 "1"] [2 "2"] [3 "3"] ~])
-  "from-set"
 ::
 ++  test-from-list-with
-  %^  expect-eq
+  %+  expect-eq
     %+  from-list-with
-    [[1 1] [2 1] [2 1] [3 3] ~]
+      [[1 1] [2 1] [2 1] [3 3] ~]
     add
   (from-list [[1 1] [2 2] [3 3] ~])
-  "from-list-with"
 ::
 ++  test-filter
-  %^  expect-eq
+  %+  expect-eq
     %+  filter
-    (from-list [[1 1] [2 1] [3 2] [4 1] ~])
+      (from-list [[1 1] [2 1] [3 2] [4 1] ~])
     |=(a/@u !=(a 1))
   (from-list [[1 1] [2 1] [4 1] ~])
-  "filter"
 ::
 ++  test-filter-with-key
-  %^  expect-eq
+  %+  expect-eq
     %+  filter-with-key
-    (from-list [[1 1] [2 1] [3 2] [4 1] ~])
+      (from-list [[1 1] [2 1] [3 2] [4 1] ~])
     |=({a/@u b/@u} =(a 2))
   (from-list [[1 1] [3 2] [4 1] ~])
-  "filter-with-key"
 ::
 ++  test-restrict-keys
-  %^  expect-eq
+  %+  expect-eq
     %+  restrict-keys
-    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
     (si:nl [1 3 5 ~])
   (from-list [[1 1] [3 3] [5 5] ~])
-  "restrict-keys"
 ::
 ++  test-without-keys
-  %^  expect-eq
+  %+  expect-eq
     %+  without-keys
-    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
     (si:nl [1 3 5 ~])
   (from-list [[2 2] [4 4] ~])
-  "restrict-keys"
 ::
 ++  test-partition
-  %^  expect-eq
+  %+  expect-eq
     %+  partition
-    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
     |=(a/@u |(=(a 1) =(a 3)))
   :-  (from-list [[1 1] [3 3] ~])
-    (from-list [[2 2] [4 4] [5 5] ~])
-  "partition"
+  (from-list [[2 2] [4 4] [5 5] ~])
 ::
 ++  test-map-maybe
-  %^  expect-eq
+  %+  expect-eq
     %+  map-maybe
-    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
     |=(a/@u ?:(=(a 3) ~ `a))
   (from-list [[1 1] [2 2] [4 4] [5 5] ~])
-  "map-maybe"
 ::
 ++  test-map-maybe-with-key
-  %^  expect-eq
+  %+  expect-eq
     %+  map-maybe-with-key
-    (from-list [[1 2] [2 3] [3 4] [4 5] [5 6] ~])
+      (from-list [[1 2] [2 3] [3 4] [4 5] [5 6] ~])
     |=({k/@u v/@u} ?:(=(k 3) ~ `v))
   (from-list [[1 2] [2 3] [4 5] [5 6] ~])
-  "map-maybe-with-key"
 ::
 ++  test-map-either
-  %^  expect-eq
-  %+  map-either
-    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
-    |=  value/@u
-    ?:  =(0 (mod value 2))
-      [%& "even"]
-    [%| 1]
+  %+  expect-eq
+    %+  map-either
+      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+      |=  value/@u
+      ?:  =(0 (mod value 2))
+        [%& "even"]
+      [%| 1]
   :-  (from-list [[2 "even"] [4 "even"] ~])
-    (from-list [[1 1] [3 1] [5 1] ~])
-  "map-either"
+  (from-list [[1 1] [3 1] [5 1] ~])
 ::
 ++  test-map-either-with-key
-  %^  expect-eq
-  %+  map-either-with-key
-    (from-list [[1 1] [2 1] [3 1] [4 1] [5 1] ~])
+  %+  expect-eq
+    %+  map-either-with-key
+      (from-list [[1 1] [2 1] [3 1] [4 1] [5 1] ~])
     |=  {key/@u value/@u}
     ?:  =(0 (mod key 2))
       [%& "even"]
     [%| 1]
   :-  (from-list [[2 "even"] [4 "even"] ~])
-    (from-list [[1 1] [3 1] [5 1] ~])
-  "map-either"
+  (from-list [[1 1] [3 1] [5 1] ~])
 ::
 ++  test-is-subdict
-  %^  expect-eq
-    %^  is-subdict-by
-    (from-list [[1 1] [4 4] ~])
-    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+  %+  expect-eq
+    %^    is-subdict-by
+        (from-list [[1 1] [4 4] ~])
+      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
     |=({a/* b/*} =(a b))
   %.y
-  "is-subdict"
 ::
 ++  test-valid
-  %^  expect-eq
-  (valid (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8] [9 9] ~]))
+  %+  expect-eq
+    (valid (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8] [9 9] ~]))
   %.y
-  "valid"
 --
 

--- a/tests/new-hoon/mp.hoon
+++ b/tests/new-hoon/mp.hoon
@@ -4,87 +4,86 @@
 =+  three=(from-list [[1 "one"] [2 "two"] [3 "three"] ~])
 |_  _tester:tester
 ++  test-empty
-  (expect-eq (empty four) %.n)
+  (expect-eq !>([%.n (empty four)]))
 ::
 ++  test-size
-  (expect-eq (size four) 4)
+  (expect-eq !>([4 (size four)]))
 ::
 ++  test-member
-  (expect-eq (member four 4) %.y)
+  (expect-eq !>([%.y (member four 4)]))
 ::
 ++  test-put-with
-  =+  ints=(from-list [["one" 1] ["two" 2] ["three" 3] ["four" 4] ~])
-  %+  expect-eq
-    (put-with ints "three" 2 add)
-  (from-list [["one" 1] ["two" 2] ["three" 5] ["four" 4] ~])
+  %-  expect-eq  !>
+  :-  (from-list [["one" 1] ["two" 2] ["three" 5] ["four" 4] ~])
+  =/  ints  (from-list [["one" 1] ["two" 2] ["three" 3] ["four" 4] ~])
+  (put-with ints "three" 2 add)
 ::
 ++  test-put-with-key
-  %+  expect-eq
-    (put-with-key four 4 "four" |=({a/@ud b/tape c/tape} (weld (scow %ud a) b)))
-  (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "4four"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "4four"] ~])
+  (put-with-key four 4 "four" |=({a/@ud b/tape c/tape} (weld (scow %ud a) b)))
 ::
 ++  test-put-lookup-with-key
-  %+  expect-eq
-    %^  put-lookup-with-key  four
-      4
-    :-  "five"
-    |=({key/@ud old/tape new/tape} new)
-  :-  `"four"
-  (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "five"] ~])
+  %-  expect-eq  !>
+  :-  [`"four" (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "five"] ~])]
+  %^  put-lookup-with-key  four
+    4
+  :-  "five"
+  |=({key/@ud old/tape new/tape} new)
 ::
 ++  test-delete
-  %+  expect-eq
-    (delete four 4)
-  three
+  %-  expect-eq  !>
+  :-  three
+  (delete four 4)
 ::
 ++  test-adjust
-  %+  expect-eq
-    %^  adjust  four
-      3
-    |=(a/tape (weld "this" a))
-  (from-list [[1 "one"] [2 "two"] [3 "thisthree"] [4 "four"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [2 "two"] [3 "thisthree"] [4 "four"] ~])
+  %^  adjust  four
+    3
+  |=(a/tape (weld "this" a))
 ::
 ++  test-adjust-with-key
-  %+  expect-eq
-    %^  adjust-with-key  four
-      3
-    |=({a/@ud b/tape} (weld (scow %ud a) b))
-  (from-list [[1 "one"] [2 "two"] [3 "3three"] [4 "four"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [2 "two"] [3 "3three"] [4 "four"] ~])
+  %^  adjust-with-key  four
+    3
+  |=({a/@ud b/tape} (weld (scow %ud a) b))
 ::
 ++  test-update
-  %+  expect-eq
-    %^  update  four
-      3
-    |=(a/tape `(maybe tape)`~)
-  (from-list [[1 "one"] [2 "two"] [4 "four"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [2 "two"] [4 "four"] ~])
+  %^  update  four
+    3
+  |=(a/tape `(maybe tape)`~)
 ::
 ++  test-update-with-key
-  %+  expect-eq
-    %^  update-with-key  four
-      3
-    |=({a/@u b/tape} `(maybe tape)`[~ (weld (scow %ud a) b)])
-  (from-list [[1 "one"] [2 "two"] [3 "3three"] [4 "four"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [2 "two"] [3 "3three"] [4 "four"] ~])
+  %^  update-with-key  four
+    3
+  |=({a/@u b/tape} `(maybe tape)`[~ (weld (scow %ud a) b)])
 ::
 ++  test-alter-as-add
-  %+  expect-eq
-    %^  alter  four
-      5
-    |=(a/(maybe tape) `(maybe tape)`[~ "five"])
-  (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "four"] [5 "five"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [2 "two"] [3 "three"] [4 "four"] [5 "five"] ~])
+  %^  alter  four
+    5
+  |=(a/(maybe tape) `(maybe tape)`[~ "five"])
 ::
 ++  test-alter-as-delete
-  %+  expect-eq
-    %^  alter  four
-      2
-    |=(a/(maybe tape) `(maybe tape)`~)
-  (from-list [[1 "one"] [3 "three"] [4 "four"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [3 "three"] [4 "four"] ~])
+  %^  alter  four
+    2
+  |=(a/(maybe tape) `(maybe tape)`~)
 ::
 ++  test-alter-as-change
-  %+  expect-eq
-    %^  alter  four
-      2
-    |=(a/(maybe tape) `(maybe tape)`[~ "dos"])
-  (from-list [[1 "one"] [2 "dos"] [3 "three"] [4 "four"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "one"] [2 "dos"] [3 "three"] [4 "four"] ~])
+  %^  alter  four
+    2
+  |=(a/(maybe tape) `(maybe tape)`[~ "dos"])
 ::
 ++  check-alter
   ::  check random dicts of 50 items with 40 random operations done on them
@@ -114,192 +113,192 @@
   $(i +(i))
 ::
 ++  test-union
-  %+  expect-eq
-    %+  union
-      (from-list [[1 "left"] [2 "left"] ~])
-    (from-list [[2 "right"] [3 "right"] ~])
-  (from-list [[1 "left"] [2 "left"] [3 "right"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "left"] [2 "left"] [3 "right"] ~])
+  %+  union
+    (from-list [[1 "left"] [2 "left"] ~])
+  (from-list [[2 "right"] [3 "right"] ~])
 ::
 ++  test-union-with
-  %+  expect-eq
-    %^    union-with
-        (from-list [[1 "left"] [2 "left"] ~])
-      (from-list [[2 "right"] [3 "right"] ~])
-    |=({a/tape b/tape} (weld a b))
-  (from-list [[1 "left"] [2 "leftright"] [3 "right"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "left"] [2 "leftright"] [3 "right"] ~])
+  %^    union-with
+      (from-list [[1 "left"] [2 "left"] ~])
+    (from-list [[2 "right"] [3 "right"] ~])
+  |=({a/tape b/tape} (weld a b))
 ::
 ++  test-union-with-key
-  %+  expect-eq
-    %^    union-with-key
-        (from-list [[1 "left"] [2 "left"] ~])
-      (from-list [[2 "right"] [3 "right"] ~])
-    |=({a/@ud b/tape c/tape} :(weld `tape`(scow %ud a) b c))
-  (from-list [[1 "left"] [2 "2leftright"] [3 "right"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "left"] [2 "2leftright"] [3 "right"] ~])
+  %^    union-with-key
+      (from-list [[1 "left"] [2 "left"] ~])
+    (from-list [[2 "right"] [3 "right"] ~])
+  |=({a/@ud b/tape c/tape} :(weld `tape`(scow %ud a) b c))
 ::
 ++  test-map
-  %+  expect-eq
-    (map:dct three crip)
-  (from-list [[1 'one'] [2 'two'] [3 'three'] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 'one'] [2 'two'] [3 'three'] ~])
+  (map:dct three crip)
 ::
 ++  test-map-with-key
-  %+  expect-eq
-    %+  map-with-key  three
-    |=({a/@u b/tape} (weld (scow %ud a) b))
-  (from-list [[1 "1one"] [2 "2two"] [3 "3three"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "1one"] [2 "2two"] [3 "3three"] ~])
+  %+  map-with-key  three
+  |=({a/@u b/tape} (weld (scow %ud a) b))
 ::
 ++  test-map-fold
-  %+  expect-eq
-    %^  map-fold  three
-      "Everything:"
-    |=  {accumulator/tape value/tape}
-    [:(weld accumulator " " value) (weld value "X")]
-  :-  "Everything: two one three"
-  (from-list [[1 "oneX"] [2 "twoX"] [3 "threeX"] ~])
+  %-  expect-eq  !>
+  :-  :-  "Everything: two one three"
+      (from-list [[1 "oneX"] [2 "twoX"] [3 "threeX"] ~])
+  %^  map-fold  three
+    "Everything:"
+  |=  {accumulator/tape value/tape}
+  [:(weld accumulator " " value) (weld value "X")]
 ::
 ++  test-map-keys
-  %+  expect-eq
-    %+  map-keys  three
-    |=(a/@u (add a 10))
-  (from-list [[11 "one"] [12 "two"] [13 "three"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[11 "one"] [12 "two"] [13 "three"] ~])
+  %+  map-keys  three
+  |=(a/@u (add a 10))
 ::
 ++  test-map-keys-with
-  %+  expect-eq
-    %^  map-keys-with  three
-      |=(a/@u 42)
-    weld
-  (from-list [[42 "twothreeone"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[42 "twothreeone"] ~])
+  %^  map-keys-with  three
+    |=(a/@u 42)
+  weld
 ::
 ++  test-fold
-  %+  expect-eq
-    %^  fold  three
-      "Everything: "
-    ::  todo: this works but replacing with just ++weld causes an out of loom.
-    |=  {accumulator/tape value/tape}
-    ^-  tape
-    (weld accumulator value)
-  "Everything: twoonethree"
+  %-  expect-eq  !>
+  :-  "Everything: twoonethree"
+  %^  fold  three
+    "Everything: "
+  ::  todo: this works but replacing with just ++weld causes an out of loom.
+  |=  {accumulator/tape value/tape}
+  ^-  tape
+  (weld accumulator value)
 ::
 ++  test-fold-with-keys
-  %+  expect-eq
-    %^  fold-with-keys  three
-      "Everything: "
-    |=  {accumulator/tape key/@u value/tape}
-    ^-  tape
-    :(weld accumulator (scow %ud key) value)
-  "Everything: 2two1one3three"
+  %-  expect-eq  !>
+  :-  "Everything: 2two1one3three"
+  %^  fold-with-keys  three
+    "Everything: "
+  |=  {accumulator/tape key/@u value/tape}
+  ^-  tape
+  :(weld accumulator (scow %ud key) value)
 ::
 ++  test-elems
-  %+  expect-eq
-    (elems three)
-  ["two" "three" "one" ~]
+  %-  expect-eq  !>
+  :-  ["two" "three" "one" ~]
+  (elems three)
 ::
 ++  test-keys
-  %+  expect-eq
-    (keys three)
-  [2 3 1 ~]
+  %-  expect-eq  !>
+  :-  [2 3 1 ~]
+  (keys three)
 ::
 ++  test-keys-set
-  %+  expect-eq
-    (keys-set three)
-  (si:nl [2 3 1 ~])
+  %-  expect-eq  !>
+  :-  (si:nl [2 3 1 ~])
+  (keys-set three)
 ::
 ++  test-from-set
-  %+  expect-eq
-    %+  from-set 
-      (si:nl [1 2 3 ~])
-    |=(a/@u (scow %ud a))
-  (from-list [[1 "1"] [2 "2"] [3 "3"] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 "1"] [2 "2"] [3 "3"] ~])
+  %+  from-set
+    (si:nl [1 2 3 ~])
+  |=(a/@u (scow %ud a))
 ::
 ++  test-from-list-with
-  %+  expect-eq
-    %+  from-list-with
-      [[1 1] [2 1] [2 1] [3 3] ~]
-    add
-  (from-list [[1 1] [2 2] [3 3] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 1] [2 2] [3 3] ~])
+  %+  from-list-with
+    [[1 1] [2 1] [2 1] [3 3] ~]
+  add
 ::
 ++  test-filter
-  %+  expect-eq
-    %+  filter
-      (from-list [[1 1] [2 1] [3 2] [4 1] ~])
-    |=(a/@u !=(a 1))
-  (from-list [[1 1] [2 1] [4 1] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 1] [2 1] [4 1] ~])
+  %+  filter
+    (from-list [[1 1] [2 1] [3 2] [4 1] ~])
+  |=(a/@u !=(a 1))
 ::
 ++  test-filter-with-key
-  %+  expect-eq
-    %+  filter-with-key
-      (from-list [[1 1] [2 1] [3 2] [4 1] ~])
-    |=({a/@u b/@u} =(a 2))
-  (from-list [[1 1] [3 2] [4 1] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 1] [3 2] [4 1] ~])
+  %+  filter-with-key
+    (from-list [[1 1] [2 1] [3 2] [4 1] ~])
+  |=({a/@u b/@u} =(a 2))
 ::
 ++  test-restrict-keys
-  %+  expect-eq
-    %+  restrict-keys
-      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
-    (si:nl [1 3 5 ~])
-  (from-list [[1 1] [3 3] [5 5] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 1] [3 3] [5 5] ~])
+  %+  restrict-keys
+    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+  (si:nl [1 3 5 ~])
 ::
 ++  test-without-keys
-  %+  expect-eq
-    %+  without-keys
-      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
-    (si:nl [1 3 5 ~])
-  (from-list [[2 2] [4 4] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[2 2] [4 4] ~])
+  %+  without-keys
+    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+  (si:nl [1 3 5 ~])
 ::
 ++  test-partition
-  %+  expect-eq
-    %+  partition
-      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
-    |=(a/@u |(=(a 1) =(a 3)))
-  :-  (from-list [[1 1] [3 3] ~])
-  (from-list [[2 2] [4 4] [5 5] ~])
+  %-  expect-eq  !>
+  :-  :-  (from-list [[1 1] [3 3] ~])
+      (from-list [[2 2] [4 4] [5 5] ~])
+  %+  partition
+    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+  |=(a/@u |(=(a 1) =(a 3)))
 ::
 ++  test-map-maybe
-  %+  expect-eq
-    %+  map-maybe
-      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
-    |=(a/@u ?:(=(a 3) ~ `a))
-  (from-list [[1 1] [2 2] [4 4] [5 5] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 1] [2 2] [4 4] [5 5] ~])
+  %+  map-maybe
+    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+  |=(a/@u ?:(=(a 3) ~ `a))
 ::
 ++  test-map-maybe-with-key
-  %+  expect-eq
-    %+  map-maybe-with-key
-      (from-list [[1 2] [2 3] [3 4] [4 5] [5 6] ~])
-    |=({k/@u v/@u} ?:(=(k 3) ~ `v))
-  (from-list [[1 2] [2 3] [4 5] [5 6] ~])
+  %-  expect-eq  !>
+  :-  (from-list [[1 2] [2 3] [4 5] [5 6] ~])
+  %+  map-maybe-with-key
+    (from-list [[1 2] [2 3] [3 4] [4 5] [5 6] ~])
+  |=({k/@u v/@u} ?:(=(k 3) ~ `v))
 ::
 ++  test-map-either
-  %+  expect-eq
-    %+  map-either
-      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
-      |=  value/@u
-      ?:  =(0 (mod value 2))
-        [%& "even"]
-      [%| 1]
-  :-  (from-list [[2 "even"] [4 "even"] ~])
-  (from-list [[1 1] [3 1] [5 1] ~])
-::
-++  test-map-either-with-key
-  %+  expect-eq
-    %+  map-either-with-key
-      (from-list [[1 1] [2 1] [3 1] [4 1] [5 1] ~])
-    |=  {key/@u value/@u}
-    ?:  =(0 (mod key 2))
+  %-  expect-eq  !>
+  :-  :-  (from-list [[2 "even"] [4 "even"] ~])
+      (from-list [[1 1] [3 1] [5 1] ~])
+  %+  map-either
+    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+    |=  value/@u
+    ?:  =(0 (mod value 2))
       [%& "even"]
     [%| 1]
-  :-  (from-list [[2 "even"] [4 "even"] ~])
-  (from-list [[1 1] [3 1] [5 1] ~])
+::
+++  test-map-either-with-key
+  %-  expect-eq  !>
+  :-  :-  (from-list [[2 "even"] [4 "even"] ~])
+      (from-list [[1 1] [3 1] [5 1] ~])
+  %+  map-either-with-key
+    (from-list [[1 1] [2 1] [3 1] [4 1] [5 1] ~])
+  |=  {key/@u value/@u}
+  ?:  =(0 (mod key 2))
+    [%& "even"]
+  [%| 1]
 ::
 ++  test-is-subdict
-  %+  expect-eq
-    %^    is-subdict-by
-        (from-list [[1 1] [4 4] ~])
-      (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
-    |=({a/* b/*} =(a b))
-  %.y
+  %-  expect-eq  !>
+  :-  &
+  %^    is-subdict-by
+      (from-list [[1 1] [4 4] ~])
+    (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] ~])
+  |=({a/* b/*} =(a b))
 ::
 ++  test-valid
-  %+  expect-eq
-    (valid (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8] [9 9] ~]))
-  %.y
+  %-  expect-eq  !>
+  :-  &
+  (valid (from-list [[1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8] [9 9] ~]))
 --
 

--- a/tests/new-hoon/myb.hoon
+++ b/tests/new-hoon/myb.hoon
@@ -2,31 +2,30 @@
 =,  myb:new-hoon
 |_  tester-type:tester
 ++  test-from-list-null
-  (expect-eq (from-list ~) ~ "from-list")
+  (expect-eq (from-list ~) ~)
 ::
 ++  test-from-list-real
-  (expect-eq (from-list [5 ~]) [~ 5] "from-list")
+  (expect-eq (from-list [5 ~]) [~ 5])
 ::
 ++  test-to-list-null
-  (expect-eq (to-list ~) ~ "to-list")
+  (expect-eq (to-list ~) ~)
 ::
 ++  test-to-list-real
-  (expect-eq (to-list [~ 5]) [5 ~] "to-list")
+  (expect-eq (to-list [~ 5]) [5 ~])
 ::
 ++  test-concat-null
-  (expect-eq (concat ~) ~ "concat")
+  (expect-eq (concat ~) ~)
 ::
 ++  test-concat-real
   ::  wait, if i pull the cast out from below, the concat implementation
   ::  doesn't compile anymore?
-  (expect-eq (concat `(list (maybe @ud))`[~ [~ 1] ~ [~ 2] ~]) [1 2 ~] "concat")
+  (expect-eq (concat `(list (maybe @ud))`[~ [~ 1] ~ [~ 2] ~]) [1 2 ~])
 ::
 ++  test-map
-  %^  expect-eq
+  %+  expect-eq
     %+  map:myb
-    [1 2 3 2 ~]
+      [1 2 3 2 ~]
     |=(a/@u ?:(=(2 a) [~ 2] ~))
   [2 2 ~]
-  "map"
 --
 

--- a/tests/new-hoon/myb.hoon
+++ b/tests/new-hoon/myb.hoon
@@ -2,30 +2,30 @@
 =,  myb:new-hoon
 |_  _tester:tester
 ++  test-from-list-null
-  (expect-eq (from-list ~) ~)
+  (expect-eq !>([~ (from-list ~)]))
 ::
 ++  test-from-list-real
-  (expect-eq (from-list [5 ~]) [~ 5])
+  (expect-eq !>([[~ 5] (from-list [5 ~])]))
 ::
 ++  test-to-list-null
-  (expect-eq (to-list ~) ~)
+  (expect-eq !>([~ (to-list ~)]))
 ::
 ++  test-to-list-real
-  (expect-eq (to-list [~ 5]) [5 ~])
+  (expect-eq !>([[5 ~] (to-list [~ 5])]))
 ::
 ++  test-concat-null
-  (expect-eq (concat ~) ~)
+  (expect-eq !>([~ (concat ~)]))
 ::
 ++  test-concat-real
   ::  wait, if i pull the cast out from below, the concat implementation
   ::  doesn't compile anymore?
-  (expect-eq (concat `(list (maybe @ud))`[~ [~ 1] ~ [~ 2] ~]) [1 2 ~])
+  (expect-eq !>([[1 2 ~] (concat `(list (maybe @ud))`[~ [~ 1] ~ [~ 2] ~])]))
 ::
 ++  test-map
-  %+  expect-eq
-    %+  map:myb
-      [1 2 3 2 ~]
-    |=(a/@u ?:(=(2 a) [~ 2] ~))
-  [2 2 ~]
+  %-  expect-eq  !>
+  :-  [2 2 ~]
+  %+  map:myb
+    [1 2 3 2 ~]
+  |=(a/@u ?:(=(2 a) [~ 2] ~))
 --
 

--- a/tests/new-hoon/myb.hoon
+++ b/tests/new-hoon/myb.hoon
@@ -1,6 +1,6 @@
 /+  new-hoon, tester
 =,  myb:new-hoon
-|_  tester-type:tester
+|_  _tester:tester
 ++  test-from-list-null
   (expect-eq (from-list ~) ~)
 ::

--- a/tests/new-hoon/thr.hoon
+++ b/tests/new-hoon/thr.hoon
@@ -4,24 +4,24 @@
 =/  data/(list (either @u tape))  [[%& 1] [%| "one"] [%& 2] [%| "two"] ~]
 |_  _tester:tester
 ++  test-apply
-  %+  expect-eq
-    %^  apply  `(either @u tape)`[%| "one"]
-      |=(a/@u "left")
-    |=(b/tape "right")
-  "right"
+  %-  expect-eq  !>
+  :-  "right"
+  %^  apply  `(either @u tape)`[%| "one"]
+    |=(a/@u "left")
+  |=(b/tape "right")
 ::
 ++  test-firsts
-  %+  expect-eq
-    (firsts data)
-  [1 2 ~]
+  %-  expect-eq  !>
+  :-  [1 2 ~]
+  (firsts data)
 ::
 ++  test-seconds
-  %+  expect-eq
-    (seconds data)
-  ["one" "two" ~]
+  %-  expect-eq  !>
+  :-  ["one" "two" ~]
+  (seconds data)
 ::
 ++  test-partition
-  %+  expect-eq
-    (partition data)
-  [[1 2 ~] ["one" "two" ~]]
+  %-  expect-eq  !>
+  :-  [[1 2 ~] ["one" "two" ~]]
+  (partition data)
 --

--- a/tests/new-hoon/thr.hoon
+++ b/tests/new-hoon/thr.hoon
@@ -2,7 +2,7 @@
 /+  new-hoon, tester
 =,  thr:new-hoon
 =/  data/(list (either @u tape))  [[%& 1] [%| "one"] [%& 2] [%| "two"] ~]
-|_  tester-type:tester
+|_  _tester:tester
 ++  test-apply
   %+  expect-eq
     %^  apply  `(either @u tape)`[%| "one"]

--- a/tests/new-hoon/thr.hoon
+++ b/tests/new-hoon/thr.hoon
@@ -4,29 +4,24 @@
 =/  data/(list (either @u tape))  [[%& 1] [%| "one"] [%& 2] [%| "two"] ~]
 |_  tester-type:tester
 ++  test-apply
-  %^  expect-eq
-    %^  apply
-    `(either @u tape)`[%| "one"]
-    |=(a/@u "left")
+  %+  expect-eq
+    %^  apply  `(either @u tape)`[%| "one"]
+      |=(a/@u "left")
     |=(b/tape "right")
   "right"
-  "apply"
 ::
 ++  test-firsts
-  %^  expect-eq
-  (firsts data)
+  %+  expect-eq
+    (firsts data)
   [1 2 ~]
-  "firsts"
 ::
 ++  test-seconds
-  %^  expect-eq
-  (seconds data)
+  %+  expect-eq
+    (seconds data)
   ["one" "two" ~]
-  "seconds"
 ::
 ++  test-partition
-  %^  expect-eq
-  (partition data)
+  %+  expect-eq
+    (partition data)
   [[1 2 ~] ["one" "two" ~]]
-  "partition"
 --

--- a/tests/zuse/crypto/keccak.hoon
+++ b/tests/zuse/crypto/keccak.hoon
@@ -87,10 +87,10 @@
   =*  bytes  p.i.answers
   =*  answer  q.i.answers
   =-  $(tst -, answers t.answers)
-  %^  expect-eq.tst
-      (hash bytes (~(got by keccak-inputs) bytes))
-    answer
-  "{name} {(scow %ud bytes)} bytes"
+  %+  expect-eq.tst
+    (hash bytes (~(got by keccak-inputs) bytes))
+  answer
+  ::"{name} {(scow %ud bytes)} bytes"
 ::
 ::  keccak
 ::
@@ -242,71 +242,63 @@
 ::  sha3
 ::
 ++  test-sha3-224
-  %^  expect-eq.tst
-      (sha3-224 0 `@`0)
-    0x6b4e.0342.3667.dbb7.3b6e.1545.4f0e.b1ab.
-      d459.7f9a.1b07.8e3f.5b5a.6bc7
-  "sha3-224"
+  %+  expect-eq.tst
+    (sha3-224 0 `@`0)
+  0x6b4e.0342.3667.dbb7.3b6e.1545.4f0e.b1ab.
+    d459.7f9a.1b07.8e3f.5b5a.6bc7
 ::
 ++  test-sha3-256
-  %^  expect-eq.tst
-      (sha3-256 0 `@`0)
-    0xa7ff.c6f8.bf1e.d766.51c1.4756.a061.d662.
-      f580.ff4d.e43b.49fa.82d8.0a4b.80f8.434a
-  "sha3-256"
+  %+  expect-eq.tst
+    (sha3-256 0 `@`0)
+  0xa7ff.c6f8.bf1e.d766.51c1.4756.a061.d662.
+    f580.ff4d.e43b.49fa.82d8.0a4b.80f8.434a
 ::
 ++  test-sha3-384
-  %^  expect-eq.tst
-      (sha3-384 0 `@`0)
-     0xc63.a75b.845e.4f7d.0110.7d85.2e4c.2485.
-      c51a.50aa.aa94.fc61.995e.71bb.ee98.3a2a.
-      c371.3831.264a.db47.fb6b.d1e0.58d5.f004
-  "sha3-384"
+  %+  expect-eq.tst
+    (sha3-384 0 `@`0)
+   0xc63.a75b.845e.4f7d.0110.7d85.2e4c.2485.
+    c51a.50aa.aa94.fc61.995e.71bb.ee98.3a2a.
+    c371.3831.264a.db47.fb6b.d1e0.58d5.f004
 ::
 ++  test-sha3-512
-  %^  expect-eq.tst
-      (sha3-512 0 `@`0)
-    0xa69f.73cc.a23a.9ac5.c8b5.67dc.185a.756e.
-      97c9.8216.4fe2.5859.e0d1.dcc1.475c.80a6.
-      15b2.123a.f1f5.f94c.11e3.e940.2c3a.c558.
-      f500.199d.95b6.d3e3.0175.8586.281d.cd26
-  "sha3-512"
+  %+  expect-eq.tst
+    (sha3-512 0 `@`0)
+  0xa69f.73cc.a23a.9ac5.c8b5.67dc.185a.756e.
+    97c9.8216.4fe2.5859.e0d1.dcc1.475c.80a6.
+    15b2.123a.f1f5.f94c.11e3.e940.2c3a.c558.
+    f500.199d.95b6.d3e3.0175.8586.281d.cd26
 ::
 ::  shake
 ::
 ++  test-shake-128
-  %^  expect-eq.tst
-      (shake-128 512 0 `@`0)
-    0x7f9c.2ba4.e88f.827d.6160.4550.7605.853e.
-      d73b.8093.f6ef.bc88.eb1a.6eac.fa66.ef26.
-      3cb1.eea9.8800.4b93.103c.fb0a.eefd.2a68.
-      6e01.fa4a.58e8.a363.9ca8.a1e3.f9ae.57e2
-  "shake-128"
+  %+  expect-eq.tst
+    (shake-128 512 0 `@`0)
+  0x7f9c.2ba4.e88f.827d.6160.4550.7605.853e.
+    d73b.8093.f6ef.bc88.eb1a.6eac.fa66.ef26.
+    3cb1.eea9.8800.4b93.103c.fb0a.eefd.2a68.
+    6e01.fa4a.58e8.a363.9ca8.a1e3.f9ae.57e2
 ::
 ++  test-shake-256
-  %^  expect-eq.tst
-      (shake-256 512 0 `@`0)
-    0x46b9.dd2b.0ba8.8d13.233b.3feb.743e.eb24.
-      3fcd.52ea.62b8.1b82.b50c.2764.6ed5.762f.
-      d75d.c4dd.d8c0.f200.cb05.019d.67b5.92f6.
-      fc82.1c49.479a.b486.4029.2eac.b3b7.c4be
-  "shake-256"
+  %+  expect-eq.tst
+    (shake-256 512 0 `@`0)
+  0x46b9.dd2b.0ba8.8d13.233b.3feb.743e.eb24.
+    3fcd.52ea.62b8.1b82.b50c.2764.6ed5.762f.
+    d75d.c4dd.d8c0.f200.cb05.019d.67b5.92f6.
+    fc82.1c49.479a.b486.4029.2eac.b3b7.c4be
 ::
 ++  test-rawshake-128
-  %^  expect-eq.tst
-      (rawshake-128 512 0 `@`0)
-    0xfa01.9a3b.1763.0df6.0148.53b5.4707.73f1.
-      3c3a.b704.4782.11d7.a658.6751.5dea.1cc7.
-      926b.2147.e396.076b.22cb.7263.3af5.0647.
-      c7f2.3d0d.8f00.1d6d.8daf.0f6f.2e92.fc0e
-  "rawshake-128"
+  %+  expect-eq.tst
+    (rawshake-128 512 0 `@`0)
+  0xfa01.9a3b.1763.0df6.0148.53b5.4707.73f1.
+    3c3a.b704.4782.11d7.a658.6751.5dea.1cc7.
+    926b.2147.e396.076b.22cb.7263.3af5.0647.
+    c7f2.3d0d.8f00.1d6d.8daf.0f6f.2e92.fc0e
 ::
 ++  test-rawshake-256
-  %^  expect-eq.tst
-      (rawshake-256 512 0 `@`0)
-    0x3a11.08d4.a90a.31b8.5a10.bdce.77f4.bfbd.
-      cc5b.1d70.dd40.5686.f8bb.de83.4aa1.a410.
-      db8c.9e1c.166c.3e23.9cd7.6a55.f6a6.92aa.
-      2d17.49f2.ec79.cd0b.a3b1.7bb6.5995.9b6e
-  "rawshake-256"
+  %+  expect-eq.tst
+    (rawshake-256 512 0 `@`0)
+  0x3a11.08d4.a90a.31b8.5a10.bdce.77f4.bfbd.
+    cc5b.1d70.dd40.5686.f8bb.de83.4aa1.a410.
+    db8c.9e1c.166c.3e23.9cd7.6a55.f6a6.92aa.
+    2d17.49f2.ec79.cd0b.a3b1.7bb6.5995.9b6e
 --

--- a/tests/zuse/crypto/keccak.hoon
+++ b/tests/zuse/crypto/keccak.hoon
@@ -87,9 +87,9 @@
   %+  weld  $(answers t.answers)
   =+  `[bytes=@ud answer=@]`i.answers
   %+  category.tst  name
-  %+  expect-eq.tst
-    (hash bytes (~(got by keccak-inputs) bytes))
-  answer
+  %-  expect-eq.tst  !>
+  :-  answer
+  (hash bytes (~(got by keccak-inputs) bytes))
 ::
 ::  keccak
 ::
@@ -241,63 +241,63 @@
 ::  sha3
 ::
 ++  test-sha3-224
-  %+  expect-eq.tst
-    (sha3-224 0 `@`0)
-  0x6b4e.0342.3667.dbb7.3b6e.1545.4f0e.b1ab.
-    d459.7f9a.1b07.8e3f.5b5a.6bc7
+  %-  expect-eq.tst  !>
+  :-  0x6b4e.0342.3667.dbb7.3b6e.1545.4f0e.b1ab.
+        d459.7f9a.1b07.8e3f.5b5a.6bc7
+  (sha3-224 0 `@`0)
 ::
 ++  test-sha3-256
-  %+  expect-eq.tst
-    (sha3-256 0 `@`0)
-  0xa7ff.c6f8.bf1e.d766.51c1.4756.a061.d662.
-    f580.ff4d.e43b.49fa.82d8.0a4b.80f8.434a
+  %-  expect-eq.tst  !>
+  :-  0xa7ff.c6f8.bf1e.d766.51c1.4756.a061.d662.
+        f580.ff4d.e43b.49fa.82d8.0a4b.80f8.434a
+  (sha3-256 0 `@`0)
 ::
 ++  test-sha3-384
-  %+  expect-eq.tst
-    (sha3-384 0 `@`0)
-   0xc63.a75b.845e.4f7d.0110.7d85.2e4c.2485.
-    c51a.50aa.aa94.fc61.995e.71bb.ee98.3a2a.
-    c371.3831.264a.db47.fb6b.d1e0.58d5.f004
+  %-  expect-eq.tst  !>
+  :-  0xc63.a75b.845e.4f7d.0110.7d85.2e4c.2485.
+        c51a.50aa.aa94.fc61.995e.71bb.ee98.3a2a.
+        c371.3831.264a.db47.fb6b.d1e0.58d5.f004
+  (sha3-384 0 `@`0)
 ::
 ++  test-sha3-512
-  %+  expect-eq.tst
+  %-  expect-eq.tst  !>
+  :-  0xa69f.73cc.a23a.9ac5.c8b5.67dc.185a.756e.
+        97c9.8216.4fe2.5859.e0d1.dcc1.475c.80a6.
+        15b2.123a.f1f5.f94c.11e3.e940.2c3a.c558.
+        f500.199d.95b6.d3e3.0175.8586.281d.cd26
     (sha3-512 0 `@`0)
-  0xa69f.73cc.a23a.9ac5.c8b5.67dc.185a.756e.
-    97c9.8216.4fe2.5859.e0d1.dcc1.475c.80a6.
-    15b2.123a.f1f5.f94c.11e3.e940.2c3a.c558.
-    f500.199d.95b6.d3e3.0175.8586.281d.cd26
-::
+  ::
 ::  shake
 ::
 ++  test-shake-128
-  %+  expect-eq.tst
-    (shake-128 512 0 `@`0)
-  0x7f9c.2ba4.e88f.827d.6160.4550.7605.853e.
-    d73b.8093.f6ef.bc88.eb1a.6eac.fa66.ef26.
-    3cb1.eea9.8800.4b93.103c.fb0a.eefd.2a68.
-    6e01.fa4a.58e8.a363.9ca8.a1e3.f9ae.57e2
+  %-  expect-eq.tst  !>
+  :-  0x7f9c.2ba4.e88f.827d.6160.4550.7605.853e.
+        d73b.8093.f6ef.bc88.eb1a.6eac.fa66.ef26.
+        3cb1.eea9.8800.4b93.103c.fb0a.eefd.2a68.
+      6e01.fa4a.58e8.a363.9ca8.a1e3.f9ae.57e2
+  (shake-128 512 0 `@`0)
 ::
 ++  test-shake-256
-  %+  expect-eq.tst
-    (shake-256 512 0 `@`0)
-  0x46b9.dd2b.0ba8.8d13.233b.3feb.743e.eb24.
-    3fcd.52ea.62b8.1b82.b50c.2764.6ed5.762f.
-    d75d.c4dd.d8c0.f200.cb05.019d.67b5.92f6.
-    fc82.1c49.479a.b486.4029.2eac.b3b7.c4be
+  %-  expect-eq.tst  !>
+  :-  0x46b9.dd2b.0ba8.8d13.233b.3feb.743e.eb24.
+        3fcd.52ea.62b8.1b82.b50c.2764.6ed5.762f.
+        d75d.c4dd.d8c0.f200.cb05.019d.67b5.92f6.
+      fc82.1c49.479a.b486.4029.2eac.b3b7.c4be
+  (shake-256 512 0 `@`0)
 ::
 ++  test-rawshake-128
-  %+  expect-eq.tst
-    (rawshake-128 512 0 `@`0)
-  0xfa01.9a3b.1763.0df6.0148.53b5.4707.73f1.
-    3c3a.b704.4782.11d7.a658.6751.5dea.1cc7.
-    926b.2147.e396.076b.22cb.7263.3af5.0647.
-    c7f2.3d0d.8f00.1d6d.8daf.0f6f.2e92.fc0e
+  %-  expect-eq.tst  !>
+  :-  0xfa01.9a3b.1763.0df6.0148.53b5.4707.73f1.
+        3c3a.b704.4782.11d7.a658.6751.5dea.1cc7.
+        926b.2147.e396.076b.22cb.7263.3af5.0647.
+        c7f2.3d0d.8f00.1d6d.8daf.0f6f.2e92.fc0e
+  (rawshake-128 512 0 `@`0)
 ::
 ++  test-rawshake-256
-  %+  expect-eq.tst
-    (rawshake-256 512 0 `@`0)
-  0x3a11.08d4.a90a.31b8.5a10.bdce.77f4.bfbd.
-    cc5b.1d70.dd40.5686.f8bb.de83.4aa1.a410.
-    db8c.9e1c.166c.3e23.9cd7.6a55.f6a6.92aa.
-    2d17.49f2.ec79.cd0b.a3b1.7bb6.5995.9b6e
+  %-  expect-eq.tst  !>
+  :-  0x3a11.08d4.a90a.31b8.5a10.bdce.77f4.bfbd.
+        cc5b.1d70.dd40.5686.f8bb.de83.4aa1.a410.
+        db8c.9e1c.166c.3e23.9cd7.6a55.f6a6.92aa.
+        2d17.49f2.ec79.cd0b.a3b1.7bb6.5995.9b6e
+  (rawshake-256 512 0 `@`0)
 --

--- a/tests/zuse/crypto/keccak.hoon
+++ b/tests/zuse/crypto/keccak.hoon
@@ -86,10 +86,10 @@
   ?~  answers  ~
   %+  weld  $(answers t.answers)
   =+  `[bytes=@ud answer=@]`i.answers
+  %+  category.tst  name
   %+  expect-eq.tst
     (hash bytes (~(got by keccak-inputs) bytes))
   answer
-  ::"{name} {(scow %ud bytes)} bytes"
 ::
 ::  keccak
 ::

--- a/tests/zuse/crypto/keccak.hoon
+++ b/tests/zuse/crypto/keccak.hoon
@@ -82,11 +82,10 @@
           name=tape
           answers=(list (pair @ud @))
       ==
-  ^+  tst
-  ?~  answers  tst
-  =*  bytes  p.i.answers
-  =*  answer  q.i.answers
-  =-  $(tst -, answers t.answers)
+  ^-  wall
+  ?~  answers  ~
+  %+  weld  $(answers t.answers)
+  =+  `[bytes=@ud answer=@]`i.answers
   %+  expect-eq.tst
     (hash bytes (~(got by keccak-inputs) bytes))
   answer

--- a/tests/zuse/crypto/keccak.hoon
+++ b/tests/zuse/crypto/keccak.hoon
@@ -72,7 +72,7 @@
       d79d.c266.f6a5.be6b.b0e4.a92e.ceeb.aeb1
   ==
 ::
-|_  tst=tester-type:tester
+|_  tst=_tester:tester
 ::
 ::  check a list of bytelength-answer pairs to see if
 ::  they match the output given by {hash} for the


### PR DESCRIPTION
- clean up interface, pretty-print bug
- speed up by avoiding half a second of per-test compilation, instead doing it up front where the cache works