### PR TITLE
Fix |overload so it takes a date

### DIFF
--- a/app/hood.hoon
+++ b/app/hood.hoon
@@ -107,13 +107,12 @@
 ::
 ::
 ++  from-module                                         ::  create wrapper
-  |*  _[%module ..$ _abet]:(hood-module)
-  =>  .(+< [identity start finish]=+<)
+  |*  _[identity=%module start=..$ finish=_abet]:(hood-module)
   =-  [wrap=- *start]                 ::  usage (wrap handle-arm):from-foo
   |*  handle/_finish
-  |=  _+<.handle
+  |=  a=_+<.handle
   =.  +>.handle  (start hid (able identity))
-  (ably (handle +<))
+  (ably (handle a))
 ::
 ::  per-module interface wrappers
 ++  from-drum  (from-module %drum [..$ _se-abet]:(hood-drum))

--- a/gen/hood/overload.hoon
+++ b/gen/hood/overload.hoon
@@ -8,7 +8,6 @@
   ::
 :-  %say
 |=  $:  {now/@da eny/@uvJ bec/beak}
-        {arg/$@($~ {tym/@dr $~}) $~}
+        {{recur/@dr start/@da $~} $~}
     ==
-?~  arg  $(arg [~h4 ~])
-[%kiln-overload tym.arg]
+[%kiln-overload recur start]

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -269,8 +269,10 @@
   --
 ::
 ++  poke-overload
-  |=  tym/@dr
-  abet:(emit %wait /kiln/overload/(scot %dr tym) (add ~s10 now))
+  :>  +poke-overload: wipes ford cache at {start}, and then every {recur}.
+  |=  [recur=@dr start=@da]
+  ?>  (gte start now)
+  abet:(emit %wait /kiln/overload/(scot %dr recur) start)
 ::
 ++  poke-wipe-ford  |=($~ abet:(emit %wipe /kiln our ~))
 ::


### PR DESCRIPTION
Makes |overload take a date so we can wipe the cache daily outside of business hours.

If merged you should be able to do something like, `|overload ~d1 ~2018.3.13..10.00.00`, where 10.00.00 is a middle of the night time for the west coast in UTC.

Part of mitigating #669.

Next up after this is to just have kiln do a poke to ford or eyre to cause a rebuild right after dropping the cache on the timer.