### PR TITLE
Add timestamps to Ford cache wipes

### DIFF
--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -1926,7 +1926,7 @@
       ?~(buy *baby u.buy)
   =^  mos  bay
     ?-    -.kis
-        $wipe  ~&(%ford-cache-wiped [~ bay(jav ~)])
+        $wipe  ~&(ford-cache-wiped/at=now [~ bay(jav ~)])
         $wasp
       (~(wasp za [our hen [now eny ski] ~] bay) q.kis)
         $exec


### PR DESCRIPTION
This will be more helpful in understanding current Ford's cache-clearing behavior as we continue to make changes to alleviate its issues relating to potential memory overflows, slow build performance, and subsequent `504` HTTP errors.

cc @belisarius222 