### PR TITLE
Prime the cache during |overload

### DIFF
--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -288,6 +288,14 @@
 ::
 ++  take-made                                         ::
   |=  {way/wire dep/@uvH reg/gage:ford}
+  ::  hack for |overload
+  ::
+  ::    We might have gotten an ignorable response back for our cache priming
+  ::    ford call. If it matches our magic wire, ignore it.
+  ::
+  ?:  =(/prime/cache way)
+    ~&  %cache-primed
+    abet
   abet:abet:(made:(take way) dep reg)
 ::
 ++  take-coup-fancy                                   ::
@@ -333,6 +341,19 @@
   |=  {way/wire $~}
   ?>  ?=({@ $~} way)
   =+  tym=(slav %dr i.way)
+  ::  this builds up a ford build for the front page to prime the cache.
+  =.  +>.$
+    =/  request-data  :~
+        [0 [0 8.080] 0 'localhost' ~]
+        ::  associate 0 as the anonymous ship, which is the ++add result.
+        [[0 (scot %p (add our ^~((bex 64))))] ~ ~]
+        'not-yet-implemented'
+        `'en-US,en;q=0.9'
+        `.127.0.0.1
+      ==
+    =/  monies/coin  [%many ~[[%blob request-data] [%$ ~.n 0]]]
+    =/  request/silk:ford  [%bake %urb monies [our %home [%da now]] /web]
+    (emit `card`[%exec /kiln/prime/cache our `[[our %home [%da now]] request]])
   =.  +>.$
     (emit %wipe /kiln/overload/[i.way] our ~)
   =.  +>.$


### PR DESCRIPTION
While we are wiping the ford cache from |overload, we want to simulate an http request to prime as much of the ford cache as we can. Due to ongoing crashes in cttp, we try to fake it by replicating the ford %exec.

@belisarius222