### PR TITLE
Add |invite support for up to sixty-four ships

### DIFF
--- a/gen/hood/invite.hoon
+++ b/gen/hood/invite.hoon
@@ -17,9 +17,21 @@
   ~|  plural-stub+a  ::TODO expand
   %-  trip
   %+  snag  a  ^~
-  %+  weld
-    /no/''/two/three/four/five/six/seven/eight/nine/ten/elven/twelve
-  /thirteen/fourteen/fifteen/sixteen/seventeen/eighteen/nineteen/twenty
+  ;:  weld
+    /no/''/two/three/four/five/six/seven/eight/nine/ten
+    /eleven/twelve/thirteen/fourteen/fifteen/sixteen
+    /seventeen/eighteen/nineteen/twenty/twenty-one
+    /twenty-two/twenty-three/twenty-four/twenty-five
+    /twenty-six/twenty-seven/twenty-eight/twenty-nine
+    /thirty/thirty-one/thirty-two/thirty-three
+    /thirty-four/thirty-five/thirty-six/thirty-seven
+    /thirty-eight/thirty-nine/forty/forty-one/forty-two
+    /forty-three/forty-four/forty-five/forty-six
+    /forty-seven/forty-eight/forty-nine/fifty/fifty-one
+    /fifty-two/fifty-three/fifty-four/fifty-five
+    /fifty-six/fifty-seven/fifty-eight/fifty-nine/sixty
+    /sixty-one/sixty-two/sixty-three/sixty-four
+  ==
 ::
 ++  type  $%({$planets planets/@u} {$stars stars/@u})
 --


### PR DESCRIPTION
Our |invite Hood generator for Womb invites currently caps at twenty
ship invites. This commit bumps that hard-coded cap to sixty-four, which
will allow me to send the appropriate number of star invites to our
[Winter 2018 contributor-award recipients](https://fora.urbit.org/posts/~2018.2.13..20.22.22..bddb~).