### PR TITLE
Disable "last x messages" functionality in hall

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1210,7 +1210,7 @@
               ?=(^ tal.u.ran.src)
             ::
               ?-  -.u.tal.u.ran.src
-                $sd   &
+                :: $sd   &
                 $da   (gte now.bol +.u.tal.u.ran.src)
                 $ud   ?&  ?=(^ seq)
                           (gte u.seq +.u.tal.u.ran.src)
@@ -1233,12 +1233,12 @@
       =.  ran
         ?~  ran  `[[%ud 0] `[%ud count]]
         =*  hed  hed.u.ran
-        =?  hed  ?=($sd -.hed)
-          [%ud (sub count (min count (abs:si +.hed)))]
+        :: =?  hed  ?=($sd -.hed)
+        ::   [%ud (sub count (min count (abs:si +.hed)))]
         ?~  tal.u.ran  `[hed `[%ud count]]
         =*  tal  u.tal.u.ran
-        =?  tal  ?=($sd -.tal)
-          [%ud (sub count (min count (abs:si +.tal)))]
+        :: =?  tal  ?=($sd -.tal)
+        ::   [%ud (sub count (min count (abs:si +.tal)))]
         ran
       ::  never fails, but compiler needs it.
       ?>  &(?=(^ ran) ?=(^ tal.u.ran))
@@ -1248,14 +1248,14 @@
       |-  ^-  (list telegram)
       ?~  gaz  zeg
       ?:  ?-  -.tal                                     ::  after the end
-            $sd  !!  ::  caught above
+            :: $sd  !!  ::  caught above
             $ud  (lth +.tal num)
             $da  (lth +.tal wen.i.gaz)
           ==
         ::  if past the range, we're done searching.
         zeg
       ?:  ?-  -.hed                                     ::  before the start
-            $sd  !!  ::  caught above
+            :: $sd  !!  ::  caught above
             $ud  (lth num +.hed)
             $da  (lth wen.i.gaz +.hed)
           ==
@@ -1279,7 +1279,7 @@
       =/  min
         =*  hed  hed.u.ran
         ?-  -.hed
-          $sd  &  ::  relative is always in.
+          :: $sd  &  ::  relative is always in.
           $ud  (gth count +.hed)
           $da  (gth now.bol +.hed)
         ==
@@ -1288,7 +1288,7 @@
       =-  [&(min -) !-]
       =*  tal  u.tal.u.ran
       ?-  -.tal
-        $sd  |  ::  relative is always done.
+        :: $sd  |  ::  relative is always done.
         $ud  (gte +(+.tal) count)
         $da  (gte +.tal now.bol)
       ==

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -1300,7 +1300,6 @@
               ?=(^ tal.u.ran.src)
             ::
               ?-  -.u.tal.u.ran.src
-                :: $sd   &
                 $da   (gte now.bol +.u.tal.u.ran.src)
                 $ud   ?&  ?=(^ seq)
                           (gte u.seq +.u.tal.u.ran.src)
@@ -1323,12 +1322,8 @@
       =.  ran
         ?~  ran  `[[%ud 0] `[%ud count]]
         =*  hed  hed.u.ran
-        :: =?  hed  ?=($sd -.hed)
-        ::   [%ud (sub count (min count (abs:si +.hed)))]
         ?~  tal.u.ran  `[hed `[%ud count]]
         =*  tal  u.tal.u.ran
-        :: =?  tal  ?=($sd -.tal)
-        ::   [%ud (sub count (min count (abs:si +.tal)))]
         ran
       ::  never fails, but compiler needs it.
       ?>  &(?=(^ ran) ?=(^ tal.u.ran))
@@ -1338,14 +1333,12 @@
       |-  ^-  (list telegram)
       ?~  gaz  zeg
       ?:  ?-  -.tal                                     ::  after the end
-            :: $sd  !!  ::  caught above
             $ud  (lth +.tal num)
             $da  (lth +.tal wen.i.gaz)
           ==
         ::  if past the range, we're done searching.
         zeg
       ?:  ?-  -.hed                                     ::  before the start
-            :: $sd  !!  ::  caught above
             $ud  (lth num +.hed)
             $da  (lth wen.i.gaz +.hed)
           ==
@@ -1369,7 +1362,6 @@
       =/  min
         =*  hed  hed.u.ran
         ?-  -.hed
-          :: $sd  &  ::  relative is always in.
           $ud  (gth count +.hed)
           $da  (gth now.bol +.hed)
         ==
@@ -1378,7 +1370,6 @@
       =-  [&(min -) !-]
       =*  tal  u.tal.u.ran
       ?-  -.tal
-        :: $sd  |  ::  relative is always done.
         $ud  (gte +(+.tal) count)
         $da  (gte +.tal now.bol)
       ==

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -117,7 +117,7 @@
 :>  #
 :>    functional cores and arms.
 ::
-|_  {bol/bowl:gall $0 state}
+|_  {bol/bowl:gall $1 state}
 ::
 :>  #  %transition
 :>    prep transition
@@ -127,7 +127,41 @@
   ::
   =>  |%
       ++  states
-        $%({$0 s/state})
+        $%({$1 s/state} {$0 s/state-0})
+      ::
+      ++  state-0
+        (cork state |=(a/state a(stories (~(run by stories.a) story-0))))
+      ++  story-0
+        %+  cork  story
+        |=  a/story
+        %=  a
+          shape     *config-0
+          mirrors   (~(run by mirrors.a) config-0)
+          peers     (~(run by peers.a) |=(a/(list query) (turn a query-0)))
+        ==
+      ++  query-0
+        $?  $:  $circle
+                nom/name
+                wer/(unit circle)
+                wat/(set circle-data)
+                ran/range-0
+            ==
+            query
+        ==
+      ++  config-0
+        {src/(set source-0) cap/cord tag/tags fit/filter con/control}
+      ++  source-0
+        {cir/circle ran/range-0}
+      ++  range-0
+        %-  unit
+        $:  hed/place-0
+            tal/(unit place-0)
+        ==
+      ++  place-0
+        $%  {$da @da}
+            {$ud @ud}
+            {$sd @sd}
+        ==
       --
   =|  mos/(list move)
   |=  old/(unit states)
@@ -136,8 +170,64 @@
     %-  pre-bake
     ta-done:ta-init:ta
   ?-  -.u.old
-      $0
+      $1
     [mos ..prep(+<+ u.old)]
+  ::
+      $0
+    =-  $(old `[%1 s.u.old(stories -)])
+    |^  %-  ~(run by stories.s.u.old)
+        |=  soy/story-0
+        ^-  story
+        %=  soy
+          shape     (prep-config shape.soy)
+          mirrors   (~(run by mirrors.soy) prep-config)
+          peers     %-  ~(run by peers.soy)
+                    |=  a/(list query-0)
+                    ^-  (list query)
+                    (murn a prep-query)
+        ==
+    ::
+    ++  prep-config
+      |=  cof/config-0
+      ^-  config
+      %=  cof
+          src
+        %-  ~(gas in *(set source))
+        (murn ~(tap in src.cof) prep-source)
+      ==
+    ::
+    ++  prep-source
+      |=  src/source-0
+      ^-  (unit source)
+      =+  nan=(prep-range ran.src)
+      ?~  nan
+        ~&  [%forgetting-source src]
+        ~
+      `src(ran u.nan)
+    ::
+    ++  prep-query
+      |=  que/query-0
+      ^-  (unit query)
+      ?.  ?=($circle -.que)  `que
+      =+  nan=(prep-range ran.que)
+      ?~  nan
+        ~&  [%forgetting-query que]
+        ~
+      `que(ran u.nan)
+    ::
+    ++  prep-range
+      |=  ran/range-0
+      ^-  (unit range)
+      ?~  ran  `ran
+      ::  ranges with a relative end aren't stored because they end
+      ::  immediately, so if we find one we can safely discard it.
+      ?:  ?=({$~ {$sd @sd}} tal.u.ran)  ~
+      ::  we replace relative range starts with the current date.
+      ::  this is practically correct.
+      ?:  ?=({$sd @sd} hed.u.ran)
+        `ran(hed.u [%da now.bol])
+      `ran
+    --
   ==
 ::
 :>  #  %engines

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -284,8 +284,6 @@
       %+  welp  /circle/[inbox]/grams/config/group
       ?.  =(0 count)
         [(scot %ud last) ~]
-      :: =+  history-msgs=200
-      :: [(cat 3 '-' (scot %ud history-msgs)) ~]
       =+  history-days=~d5
       [(scot %da (sub now.bol history-days)) ~]
   ==

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -113,7 +113,7 @@
 :>  #
 :>    functional cores and arms.
 ::
-|_  {bol/bowl:gall $0 state}
+|_  {bol/bowl:gall $1 state}
 ::
 :>  #  %transition
 :>    prep transition
@@ -124,7 +124,24 @@
   ::
   =>  |%
       ++  states
-        $%({$0 s/state})
+        $%({$1 s/state} {$0 s/state-0})
+      ::
+      ++  state-0
+        (cork state |=(a/state a(mirrors (~(run by mirrors.a) config-0))))
+      ++  config-0
+        {src/(set source-0) cap/cord tag/tags fit/filter con/control}
+      ++  source-0
+        {cir/circle ran/range-0}
+      ++  range-0
+        %-  unit
+        $:  hed/place-0
+            tal/(unit place-0)
+        ==
+      ++  place-0
+        $%  {$da @da}
+            {$ud @ud}
+            {$sd @sd}
+        ==
       --
   =|  mos/(list move)
   |=  old/(unit states)
@@ -132,8 +149,46 @@
   ?~  old
     ta-done:ta-init:ta
   ?-  -.u.old
-      $0
+      $1
     [mos ..prep(+<+ u.old)]
+  ::
+      $0
+    =.  mos  [[ost.bol %pull /server/inbox server ~] peer-inbox mos]
+    =-  $(old `[%1 s.u.old(mirrors -)])
+    |^
+      (~(run by mirrors.s.u.old) prep-config)
+    ::
+    ++  prep-config
+      |=  cof/config-0
+      ^-  config
+      %=  cof
+          src
+        %-  ~(gas in *(set source))
+        (murn ~(tap in src.cof) prep-source)
+      ==
+    ::
+    ++  prep-source
+      |=  src/source-0
+      ^-  (unit source)
+      =+  nan=(prep-range ran.src)
+      ?~  nan
+        ~&  [%forgetting-source src]
+        ~
+      `src(ran u.nan)
+    ::
+    ++  prep-range
+      |=  ran/range-0
+      ^-  (unit range)
+      ?~  ran  `ran
+      ::  ranges with a relative end aren't stored because they end
+      ::  immediately, so if we find one we can safely discard it.
+      ?:  ?=({$~ {$sd @sd}} tal.u.ran)  ~
+      ::  we replace relative range starts with the current date.
+      ::  this is practically correct.
+      ?:  ?=({$sd @sd} hed.u.ran)
+        `ran(hed.u [%da now.bol])
+      `ran
+    --
   ==
 ::
 :>  #

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -229,8 +229,10 @@
       %+  welp  /circle/[inbox]/grams/config/group
       ?.  =(0 count)
         [(scot %ud last) ~]
-      =+  history-msgs=200
-      [(cat 3 '-' (scot %ud history-msgs)) ~]
+      :: =+  history-msgs=200
+      :: [(cat 3 '-' (scot %ud history-msgs)) ~]
+      =+  history-days=~d5
+      [(scot %da (sub now.bol history-days)) ~]
   ==
 ::
 :>  #

--- a/lib/hall.hoon
+++ b/lib/hall.hoon
@@ -78,9 +78,7 @@
   ::
   |=  pla/place
   ^-  knot
-  :: ?.  ?=($sd -.pla)
-    (scot -.pla +.pla)
-  :: (cat 3 '-' (scot %ud (abs:si +.pla)))
+  (scot -.pla +.pla)
 ::
 ++  path-to-range
   :>    path to msg range
@@ -107,10 +105,6 @@
     |=  a/dime
     ^-  (unit @da)
     ?:(?=($da p.a) `q.a ~)
-  ::
-    :: %+  stag  %sd
-    :: %+  cook  (cury new:si |)
-    :: ;~(pfix hep dem:ag)
   ==
 ::
 ++  change-glyphs                                       :<  ...

--- a/lib/hall.hoon
+++ b/lib/hall.hoon
@@ -78,8 +78,9 @@
   ::
   |=  pla/place
   ^-  knot
-  ?.  ?=($sd -.pla)  (scot -.pla +.pla)
-  (cat 3 '-' (scot %ud (abs:si +.pla)))
+  :: ?.  ?=($sd -.pla)
+    (scot -.pla +.pla)
+  :: (cat 3 '-' (scot %ud (abs:si +.pla)))
 ::
 ++  path-to-range
   :>    path to msg range
@@ -107,9 +108,9 @@
     ^-  (unit @da)
     ?:(?=($da p.a) `q.a ~)
   ::
-    %+  stag  %sd
-    %+  cook  (cury new:si |)
-    ;~(pfix hep dem:ag)
+    :: %+  stag  %sd
+    :: %+  cook  (cury new:si |)
+    :: ;~(pfix hep dem:ag)
   ==
 ::
 ++  change-glyphs                                       :<  ...

--- a/sur/hall.hoon
+++ b/sur/hall.hoon
@@ -55,7 +55,7 @@
 ++  place                                               :>  range indicators
   $%  {$da @da}                                         :<  date
       {$ud @ud}                                         :<  message number
-      {$sd @sd}                                         :<  previous messages
+      :: {$sd @sd}                                         :<  previous messages
   ==                                                    ::
 ++  prize                                               :>  query result
   $%  {$client prize-client}                            :<  /client

--- a/sur/hall.hoon
+++ b/sur/hall.hoon
@@ -55,7 +55,6 @@
 ++  place                                               :>  range indicators
   $%  {$da @da}                                         :<  date
       {$ud @ud}                                         :<  message number
-      :: {$sd @sd}                                         :<  previous messages
   ==                                                    ::
 ++  prize                                               :>  query result
   $%  {$client prize-client}                            :<  /client


### PR DESCRIPTION
The small change #658 made reached the structures used for communication between hall instances. Since it's not correct to assume all ships on the network get updates synchronously or at all, this is bad. To make this change, hall needs an interface versioning mechanism.

This comments out parts of the code from #658, for later re-enabling.  
I tried making `++prep` logic for this not awful, but that's actually kind of difficult.

Tested this to adapt state from current master fine. Restores the structures to their original state, so should make comms with outdates ships function again.

Re-opens #643.