### PR TITLE
updates +win:re to wrap lines safely with regards to unicode

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -4118,17 +4118,17 @@
       (weld ram(tac i.q.tac) ?~(t.q.tac voz (weld p.p.tac voz)))
     ==
   ::
-  ++  gyp                                               :: horrible hack
+  ++  ug                                                ::  horrible hack
     |%
-    ++  hew
-      |=(a=tape `tape``(list @)`(tuba a))
+    ++  ace                                             ::  strip ctrl chars
+      |=  a=tape
+      ^-  tape
+      ?~  a  ~
+      ?:  |((lth i.a 32) =(127 `@`i.a))
+        $(a t.a)
+      [i.a $(a t.a)]
     ::
-    ++  fix
-      |=  wol=wall
-      %+  turn  wol
-      |=(a=tape (tufa `(list @c)``(list @)`a))
-    ::
-    ++  act
+    ++  act                                             ::  pretend tapes
       |=  tac=tank
       ^-  tank
       ?-  -.tac
@@ -4140,12 +4140,20 @@
                  [(hew p.p.tac) (hew q.p.tac) (hew r.p.tac)]
                (turn q.tac act)
       ==
+    ::
+    ++  fix                                             ::  restore tapes
+      |=  wol=wall
+      %+  turn  wol
+      |=(a=tape (tufa `(list @c)``(list @)`a))
+    ::
+    ++  hew                                             ::  pretend tape
+      |=(a=tape `tape``(list @)`(tuba (ace a)))
     --
   ::
   ++  win
     |=  {tab/@ edg/@}
-    =.  tac  (act:gyp tac)
-    %-  fix:gyp
+    =.  tac  (act:ug tac)
+    %-  fix:ug
     =+  lug=`wall`~
     |^  |-  ^-  wall
         ?-    -.tac

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -4118,8 +4118,34 @@
       (weld ram(tac i.q.tac) ?~(t.q.tac voz (weld p.p.tac voz)))
     ==
   ::
+  ++  gyp                                               :: horrible hack
+    |%
+    ++  hew
+      |=(a=tape `tape``(list @)`(tuba a))
+    ::
+    ++  fix
+      |=  wol=wall
+      %+  turn  wol
+      |=(a=tape (tufa `(list @c)``(list @)`a))
+    ::
+    ++  act
+      |=  tac=tank
+      ^-  tank
+      ?-  -.tac
+        %leaf  [%leaf (hew p.tac)]
+        %palm  :+  %palm
+                 [(hew p.p.tac) (hew q.p.tac) (hew r.p.tac) (hew s.p.tac)]
+               (turn q.tac act)
+        %rose  :+  %rose
+                 [(hew p.p.tac) (hew q.p.tac) (hew r.p.tac)]
+               (turn q.tac act)
+      ==
+    --
+  ::
   ++  win
     |=  {tab/@ edg/@}
+    =.  tac  (act:gyp tac)
+    %-  fix:gyp
     =+  lug=`wall`~
     |^  |-  ^-  wall
         ?-    -.tac


### PR DESCRIPTION
(by converting the `tape`s in `+tank` to (list @c) before wrapping, then back)

This is a fix for unsafe unicode handling in general, and #674 specifically.

The "printable" structure `+tank`, designed for stack traces and type printing and slated for replacement, is heavily used in printing to the console. The renderer `+re` converts `+tank` to `+wall`, optionally wrapping long lines to a specified width. But since `+tank` consists of various combinations of `+tape`, which is a linked list of utf8 bytes, it's possible for `+re` to split multi-byte unicode codepoints, resulting in `%bad-text`.

For example:

```
> (~(win re [%leaf "abc’d"]) 0 5)
[%bad-text "[60 60 34 92 92 47 97 92 92 47 34 32 34 32 32 98 34 32 34 32 32 99 34 32 34 32 32 226 34 32 34 32 32 128 34 32 34 32 32 153 34 32 34 32 32 100 34 32 34 92 92 47 32 92 92 47 34 62 62 0]"]
```

This PR is a straightforward hack to make line-wrapping safe: first we make a copy of the `+tank`, converting all the tapes within to lists of codepoints, then we wrap and render the lists of codepoints, then we convert the output back to actual tapes. It's a hack because a) it's not very efficient and b) we have to lie to the type system. But it has the advantage of working without touching all the different parts of urbit that create a `+tank`, which, again, is slated for removal.

```
> (~(win re [%leaf "abc’d"]) 0 5)
<<"abc’d">>
```

These changes are all internal to `+re`, so there shouldn't be any issues pushing this out to the live network. I still need to reproduce the exact fora post scenario from #674 and confirm that no other issues are involved.