### PR TITLE
Foreign ship %next requests

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1886,6 +1886,12 @@
         $(rov [-.rov mol `+(u.aey) ~ ~])
       ::  if old isn't complete, try filling in the gaps.
       =?  old  !(complete old)
+        ::  if we're looking for changes in revision zero, then the previous
+        ::  revision only has "file does not exist" results.
+        ?:  =(u.yon 0)
+          %-  ~(gas by *(map (pair care path) cach))
+          %+  turn  ~(tap in q.mol)
+          |=(r=(pair care path) [r [~ ~]])
         (read-unknown mol(p [%ud (dec u.yon)]) old)
       ::  if the next aeon we want to compare is in the future, wait again.
       =+  aey=(case-to-aeon:ze [%ud u.yon])

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -280,7 +280,7 @@
 ++  wove  {p/(unit ship) q/rove}                        ::  stored source + req
 ++  rove                                                ::  stored request
           $%  {$sing p/mood}                            ::  single request
-              {$next p/mood q/cach}                     ::  next version
+              {$next p/mood q/(unit aeon) r/cach}       ::  next version of one
               $:  $mult                                 ::  next version of any
                   p/mool                                ::  original request
                   q/(unit aeon)                         ::  checking for change
@@ -907,7 +907,7 @@
       ::  if the requested case is in the future, we can't know anything yet.
       ?~  aey  (store ~ ~ ~)
       =+  old=(read-all-at cas)
-      =+  yon=+((need (case-to-aeon:ze cas)))
+      =+  yon=+(u.aey)
       |-  ^+  ..start-request
       ::  if we need future revisions to look for change, wait.
       ?:  (gth yon let.dom)
@@ -948,7 +948,7 @@
         ^-  rove
         ?:  ?=($mult -.rav)
           [-.rav p.rav nex old new]
-        :+  -.rav  p.rav
+        :^  -.rav  p.rav  nex
         =+  ole=~(tap by old)
         ?>  (lte (lent ole) 1)
         ?~  ole  ~
@@ -1860,10 +1860,11 @@
       |^
       =/  rov/rove
         ?:  ?=($mult -.vor)  vor
+        =*  mod  p.vor
         :*  %mult
-            [q.p.vor [[p.p.vor r.p.vor] ~ ~]]
-            `let.dom
-            [[[p.p.vor r.p.vor] q.vor] ~ ~]
+            [q.mod [[p.mod r.mod] ~ ~]]
+            q.vor
+            [[[p.mod r.mod] r.vor] ~ ~]
             ~
         ==
       ?>  ?=($mult -.rov)
@@ -1933,7 +1934,7 @@
         ?:  ?=($mult -.vor)  rov
         ?>  ?=({* $~ $~} r.rov)
         =*  one  n.r.rov
-        [%next [p.p.one p.p.rov q.p.one] q.one]
+        [%next [p.p.one p.p.rov q.p.one] q.rov q.one]
       ::
       ++  respond                                       ::  send changes
         |=  res/(map mood (each cage lobe))

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1887,12 +1887,6 @@
         $(rov [-.rov mol `+(u.aey) ~ ~])
       ::  if old isn't complete, try filling in the gaps.
       =?  old  !(complete old)
-        ::  if we're looking for changes in revision zero, then the previous
-        ::  revision only has "file does not exist" results.
-        ?:  =(u.yon 0)
-          %-  ~(gas by *(map (pair care path) cach))
-          %+  turn  ~(tap in q.mol)
-          |=(r=(pair care path) [r [~ ~]])
         (read-unknown mol(p [%ud (dec u.yon)]) old)
       ::  if the next aeon we want to compare is in the future, wait again.
       =+  aey=(case-to-aeon:ze [%ud u.yon])

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3569,7 +3569,7 @@
 ::
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 =|                                                    ::  instrument state
-    $:  $0                                            ::  vane version
+    $:  $1                                            ::  vane version
         ruf/raft                                      ::  revision tree
     ==                                                ::
 |=  {now/@da eny/@ ski/sley}                          ::  activate
@@ -3830,12 +3830,79 @@
 ::
 ++  load
   =>  |%
-      ++  axle  $%({$0 ruf/raft})
+      ++  rove-0
+        $%  {$sing p/mood}
+            {$next p/mood q/cach}
+            $:  $mult
+                p/mool
+                q/(unit aeon)
+                r/(map (pair care path) cach)
+                s/(map (pair care path) cach)
+            ==
+            {$many p/? q/moat r/(map path lobe)}
+        ==
+      ++  wove-0  (cork wove |=(a/wove a(q (rove-0 q.a))))
+      ++  cult-0  (jug wove-0 duct)
+      ++  dojo-0  (cork dojo |=(a/dojo a(qyx *cult-0)))
+      ++  rede-0  (cork rede |=(a/rede a(qyx *cult-0)))
+      ++  room-0  (cork room |=(a/room a(dos (~(run by dos.a) dojo-0))))
+      ++  rung-0  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-0))))
+      ++  raft-0
+        %+  cork  raft
+        |=  a/raft
+        %=  a
+          fat   (~(run by fat.a) room-0)
+          hoy   (~(run by hoy.a) rung-0)
+        ==
+      ::
+      ++  axle  $%({$1 ruf/raft} {$0 ruf/raft-0})
       --
   |=  old/axle
   ^+  ..^$
   ?-  -.old
-    $0  ..^$(ruf ruf.old)
+      $1
+    ..^$(ruf ruf.old)
+  ::
+      $0
+    |^
+      =-  ^$(old [%1 -])
+      =+  ruf.old
+      :*  (~(run by fat) rom)
+          (~(run by hoy) run)
+          ran  mon  hez  ~
+      ==
+    ::
+    ++  wov
+      |=  a/wove-0
+      ^-  wove
+      :-  p.a
+      ?.  ?=($next -.q.a)  q.a
+      [%next p.q.a ~ q.q.a]
+    ::
+    ++  cul
+      |=  a/cult-0
+      ^-  cult
+      %-  ~(gas by *cult)
+      %+  turn  ~(tap by a)
+      |=  {p/wove-0 q/(set duct)}
+      [(wov p) q]
+    ::
+    ++  rom
+      |=  room-0
+      ^-  room
+      :-  hun
+      %-  ~(run by dos)
+      |=  d/dojo-0
+      ^-  dojo
+      d(qyx (cul qyx.d))
+    ::
+    ++  run
+      |=  a/rung-0
+      =-  a(rus (~(run by rus.a) -))
+      |=  r/rede-0
+      ^-  rede
+      r(qyx (cul qyx.r))
+    --
   ==
 ::
 ++  scry                                              ::  inspect
@@ -3867,7 +3934,7 @@
   ?:  ?=($& -.u.u.-)  ``p.u.u.-
   ~
 ::
-++  stay  [%0 ruf]
+++  stay  [%1 ruf]
 ++  take                                              ::  accept response
   |=  {tea/wire hen/duct hin/(hypo sign)}
   ^+  [p=*(list move) q=..^$]


### PR DESCRIPTION
This fixes the symptom displayed in #681, but doesn't really address the underlying issue. This PR should probably be considered not ready to be merged until that has been resolved properly.

Currently, this PR only fixes the runtime error that would occur when trying to check revision zero for changes. It would try to look at the previous revision, but `(dec 0)` crashes. Now, it detects this and generates "file does not exist" results for all relevant files.

The underlying cause here is that the known latest revision for foreign ships (relevant [when converting a `%next` into a `%mult`](https://github.com/Fang-/arvo/blob/9f94497e87c28f8355c7a8628843b8f6bc02634e/sys/vane/clay.hoon#L1865) for code sharing purposes) is blindly used for `%next` requests, even when they're asking for changes on higher revisions.

That seems like something we probably want to fix. And that's doable, but also raises a question about `%next` requests. Was is ever supposed to work with requests to foreign ships? If we look at [the old `++wake` code for `%next`](https://github.com/urbit/arvo/blob/3f9223094a76a0fc6bc125191faecee0395cab57/sys/vane/clay.hoon#L1676-L1696) we can see that it always tries to read out the current version. If it can't do so synchronously, it prints `%oh-noes` and moves on.  
Unless I'm misunderstanding, it's not uncommon for it to go "oh noes" there on foreign files, since we're not guaranteed to have the latest version around. This creates problems, because `++wake` logic for `%next` (used to, and still) assumes that the check on the previous revision already happened.

Proposed solution is to extend the `++rove` for `%next` with a "next revision to check for change" variable. This has the tiny additional benefit of bringing it closer to `%mult`, implementation-wise.