### PR TITLE
Change %w care to return all related cases

### DIFF
--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -412,7 +412,7 @@
           leaf+"bad %writ response"
         (render "on sync" sud her syd)
       ~
-    =.  let  ?.  ?=($w p.p.u.rot)  let  ((hard @ud) q.q.r.u.rot)
+    =.  let  ?.  ?=($w p.p.u.rot)  let  ud:((hard cass) q.q.r.u.rot)
     %-  blab  ^-  (list move)  :_  ~
     :*  ost  %merg
         [%kiln %sync syd (scot %p her) sud ?:(reset /reset /)]

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -417,7 +417,7 @@
     :*  ost  %merg
         [%kiln %sync syd (scot %p her) sud ?:(reset /reset /)]
         our  syd  her  sud  ud+let
-        ?:  =(0 .^(* %cw /(scot %p our)/[syd]/(scot %da now)))
+        ?:  =(0 ud:.^(cass:clay %cw /(scot %p our)/[syd]/(scot %da now)))
           %init
         %mate
     ==
@@ -524,7 +524,7 @@
     ^+  +>
     ?.  ?=($auto gim)
       perform(auto |, gem gim, her her, cas cas, sud sud)
-    ?:  =(0 .^(@ %cw /(scot %p our)/[syd]/(scot %da now)))
+    ?:  =(0 ud:.^(cass:clay %cw /(scot %p our)/[syd]/(scot %da now)))
       =>  $(gim %init)
       .(auto &)
     =>  $(gim %fine)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1583,7 +1583,7 @@
         :+  ~
           p.r.u.rut
         ?+  p.r.u.rut  ~|  %strange-w-over-nextwork  !!
-          $aeon  !>(((hard aeon) q.r.u.rut))
+          $cass  !>(((hard cass) q.r.u.rut))
           $null  [[%atom %n ~] ~]
           $nako  !>(~|([%harding [&1 &2 &3]:q.r.u.rut] ((hard nako) q.r.u.rut)))
         ==
@@ -2462,7 +2462,7 @@
       ^-  (unit (unit (each cage lobe)))
       =+  aey=(case-to-aeon cas)
       ?~  aey  ~
-      =-  [~ ~ %& %noun !>(-)]
+      =-  [~ ~ %& %cass !>(-)]
       ^-  cass
       :+  u.aey
         t:(aeon-to-yaki u.aey)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2772,7 +2772,6 @@
                     let/@ud
                     hit/(map @ud tako)
                     lab/(map @tas @ud)
-                    bal/(jug @ud @tas)
                 ==
             q.q.r.u.rot
         ?:  =(0 let.dum)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2462,6 +2462,7 @@
       ^-  (unit (unit (each cage lobe)))
       =+  aey=(case-to-aeon cas)
       ?~  aey  ~
+      ?:  =(0 u.aey)  [~ ~]
       =-  [~ ~ %& %cass !>(-)]
       ^-  cass
       :+  u.aey

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2173,10 +2173,7 @@
            ::  +>.$(ank (map-to-ankh q.yak))
         $|
            ?<  (~(has by lab.dom) p.lem)
-           :-  ~
-           %_  ..ze
-             lab.dom  (~(put by lab.dom) p.lem let.dom)
-           ==
+           [~ ..ze(lab.dom (~(put by lab.dom) p.lem let.dom))]
       ==
     ::
     ::  Create a commit out of a list of changes against the current state.
@@ -2767,12 +2764,7 @@
         ?~  rot
           (error:he %bad-fetch-ali ~)
         =+  ^=  dum
-            %-  %-  hard
-                $:  ank/*
-                    let/@ud
-                    hit/(map @ud tako)
-                    lab/(map @tas @ud)
-                ==
+            %-  (hard {ank/* let/@ud hit/(map @ud tako) lab/(map @tas @ud)})
             q.q.r.u.rot
         ?:  =(0 let.dum)
           (error:he %no-ali-desk ~)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2460,13 +2460,13 @@
     ++  read-w
       |=  cas/case
       ^-  (unit (unit (each cage lobe)))
-      =+  aey=(case-to-aeon)
+      =+  aey=(case-to-aeon cas)
       ?~  aey  ~
       =-  [~ ~ %& %noun !>(-)]
       ^-  cass
       :+  u.aey
-        t:(aeon-to-yaki aey)
-      (~(get ju bal.dom) aey)
+        t:(aeon-to-yaki u.aey)
+      (~(get ju bal.dom) u.aey)
     ::
     ::  Gets the data at a node.
     ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -82,7 +82,6 @@
       let/aeon                                          ::  top id
       hit/(map aeon tako)                               ::  versions by id
       lab/(map @tas aeon)                               ::  labels
-      bal/(jug aeon @tas)                               ::  label reverse lookup
   ==                                                    ::
 ::
 ::  Commit state.
@@ -2177,7 +2176,6 @@
            :-  ~
            %_  ..ze
              lab.dom  (~(put by lab.dom) p.lem let.dom)
-             bal.dom  (~(put ju bal.dom) let.dom p.lem)
            ==
       ==
     ::
@@ -2447,7 +2445,6 @@
             let=yon
             hit=(molt (skim ~(tap by hit.dom) |=({p/@ud *} (lte p yon))))
             lab=(molt (skim ~(tap by lab.dom) |=({* p/@ud} (lte p yon))))
-            bal=(molt (skim ~(tap by bal.dom) |=({p/@ud *} (lte p yon))))
         ==
       ?:  (gth yon let.dom)
         ~
@@ -3793,14 +3790,8 @@
         ==
       ++  wove-0  (cork wove |=(a/wove a(q (rove-0 q.a))))
       ++  cult-0  (jug wove-0 duct)
-      ++  dome-0
-        $:  ank/ankh
-            let/aeon
-            hit/(map aeon tako)
-            lab/(map @tas aeon)
-        ==
-      ++  dojo-0  (cork dojo |=(a/dojo a(qyx *cult-0, dom *dome-0)))
-      ++  rede-0  (cork rede |=(a/rede a(qyx *cult-0, dom *dome-0)))
+      ++  dojo-0  (cork dojo |=(a/dojo a(qyx *cult-0)))
+      ++  rede-0  (cork rede |=(a/rede a(qyx *cult-0)))
       ++  room-0  (cork room |=(a/room a(dos (~(run by dos.a) dojo-0))))
       ++  rung-0  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-0))))
       ++  raft-0
@@ -3843,14 +3834,6 @@
       |=  {p/wove-0 q/(set duct)}
       [(wov p) q]
     ::
-    ++  dom
-      |=  dome-0
-      ^-  dome
-      =-  [ank let hit lab -]
-      %+  roll  ~(tap by lab)
-      |=  {{l/@tas a/aeon} r/(jug aeon @tas)}
-      (~(put ju r) a l)
-    ::
     ++  rom
       |=  room-0
       ^-  room
@@ -3858,14 +3841,14 @@
       %-  ~(run by dos)
       |=  d/dojo-0
       ^-  dojo
-      d(qyx (cul qyx.d), dom (dom dom.d))
+      d(qyx (cul qyx.d))
     ::
     ++  run
       |=  a/rung-0
       =-  a(rus (~(run by rus.a) -))
       |=  r/rede-0
       ^-  rede
-      r(qyx (cul qyx.r), dom (dom dom.r))
+      r(qyx (cul qyx.r))
     --
   ==
 ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2361,42 +2361,6 @@
         $delta     (~(put in $(lob q.q.gar)) lob)
       ==
     ::
-    ::  Should be refactored, is only called form `++read`, and even then it
-    ::  can't be called with `$v` as the care, so it's really just a crash.
-    ::
-    ::  To be clear the refactoring should start at ++read-at-aeon and probably
-    ::  eliminate ++read and ++query
-    ::
-    ++  query                                           ::    query:ze
-      |=  ren/$?($p $u $v $x $y $z)                     ::  endpoint query
-      ^-  (unit cage)
-      ?-  ren
-        $p  !!
-        $u  !!  ::  [~ %null [%atom %n] ~]
-        $v  [~ %dome !>(dom)]
-        $x  !!  ::  ?~(q.ank.dom ~ [~ q.u.q.ank.dom])
-        $y  !!  ::  [~ %arch !>(as-arch)]
-        $z  !!  ::  [~ %ankh !>(ank.dom)]
-      ==
-    ::
-    ::  See ++query.
-    ::
-    ++  read                                            ::    read:ze
-      |=  mun/mood                                      ::  read at point
-      ^-  (unit cage)
-      ?:  ?=($d p.mun)
-        ~&  %dead-d  ~
-      ?:  ?=($v p.mun)
-        [~ %dome !>(dom)]                               ::  dead code
-      ?:  &(?=($w p.mun) !?=($ud -.q.mun))
-        ?^(r.mun ~ [~ %aeon !>(let.dom)])               ::  dead code
-      ?:  ?=($w p.mun)
-        =+  ^=  yak
-            %-  aeon-to-yaki
-            let.dom
-        ?^(r.mun ~ !!) :: [~ %w !>([t.yak (forge-nori yak)])])-all
-      (query(ank.dom ank:(descend-path:(zu ank.dom) r.mun)) p.mun) ::  dead code
-    ::
     ::  Gets the permissions that apply to a particular node.
     ::
     ::  If the node has no permissions of its own, we use its parent's.
@@ -2615,68 +2579,28 @@
     ::  meaning we either have the value directly or a content hash of the
     ::  value.
     ::
-    ::  Should change last few lines to an explicit ++read-w.
-    ::
     ++  read-at-aeon                                    ::    read-at-aeon:ze
       |=  {for/(unit ship) yon/aeon mun/mood}           ::  seek and read
       ^-  (unit (unit (each cage lobe)))
       ?.  |(?=($~ for) (may-read u.for p.mun yon r.mun))
         ~
-      ?:  &(?=($w p.mun) !?=($ud -.q.mun))              ::  NB only her speed
-        (read-w q.mun)
-      ?:  ?=($d p.mun)
+      ?-  p.mun
+          $d
         =+  rom=(~(get by fat.ruf) her)
         ?~  rom
           ~&(%null-rom-cd [~ ~])
         ?^  r.mun
           ~&(%no-cd-path [~ ~])
         [~ ~ %& %noun !>(~(key by dos.u.rom))]
-      ?:  ?=($p p.mun)
-        (read-p r.mun)
-      ?:  ?=($u p.mun)
-        (read-u yon r.mun)
-      ?:  ?=($v p.mun)
-        (bind (read-v yon r.mun) (lift |=(a/cage [%& a])))
-      ?:  ?=($x p.mun)
-        (read-x yon r.mun)
-      ?:  ?=($y p.mun)
-        ::  =-  ~&  :*  %dude-someones-getting-curious
-        ::              mun=mun
-        ::              yon=yon
-        ::              our=our
-        ::              her=her
-        ::              syd=syd
-        ::              hep=-
-        ::          ==
-        ::      -
-        (bind (read-y yon r.mun) (lift |=(a/cage [%& a])))
-      ?:  ?=($z p.mun)
-        (bind (read-z yon r.mun) (lift |=(a/cage [%& a])))
-      %+  bind
-        (rewind yon)
-      |=  a/(unit _+>.$)
-      ^-  (unit (each cage lobe))
-      ?~  a
-        ~
-      `(unit (each cage lobe))`(bind (read:u.a mun) |=(a/cage [%& a]))
-    ::
-    ::  Stubbed out, should be removed in the refactoring mentioned in ++query.
-    ::
-    ++  rewind                                          ::    rewind:ze
-      |=  yon/aeon                                      ::  rewind to aeon
-      ^-  (unit (unit _+>))
-      ?:  =(let.dom yon)  ``+>
-      ?:  (gth yon let.dom)  !!                         ::  don't have version
-      =+  hat=q:(aeon-to-yaki yon)
-      ?:  (~(any by hat) |=(a/lobe ?=($delta [-:(lobe-to-blob a)])))
-        ~
-      ~
-      ::=+  ^-  (map path cage)
-      ::    %-  ~(run by hat)
-      ::    |=  a=lobe
-      ::    =+  (lobe-to-blob a)
-      ::    ?-(-.- %direct q.-, %delta !!)
-      ::`+>.$(ank.dom (map-to-ankh -), let.dom yon)
+      ::
+        $p  (read-p r.mun)
+        $u  (read-u yon r.mun)
+        $v  (bind (read-v yon r.mun) (lift |=(a/cage [%& a])))
+        $w  (read-w q.mun)
+        $x  (read-x yon r.mun)
+        $y  (bind (read-y yon r.mun) (lift |=(a/cage [%& a])))
+        $z  (bind (read-z yon r.mun) (lift |=(a/cage [%& a])))
+      ==
     ::
     ::  Traverse an ankh.
     ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2462,10 +2462,10 @@
       ^-  (unit (unit (each cage lobe)))
       =+  aey=(case-to-aeon cas)
       ?~  aey  ~
-      ?:  =(0 u.aey)  [~ ~]
       =-  [~ ~ %& %cass !>(-)]
       ^-  cass
       :+  u.aey
+        ?:  =(0 u.aey)  `@da`0
         t:(aeon-to-yaki u.aey)
       (~(get ju bal.dom) u.aey)
     ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2464,10 +2464,9 @@
       ?~  aey  ~
       =-  [~ ~ %& %cass !>(-)]
       ^-  cass
-      :+  u.aey
-        ?:  =(0 u.aey)  `@da`0
-        t:(aeon-to-yaki u.aey)
-      (~(get ju bal.dom) u.aey)
+      :-  u.aey
+      ?:  =(0 u.aey)  `@da`0
+      t:(aeon-to-yaki u.aey)
     ::
     ::  Gets the data at a node.
     ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -44,10 +44,9 @@
 ::  Type of request.
 ::
 ::  %d produces a set of desks, %p gets file permissions, %u checks for
-::  existence, %v produces a ++dome of all desk data, %w with a time or label
-::  case gets the aeon at that case, %w with a number case is not recommended,
-::  %x gets file contents, %y gets a directory listing, and %z gets a recursive
-::  hash of the file contents and children.
+::  existence, %v produces a ++dome of all desk data, %w gets all variants
+::  for the given case, %x gets file contents, %y gets a directory listing,
+::  and %z gets a recursive hash of the file contents and children.
 ::
 :: ++  care  ?($d $p $u $v $w $x $y $z)
 ::
@@ -2490,6 +2489,21 @@
         ~
       ``[%dome -:!>(*dome) dom]
     ::
+    ::  Gets all cases refering to the same revision as the given case.
+    ::
+    ::  For the %da case, we give just the canonical timestamp of the revision.
+    ::
+    ++  read-w
+      |=  cas/case
+      ^-  (unit (unit (each cage lobe)))
+      =+  aey=(case-to-aeon)
+      ?~  aey  ~
+      =-  [~ ~ %& %noun !>(-)]
+      ^-  cass
+      :+  u.aey
+        t:(aeon-to-yaki aey)
+      (~(get ju bal.dom) aey)
+    ::
     ::  Gets the data at a node.
     ::
     ::  If it's in our ankh (current state cache), we can just produce the
@@ -2609,7 +2623,7 @@
       ?.  |(?=($~ for) (may-read u.for p.mun yon r.mun))
         ~
       ?:  &(?=($w p.mun) !?=($ud -.q.mun))              ::  NB only her speed
-        ?^(r.mun [~ ~] [~ ~ %& %aeon !>(yon)])
+        (read-w q.mun)
       ?:  ?=($d p.mun)
         =+  rom=(~(get by fat.ruf) her)
         ?~  rom

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -83,6 +83,7 @@
       let/aeon                                          ::  top id
       hit/(map aeon tako)                               ::  versions by id
       lab/(map @tas aeon)                               ::  labels
+      bal/(jug aeon @tas)                               ::  label reverse lookup
   ==                                                    ::
 ::
 ::  Commit state.
@@ -2174,7 +2175,11 @@
            ::  +>.$(ank (map-to-ankh q.yak))
         $|
            ?<  (~(has by lab.dom) p.lem)
-           [~ ..ze(lab.dom (~(put by lab.dom) p.lem let.dom))]
+           :-  ~
+           %_  ..ze
+             lab.dom  (~(put by lab.dom) p.lem let.dom)
+             bal.dom  (~(put ju bal.dom) let.dom p.lem)
+           ==
       ==
     ::
     ::  Create a commit out of a list of changes against the current state.
@@ -2479,6 +2484,7 @@
             let=yon
             hit=(molt (skim ~(tap by hit.dom) |=({p/@ud *} (lte p yon))))
             lab=(molt (skim ~(tap by lab.dom) |=({* p/@ud} (lte p yon))))
+            bal=(molt (skim ~(tap by bal.dom) |=({p/@ud *} (lte p yon))))
         ==
       ?:  (gth yon let.dom)
         ~
@@ -2826,7 +2832,13 @@
         ?~  rot
           (error:he %bad-fetch-ali ~)
         =+  ^=  dum
-            %-  (hard {ank/* let/@ud hit/(map @ud tako) lab/(map @tas @ud)})
+            %-  %-  hard
+                $:  ank/*
+                    let/@ud
+                    hit/(map @ud tako)
+                    lab/(map @tas @ud)
+                    bal/(jug @ud @tas)
+                ==
             q.q.r.u.rot
         ?:  =(0 let.dum)
           (error:he %no-ali-desk ~)
@@ -3843,8 +3855,14 @@
         ==
       ++  wove-0  (cork wove |=(a/wove a(q (rove-0 q.a))))
       ++  cult-0  (jug wove-0 duct)
-      ++  dojo-0  (cork dojo |=(a/dojo a(qyx *cult-0)))
-      ++  rede-0  (cork rede |=(a/rede a(qyx *cult-0)))
+      ++  dome-0
+        $:  ank/ankh
+            let/aeon
+            hit/(map aeon tako)
+            lab/(map @tas aeon)
+        ==
+      ++  dojo-0  (cork dojo |=(a/dojo a(qyx *cult-0, dom *dome-0)))
+      ++  rede-0  (cork rede |=(a/rede a(qyx *cult-0, dom *dome-0)))
       ++  room-0  (cork room |=(a/room a(dos (~(run by dos.a) dojo-0))))
       ++  rung-0  (cork rung |=(a/rung a(rus (~(run by rus.a) rede-0))))
       ++  raft-0
@@ -3887,6 +3905,14 @@
       |=  {p/wove-0 q/(set duct)}
       [(wov p) q]
     ::
+    ++  dom
+      |=  dome-0
+      ^-  dome
+      =-  [ank let hit lab -]
+      %+  roll  ~(tap by lab)
+      |=  {{l/@tas a/aeon} r/(jug aeon @tas)}
+      (~(put ju r) a l)
+    ::
     ++  rom
       |=  room-0
       ^-  room
@@ -3894,14 +3920,14 @@
       %-  ~(run by dos)
       |=  d/dojo-0
       ^-  dojo
-      d(qyx (cul qyx.d))
+      d(qyx (cul qyx.d), dom (dom dom.d))
     ::
     ++  run
       |=  a/rung-0
       =-  a(rus (~(run by rus.a) -))
       |=  r/rede-0
       ^-  rede
-      r(qyx (cul qyx.r))
+      r(qyx (cul qyx.r), dom (dom dom.r))
     --
   ==
 ::

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -1335,7 +1335,8 @@
         =+  ext=(fall p.pok %urb)
         =+  bem=?-(-.hem $beam p.hem, $spur [-.top (weld p.hem s.top)])
         ~|  bad-beam+q.bem
-        ?<  =([~ 0] (sky [151 %noun] %cw (en-beam bem(+ ~, r [%da now]))))
+        ?<  =-  ?~(- | =(-.u.- 0))
+            (sky [151 %noun] %cw (en-beam bem(+ ~, r [%da now])))
         =+  wir=`whir`[%ha (en-beam -.bem ~)]
         =.  wir  ?+(mef !! $get wir, $head [%he wir])
         =.  r.bem  ?+(r.bem r.bem {$ud $0} da+now)

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -1098,7 +1098,7 @@
       ?:  ?=($ud -.r.bem)  (fine cof bem)
       =+  von=(syve [151 %noun] ~ %cw bem(s ~))
       ?~  von  [p=cof q=[%1 [%c %w bem ~] ~ ~]]
-      (fine cof bem(r [%ud ((hard @) +.+:(need u.von))]))
+      (fine cof bem(r [%ud ud:((hard cass:clay) +.+:(need u.von))]))
     ::
     ++  infer-product-type
       |=  {cof/cafe typ/type gen/hoon}

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -441,6 +441,7 @@
         {$tas p/@tas}                                   ::  label
         {$ud p/@ud}                                     ::  number
     ==                                                  ::
+  ++  cass  {ud/@ud da/@da tas/(set @tas)}              ::  cases for revision
   ++  coop  (unit ares)                                 ::  e2e ack
   ++  crew  (set ship)                                  ::  permissions group
   ++  dict  {src/path rul/rule}                         ::  effective permission

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -449,6 +449,7 @@
         let/@ud                                         ::  top id
         hit/(map @ud tako)                              ::  changes by id
         lab/(map @tas @ud)                              ::  labels
+        bal/(map @ud @tas)                              ::  label reverse lookup
     ==                                                  ::
   ++  germ                                              ::  merge style
     $?  $init                                           ::  new desk

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -450,7 +450,6 @@
         let/@ud                                         ::  top id
         hit/(map @ud tako)                              ::  changes by id
         lab/(map @tas @ud)                              ::  labels
-        bal/(map @ud @tas)                              ::  label reverse lookup
     ==                                                  ::
   ++  germ                                              ::  merge style
     $?  $init                                           ::  new desk

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -441,7 +441,7 @@
         {$tas p/@tas}                                   ::  label
         {$ud p/@ud}                                     ::  number
     ==                                                  ::
-  ++  cass  {ud/@ud da/@da tas/(set @tas)}              ::  cases for revision
+  ++  cass  {ud/@ud da/@da}                             ::  cases for revision
   ++  coop  (unit ares)                                 ::  e2e ack
   ++  crew  (set ship)                                  ::  permissions group
   ++  dict  {src/path rul/rule}                         ::  effective permission


### PR DESCRIPTION
Since this builds on #726's `++load` changes instead of adding a new clay version altogether, we'll want to wait for this to merge before pushing the master branch to the network.

This PR changes the result returned for `%w` clay requests from `@ud` to `[ud=@ud da=@da tas=(set @tas)]`, to aid in New Ford work.

As discussed with @belisarius222, this is not ready to be merged until either he or @eglaysher updates the places where the `%w` care is used. It seems this is just kiln and ford.  
Not to mention, I haven't taken care of the `++take-foreign-update` case. I'll get to that tomorrow.

I haven't been able to test this properly yet, since ford apparently comes into play (and trips over the changed `%w` result) even for apps that have already been built. But maybe that has to do with zuse also getting changed, idk, I'll try a bit harder tomorrow. Fairly confident this works as advertised though.