### PR TITLE
Change %w care to return both @ud and @da cases

### DIFF
--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -412,12 +412,12 @@
           leaf+"bad %writ response"
         (render "on sync" sud her syd)
       ~
-    =.  let  ?.  ?=($w p.p.u.rot)  let  ((hard @ud) q.q.r.u.rot)
+    =.  let  ?.  ?=($w p.p.u.rot)  let  ud:((hard cass:clay) q.q.r.u.rot)
     %-  blab  ^-  (list move)  :_  ~
     :*  ost  %merg
         [%kiln %sync syd (scot %p her) sud ?:(reset /reset /)]
         our  syd  her  sud  ud+let
-        ?:  =(0 .^(* %cw /(scot %p our)/[syd]/(scot %da now)))
+        ?:  =(0 ud:.^(cass:clay %cw /(scot %p our)/[syd]/(scot %da now)))
           %init
         %mate
     ==
@@ -524,7 +524,7 @@
     ^+  +>
     ?.  ?=($auto gim)
       perform(auto |, gem gim, her her, cas cas, sud sud)
-    ?:  =(0 .^(@ %cw /(scot %p our)/[syd]/(scot %da now)))
+    ?:  =(0 ud:.^(cass:clay %cw /(scot %p our)/[syd]/(scot %da now)))
       =>  $(gim %init)
       .(auto &)
     =>  $(gim %fine)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -44,10 +44,9 @@
 ::  Type of request.
 ::
 ::  %d produces a set of desks, %p gets file permissions, %u checks for
-::  existence, %v produces a ++dome of all desk data, %w with a time or label
-::  case gets the aeon at that case, %w with a number case is not recommended,
-::  %x gets file contents, %y gets a directory listing, and %z gets a recursive
-::  hash of the file contents and children.
+::  existence, %v produces a ++dome of all desk data, %w gets @ud and @da
+::  variants for the given case, %x gets file contents, %y gets a directory
+::  listing, and %z gets a recursive hash of the file contents and children.
 ::
 :: ++  care  ?($d $p $u $v $w $x $y $z)
 ::
@@ -1583,7 +1582,7 @@
         :+  ~
           p.r.u.rut
         ?+  p.r.u.rut  ~|  %strange-w-over-nextwork  !!
-          $aeon  !>(((hard aeon) q.r.u.rut))
+          $cass  !>(((hard cass) q.r.u.rut))
           $null  [[%atom %n ~] ~]
           $nako  !>(~|([%harding [&1 &2 &3]:q.r.u.rut] ((hard nako) q.r.u.rut)))
         ==
@@ -2484,6 +2483,21 @@
         ~
       ``[%dome -:!>(*dome) dom]
     ::
+    ::  Gets all cases refering to the same revision as the given case.
+    ::
+    ::  For the %da case, we give just the canonical timestamp of the revision.
+    ::
+    ++  read-w
+      |=  cas/case
+      ^-  (unit (unit (each cage lobe)))
+      =+  aey=(case-to-aeon cas)
+      ?~  aey  ~
+      =-  [~ ~ %& %cass !>(-)]
+      ^-  cass
+      :-  u.aey
+      ?:  =(0 u.aey)  `@da`0
+      t:(aeon-to-yaki u.aey)
+    ::
     ::  Gets the data at a node.
     ::
     ::  If it's in our ankh (current state cache), we can just produce the
@@ -2603,7 +2617,7 @@
       ?.  |(?=($~ for) (may-read u.for p.mun yon r.mun))
         ~
       ?:  &(?=($w p.mun) !?=($ud -.q.mun))              ::  NB only her speed
-        ?^(r.mun [~ ~] [~ ~ %& %aeon !>(yon)])
+        (read-w q.mun)
       ?:  ?=($d p.mun)
         =+  rom=(~(get by fat.ruf) her)
         ?~  rom

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2356,42 +2356,6 @@
         $delta     (~(put in $(lob q.q.gar)) lob)
       ==
     ::
-    ::  Should be refactored, is only called form `++read`, and even then it
-    ::  can't be called with `$v` as the care, so it's really just a crash.
-    ::
-    ::  To be clear the refactoring should start at ++read-at-aeon and probably
-    ::  eliminate ++read and ++query
-    ::
-    ++  query                                           ::    query:ze
-      |=  ren/$?($p $u $v $x $y $z)                     ::  endpoint query
-      ^-  (unit cage)
-      ?-  ren
-        $p  !!
-        $u  !!  ::  [~ %null [%atom %n] ~]
-        $v  [~ %dome !>(dom)]
-        $x  !!  ::  ?~(q.ank.dom ~ [~ q.u.q.ank.dom])
-        $y  !!  ::  [~ %arch !>(as-arch)]
-        $z  !!  ::  [~ %ankh !>(ank.dom)]
-      ==
-    ::
-    ::  See ++query.
-    ::
-    ++  read                                            ::    read:ze
-      |=  mun/mood                                      ::  read at point
-      ^-  (unit cage)
-      ?:  ?=($d p.mun)
-        ~&  %dead-d  ~
-      ?:  ?=($v p.mun)
-        [~ %dome !>(dom)]                               ::  dead code
-      ?:  &(?=($w p.mun) !?=($ud -.q.mun))
-        ?^(r.mun ~ [~ %aeon !>(let.dom)])               ::  dead code
-      ?:  ?=($w p.mun)
-        =+  ^=  yak
-            %-  aeon-to-yaki
-            let.dom
-        ?^(r.mun ~ !!) :: [~ %w !>([t.yak (forge-nori yak)])])-all
-      (query(ank.dom ank:(descend-path:(zu ank.dom) r.mun)) p.mun) ::  dead code
-    ::
     ::  Gets the permissions that apply to a particular node.
     ::
     ::  If the node has no permissions of its own, we use its parent's.
@@ -2609,68 +2573,28 @@
     ::  meaning we either have the value directly or a content hash of the
     ::  value.
     ::
-    ::  Should change last few lines to an explicit ++read-w.
-    ::
     ++  read-at-aeon                                    ::    read-at-aeon:ze
       |=  {for/(unit ship) yon/aeon mun/mood}           ::  seek and read
       ^-  (unit (unit (each cage lobe)))
       ?.  |(?=($~ for) (may-read u.for p.mun yon r.mun))
         ~
-      ?:  &(?=($w p.mun) !?=($ud -.q.mun))              ::  NB only her speed
-        (read-w q.mun)
-      ?:  ?=($d p.mun)
+      ?-  p.mun
+          $d
         =+  rom=(~(get by fat.ruf) her)
         ?~  rom
           ~&(%null-rom-cd [~ ~])
         ?^  r.mun
           ~&(%no-cd-path [~ ~])
         [~ ~ %& %noun !>(~(key by dos.u.rom))]
-      ?:  ?=($p p.mun)
-        (read-p r.mun)
-      ?:  ?=($u p.mun)
-        (read-u yon r.mun)
-      ?:  ?=($v p.mun)
-        (bind (read-v yon r.mun) (lift |=(a/cage [%& a])))
-      ?:  ?=($x p.mun)
-        (read-x yon r.mun)
-      ?:  ?=($y p.mun)
-        ::  =-  ~&  :*  %dude-someones-getting-curious
-        ::              mun=mun
-        ::              yon=yon
-        ::              our=our
-        ::              her=her
-        ::              syd=syd
-        ::              hep=-
-        ::          ==
-        ::      -
-        (bind (read-y yon r.mun) (lift |=(a/cage [%& a])))
-      ?:  ?=($z p.mun)
-        (bind (read-z yon r.mun) (lift |=(a/cage [%& a])))
-      %+  bind
-        (rewind yon)
-      |=  a/(unit _+>.$)
-      ^-  (unit (each cage lobe))
-      ?~  a
-        ~
-      `(unit (each cage lobe))`(bind (read:u.a mun) |=(a/cage [%& a]))
-    ::
-    ::  Stubbed out, should be removed in the refactoring mentioned in ++query.
-    ::
-    ++  rewind                                          ::    rewind:ze
-      |=  yon/aeon                                      ::  rewind to aeon
-      ^-  (unit (unit _+>))
-      ?:  =(let.dom yon)  ``+>
-      ?:  (gth yon let.dom)  !!                         ::  don't have version
-      =+  hat=q:(aeon-to-yaki yon)
-      ?:  (~(any by hat) |=(a/lobe ?=($delta [-:(lobe-to-blob a)])))
-        ~
-      ~
-      ::=+  ^-  (map path cage)
-      ::    %-  ~(run by hat)
-      ::    |=  a=lobe
-      ::    =+  (lobe-to-blob a)
-      ::    ?-(-.- %direct q.-, %delta !!)
-      ::`+>.$(ank.dom (map-to-ankh -), let.dom yon)
+      ::
+        $p  (read-p r.mun)
+        $u  (read-u yon r.mun)
+        $v  (bind (read-v yon r.mun) (lift |=(a/cage [%& a])))
+        $w  (read-w q.mun)
+        $x  (read-x yon r.mun)
+        $y  (bind (read-y yon r.mun) (lift |=(a/cage [%& a])))
+        $z  (bind (read-z yon r.mun) (lift |=(a/cage [%& a])))
+      ==
     ::
     ::  Traverse an ankh.
     ::

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -1335,7 +1335,8 @@
         =+  ext=(fall p.pok %urb)
         =+  bem=?-(-.hem $beam p.hem, $spur [-.top (weld p.hem s.top)])
         ~|  bad-beam+q.bem
-        ?<  =([~ 0] (sky [151 %noun] %cw (en-beam bem(+ ~, r [%da now]))))
+        ?<  =-  ?~(- | =(-.u.- 0))
+            (sky [151 %noun] %cw (en-beam bem(+ ~, r [%da now])))
         =+  wir=`whir`[%ha (en-beam -.bem ~)]
         =.  wir  ?+(mef !! $get wir, $head [%he wir])
         =.  r.bem  ?+(r.bem r.bem {$ud $0} da+now)

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -1098,7 +1098,7 @@
       ?:  ?=($ud -.r.bem)  (fine cof bem)
       =+  von=(syve [151 %noun] ~ %cw bem(s ~))
       ?~  von  [p=cof q=[%1 [%c %w bem ~] ~ ~]]
-      (fine cof bem(r [%ud ((hard @) +.+:(need u.von))]))
+      (fine cof bem(r [%ud ud:((hard cass:clay) +.+:(need u.von))]))
     ::
     ++  infer-product-type
       |=  {cof/cafe typ/type gen/hoon}

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -441,6 +441,7 @@
         {$tas p/@tas}                                   ::  label
         {$ud p/@ud}                                     ::  number
     ==                                                  ::
+  ++  cass  {ud/@ud da/@da}                             ::  cases for revision
   ++  coop  (unit ares)                                 ::  e2e ack
   ++  crew  (set ship)                                  ::  permissions group
   ++  dict  {src/path rul/rule}                         ::  effective permission


### PR DESCRIPTION
This is #728 but tidier.

This PR changes the result returned for `%w` clay requests from `@ud` to `[ud=@ud da=@da]`, to aid in New Ford work.

Pretty sure I've found all existing usage of `%w` requests and updated them without doing anything weird.

As far as I'm concerned, this is ready for review.