### PR TITLE
Fora Posts and Comments with no text ignored

### DIFF
--- a/app/fora.hoon
+++ b/app/fora.hoon
@@ -45,18 +45,11 @@
   ^-  (quip move _+>)
   :_  +>
   ::
-  :: Does txt actually have content, or is it blank?
+  ::  if txt is blank then return no moves.
   ::
-  =/  txt-blank=?
-    ?~  (rust (trip txt) spac:de-json:html)
-      %|
-    %&
+  ?:  ?=(^ (rush txt spac:de-json:html))  ~
   ::
-  :: If txt is blank then return no moves.
-  ::
-  ?:  txt-blank  ~
-  ::
-  :: Otherwise, post the content.
+  ::  otherwise, post the content.
   ::
   :~  %-  act
       :+  %phrase  [[our.bol %fora-posts] ~ ~]
@@ -82,18 +75,11 @@
   ^-  (quip move _+>)
   :_  +>
   ::
-  :: Does txt actually have content, or is it blank?
+  ::  if txt is blank then return no moves.
   ::
-  =/  txt-blank=?
-    ?~  (rust (trip txt) spac:de-json:html)
-      %|
-    %&
+  ?:  ?=(^ (rush txt spac:de-json:html))  ~
   ::
-  :: If txt is blank then return no moves.
-  ::
-  ?:  txt-blank  ~
-  ::
-  :: Otherwise, post the content.
+  ::  otherwise, post the content.
   ::
   :~  ^-  move
       %-  act

--- a/app/fora.hoon
+++ b/app/fora.hoon
@@ -44,7 +44,20 @@
   |=  {pax/path sup/spur hed/@t txt/@t}
   ^-  (quip move _+>)
   :_  +>
-  ?:  =(txt '')  ~
+  ::
+  :: Does txt actually have content, or is it blank?
+  ::
+  =/  txt-blank=?
+    ?~  (rust (trip txt) spac:de-json:html)
+      %|
+    %&
+  ::
+  :: If txt is blank then return no moves.
+  ::
+  ?:  txt-blank  ~
+  ::
+  :: Otherwise, post the content.
+  ::
   :~  %-  act
       :+  %phrase  [[our.bol %fora-posts] ~ ~]
       :_  ~
@@ -68,7 +81,20 @@
   |=  {pax/path sup/spur txt/@t}
   ^-  (quip move _+>)
   :_  +>
-  ?:  =(txt '')  ~
+  ::
+  :: Does txt actually have content, or is it blank?
+  ::
+  =/  txt-blank=?
+    ?~  (rust (trip txt) spac:de-json:html)
+      %|
+    %&
+  ::
+  :: If txt is blank then return no moves.
+  ::
+  ?:  txt-blank  ~
+  ::
+  :: Otherwise, post the content.
+  ::
   :~  ^-  move
       %-  act
       :+  %phrase  [[our.bol %fora-comments] ~ ~]

--- a/app/fora.hoon
+++ b/app/fora.hoon
@@ -44,6 +44,7 @@
   |=  {pax/path sup/spur hed/@t txt/@t}
   ^-  (quip move _+>)
   :_  +>
+  ?:  =(txt '')  ~
   :~  %-  act
       :+  %phrase  [[our.bol %fora-posts] ~ ~]
       :_  ~
@@ -67,6 +68,7 @@
   |=  {pax/path sup/spur txt/@t}
   ^-  (quip move _+>)
   :_  +>
+  ?:  =(txt '')  ~
   :~  ^-  move
       %-  act
       :+  %phrase  [[our.bol %fora-comments] ~ ~]


### PR DESCRIPTION
In response to ~ravmel's issue here: https://github.com/urbit/fora/issues/6

With this change if you try to submit a post or comment without text, then the poke is ignored.  Yes, this is a really dumb fix, but it works and fora is minimalist anyway.  Only downside is there is no explicit feedback to the poster.  If someone wants to hold my hand a little I'll try to make a more fancy change.