### PR TITLE
fixes +spin to preserve the type of the head of the product

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -650,7 +650,7 @@
   :>  c: gate from list-item and state to product and new state
   ~/  %spin
   |*  [a=(list) b=* c=_|=(^ [** +<+])]
-  =>  .(c `$-([_?>(?=(^ a) i.a) _b] [* _b])`c)
+  =>  .(c `$-([_?>(?=(^ a) i.a) _b] [_-:(c) _b])`c)
   =/  acc=(list _-:(c))  ~
   :>  transformed list and updated state
   |-  ^-  (pair _acc _b)


### PR DESCRIPTION
This resolves an issue that I introduced when I refactor `+spin` and `+spun` in #649. The typecast of the sample gate `c` in `+spin` was throwing away the type of the head of the product, which is somewhat unfortunate:

```
> ? (spun "foo" |=([a=@tD b=@ud] [[b a] +(b)]))
  it(*)
~[[0 102] [1 111] [2 111]]
```

With this fix in place:

```
> ? (spun "foo" |=([a=@tD b=@ud] [[b a] +(b)]))
  it({@ud @tD})
~[[0 'f'] [1 'o'] [2 'o']]
```

My apologies for insufficiently testing the previous PR.