### PR TITLE
Bump Ames :protocol-version from 0 to 1

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -4,7 +4,7 @@
   =>  =~
 ::  structures
 =,  ames
-=+  protocol-version=0
+=+  protocol-version=1
 |%
 +=  move  [p=duct q=(wind note:able gift:able)]         ::  local move
 --


### PR DESCRIPTION
For the ~2018.5.24 continuity breach.