### PR TITLE
Transition ~marzod's Ask duties to a dedicated ship

### DIFF
--- a/lib/hood/helm.hoon
+++ b/lib/hood/helm.hoon
@@ -107,8 +107,8 @@
 ::
 ++  poke-send-ask
   |=  mel/cord  =<  abet
-  %^  emit  %poke  /helm/ask/(scot %p ~marzod)
-  [[~marzod %ask] %ask-mail mel]
+  %^  emit  %poke  /helm/ask/(scot %p ~socden-malzod)
+  [[~socden-malzod %ask] %ask-mail mel]
 ::
 ++  poke-serve
   |=  top/?(desk beam)  =<  abet


### PR DESCRIPTION
This commit allows Ask app responsibility/load to get taken off of
~marzod and assigned to a dedicated Ask ship: currently, ~socden-malzod,
a child of Tlon's ops star, ~dopzod.