### PR TITLE
Bump Ames :protocol-version from 1 to 2

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -4,7 +4,7 @@
   =>  =~
 ::  structures
 =,  ames
-=+  protocol-version=1
+=+  protocol-version=2
 |%
 +=  move  [p=duct q=(wind note:able gift:able)]         ::  local move
 --


### PR DESCRIPTION
For the ~2018.6.8 continuity breach. See urbit/urbit#997.