### PR TITLE
clay permissions issue #749

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2370,10 +2370,19 @@
       (read-p-in pax pew.red)
     ::
     ++  read-p-in
+      !:
       |=  {pax/path pes/regs}
       ^-  dict
-      =+  rul=(~(get by pes) pax)
-      ?^  rul  [pax u.rul]
+      =/  rul=(unit rule)  (~(get by pes) pax)
+      ?^  rul
+        :+  pax  mod.u.rul
+        %-  ~(rep in who.u.rul)
+        |=  {w/whom out/(set @p)}
+        ?:  ?=([$& @p] w)
+          (~(put in out) +.w)
+        =/  cru=(unit (set @p))  (~(get by cez.ruf) +.w)
+        ?~  cru  out
+        (~(uni in out) u.cru)
       ?~  pax  [/ %white ~]
       $(pax (scag (dec (lent pax)) `path`pax))
     ::
@@ -2407,14 +2416,12 @@
     ++  allowed-by
       |=  {who/ship pax/path pes/regs}
       ^-  ?
-      =+  rul=rul:(read-p-in pax pes)
-      =-  ?:(?=($black mod.rul) !- -)
-      %-  ~(rep in who.rul)
-      |=  {w/whom h/_|}
-      ?:  h  &
-      ?:  ?=($& -.w)  =(p.w who)
-      (~(has in (fall (~(get by cez) p.w) ~)) who)
-    ::
+      =/  rul=real  rul:(read-p-in pax pes)
+      =/  in-list=?  (~(has in who.rul) who)
+      ?:  =(%black mod.rul)
+        !in-list
+      in-list
+    ::  ::
     ::  Checks for existence of a node at an aeon.
     ::
     ::  This checks for existence of content at the node, and does *not* look

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2376,8 +2376,8 @@
       ?^  rul
         :+  pax  mod.u.rul
         %-  ~(rep in who.u.rul)
-        |=  {w/whom out/(pair (set @p) (map @ta crew))}
-        ?:  ?=([$& @p] w)
+        |=  {w/whom out/(pair (set ship) (map @ta crew))}
+        ?:  ?=({$& @p} w)
           [(~(put in p.out) +.w) q.out]
         =/  cru=(unit crew)  (~(get by cez.ruf) +.w)
         ?~  cru  out
@@ -2418,15 +2418,16 @@
       =/  rul=real  rul:(read-p-in pax pes)
       =/  in-list=?  
         ?|  (~(has in p.who.rul) who)
+          ::
             %-  ~(rep by q.who.rul)
-            |=  [[@ta cru=crew] out=_|]
+            |=  {{@ta cru=crew} out/_|}
             ?:  out  &
             (~(has in cru) who)
         ==
       ?:  =(%black mod.rul)
         !in-list
       in-list
-    ::  ::
+    ::
     ::  Checks for existence of a node at an aeon.
     ::
     ::  This checks for existence of content at the node, and does *not* look

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2372,14 +2372,14 @@
     ++  read-p-in
       |=  {pax/path pes/regs}
       ^-  dict
-      =/  rul=(unit rule)  (~(get by pes) pax)
+      =/  rul/(unit rule)  (~(get by pes) pax)
       ?^  rul
         :+  pax  mod.u.rul
         %-  ~(rep in who.u.rul)
         |=  {w/whom out/(pair (set ship) (map @ta crew))}
         ?:  ?=({$& @p} w)
           [(~(put in p.out) +.w) q.out]
-        =/  cru=(unit crew)  (~(get by cez.ruf) +.w)
+        =/  cru/(unit crew)  (~(get by cez.ruf) +.w)
         ?~  cru  out
         [p.out (~(put by q.out) +.w u.cru)]
       ?~  pax  [/ %white ~ ~]
@@ -2415,12 +2415,12 @@
     ++  allowed-by
       |=  {who/ship pax/path pes/regs}
       ^-  ?
-      =/  rul=real  rul:(read-p-in pax pes)
-      =/  in-list=?  
+      =/  rul/real  rul:(read-p-in pax pes)
+      =/  in-list/?
         ?|  (~(has in p.who.rul) who)
           ::
             %-  ~(rep by q.who.rul)
-            |=  {{@ta cru=crew} out/_|}
+            |=  {{@ta cru/crew} out/_|}
             ?:  out  &
             (~(has in cru) who)
         ==

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -2370,20 +2370,19 @@
       (read-p-in pax pew.red)
     ::
     ++  read-p-in
-      !:
       |=  {pax/path pes/regs}
       ^-  dict
       =/  rul=(unit rule)  (~(get by pes) pax)
       ?^  rul
         :+  pax  mod.u.rul
         %-  ~(rep in who.u.rul)
-        |=  {w/whom out/(set @p)}
+        |=  {w/whom out/(pair (set @p) (map @ta crew))}
         ?:  ?=([$& @p] w)
-          (~(put in out) +.w)
-        =/  cru=(unit (set @p))  (~(get by cez.ruf) +.w)
+          [(~(put in p.out) +.w) q.out]
+        =/  cru=(unit crew)  (~(get by cez.ruf) +.w)
         ?~  cru  out
-        (~(uni in out) u.cru)
-      ?~  pax  [/ %white ~]
+        [p.out (~(put by q.out) +.w u.cru)]
+      ?~  pax  [/ %white ~ ~]
       $(pax (scag (dec (lent pax)) `path`pax))
     ::
     ++  may-read
@@ -2417,7 +2416,13 @@
       |=  {who/ship pax/path pes/regs}
       ^-  ?
       =/  rul=real  rul:(read-p-in pax pes)
-      =/  in-list=?  (~(has in who.rul) who)
+      =/  in-list=?  
+        ?|  (~(has in p.who.rul) who)
+            %-  ~(rep by q.who.rul)
+            |=  [[@ta cru=crew] out=_|]
+            ?:  out  &
+            (~(has in cru) who)
+        ==
       ?:  =(%black mod.rul)
         !in-list
       in-list

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -444,7 +444,7 @@
   ++  cass  {ud/@ud da/@da}                             ::  cases for revision
   ++  coop  (unit ares)                                 ::  e2e ack
   ++  crew  (set ship)                                  ::  permissions group
-  ++  dict  {src/path rul/rule}                         ::  effective permission
+  ++  dict  {src/path rul/real}                         ::  effective permission
   ++  dome                                              ::  project state
     $:  ank/ankh                                        ::  state
         let/@ud                                         ::  top id
@@ -508,6 +508,7 @@
         {$mult p/mool}                                  ::  next version of any
         {$many p/? q/moat}                              ::  track range
     ==                                                  ::
+  ++  real  {mod/?($black $white) who/(set ship)}       ::  resolved permissions
   ++  regs  (map path rule)                             ::  rules for paths
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist
   ++  rite                                              ::  new permissions

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -508,7 +508,10 @@
         {$mult p/mool}                                  ::  next version of any
         {$many p/? q/moat}                              ::  track range
     ==                                                  ::
-  ++  real  {mod/?($black $white) who/(set ship)}       ::  resolved permissions
+  ++  real                                              ::  resolved permissions
+    $:  mod/?($black $white)                            ::
+        who/(pair (set ship) (map @ta crew))            ::
+    ==                                                  ::
   ++  regs  (map path rule)                             ::  rules for paths
   ++  riff  {p/desk q/(unit rave)}                      ::  request+desist
   ++  rite                                              ::  new permissions


### PR DESCRIPTION
Fixes https://github.com/urbit/arvo/issues/749

Since dict is only used once in clay, in the place that gets permissions for a scry, I changed its definition to:
```
++  dict  {src/path rul/real}
```
where real is
```
++  real  {mod/?($black $white) who/(set ship)}
```
And made the necessary changes in clay to handle this. 

Perhaps I should return all the group information rather than reducing it to a `(set ship)`. If anyone has any objections I can change it to `(set (each ship (map @ta crew)))`, or something else if you have a better suggestion.