### PR TITLE
adds dns app, http(s) server-config and proxy notification moves

### DIFF
--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -5,6 +5,7 @@
 +=  move  (pair bone card)
 +=  poke  $%  [%dns-bind for=ship him=ship target]
               [%dns-bond for=ship him=ship turf]
+              [%dns-authority authority]
           ==
 +=  card  $%  [%tend wire ~]
               [%poke wire dock poke]
@@ -101,6 +102,7 @@
 ::
 ++  sigh-httr
   |=  [wir=wire rep=httr:eyre]
+  ^-  (quip move _this)
   ?-  wir
       [%authority %confirm ~]
     ?~  nem
@@ -129,16 +131,15 @@
 ++  poke-dns-bind                                     ::  bind or forward
   |=  [for=ship him=ship tar=target]
   ^-  (quip move _this)
-  ~&  [%bind src=src.bow him=him tar=tar]
+  ~&  [%bind src=src.bow for=for him=him tar=tar]
+  ~|  %bind-yoself
+  ?<  =(for him)
   =^  zom=(list move)  ..this
-  ^-  (quip move _this)
+    ?~  nem  [~ this]
+    abet:(~(create bind u.nem) for him tar)
+  =^  zam=(list move)  ..this
     abet:(~(forward tell him ~) tar)
-  ?~  nem
-    [zom this]
-  :: XX =^ nest-fail
-  =/  zam=(quip move _this)
-    abet:(~(create bind u.nem) him tar)
-  [(weld zom -.zam) +.zam]
+  [(weld zom zam) this]
 ::
 :: ++  coup-dns-bind                                     ::  retry?
 ::   |=  [wir=wire saw=(unit tang)]
@@ -155,8 +156,9 @@
 ++  poke-dns-bond                                    ::  confirm or forward
   |=  [for=ship him=ship dom=turf]
   ^-  (quip move _this)
+  ~&  [%bond +<]
+  ~|  %bond-yoself
   ?<  =(for him)
-  ~&  [%bound +<]
   ?:  =(our.bow him)
     :: XX notify eyre/hood/acme etc
     ~&  [%bound-us dom]
@@ -276,10 +278,11 @@
     =/  wir=wire
       /bind/(scot %p him)/for/(scot %p our.bow)
     %-  emit(rel `ler)
-    [%poke wir [our.bow %dns] %dns-bind our.bow him tar]
+    [%poke wir [our.bow dap.bow] %dns-bind our.bow him tar]
   ::
   ++  bake                                            ::  bound
     |=  dom=turf
+    ~&  [%bake dom]
     ^+  this
     ?>  ?=(^ rel)
     =.  bon.u.rel  &
@@ -289,6 +292,7 @@
   ::
   ++  forward                                         ::  on to parent
     |=  tar=target
+    ~&  [%forward tar]
     ^+  this
     ?:  ?=(%~zod our.bow)  ::  ~zod don't forward
       ~&  [%zod-no-forward him tar]
@@ -301,6 +305,6 @@
     =/  wir=wire
       /forward/bind/(scot %p him)/for/(scot %p src.bow)
     %-  emit  :: XX for
-    [%poke wir [to %dns] %dns-bind src.bow him tar]
+    [%poke wir [to dap.bow] %dns-bind src.bow him tar]
   --
 --

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -255,9 +255,8 @@
 ++  poke-dns-bond
   |=  [for=ship him=ship dom=turf]
   ^-  (quip move _this)
-  ~&  [%bond +<]
-  ~|  %bond-yoself
-  ?<  =(for him)
+  ?:  =(for him)
+    ~|(%bond-yoself !!)
   ?:  =(our.bow him)
     :: XX notify eyre/hood/acme etc
     ~&  [%bound-us dom]
@@ -317,11 +316,6 @@
     ~&  [%emit-bind car]
     ^+  this
     this(moz [[ost.bow car] moz])
-  :: +emil: emit a list of moves
-  ::
-  ++  emil
-    |=  rac=(list card)
-    q:(spin rac this |=([a=card b=_this] [~ (emit:b a)]))
   :: +init: establish zone authority (request confirmation)
   ::
   ++  init
@@ -361,13 +355,11 @@
     =.  pen.nam  (~(del by pen.nam) him)
     =.  bon.nam  (~(put by bon.nam) him nob)
     =/  wir=wire
-      /forward/bound/(scot %p him)/for/(scot %p for)
-    =/  pok=poke
-      [%dns-bond him for *turf]
-    %-  emil  :~
-      [%poke wir [him dap.bow] pok]
-      [%poke wir [for dap.bow] pok]
-    ==
+      /bound/(scot %p him)/for/(scot %p for)
+    =/  dom=turf
+      (weld dom.aut.nam /(crip +:(scow %p him)))
+    %-  emit
+    [%poke wir [for dap.bow] %dns-bond for him dom]
   --
 :: |tell: acting as planet parent or relay
 ::
@@ -426,10 +418,11 @@
     ~&  [%bake dom]
     ^+  this
     ?>  ?=(^ rel)
-    =.  bon.u.rel  &
-    :: XX save domain?
-    :: XX notify ship?
-    this
+    =/  wir=wire
+      /forward/bound/(scot %p him)/for/(scot %p our.bow)
+    :: XX save domain, track bound-state per-domain
+    %-  emit(bon.u.rel &)
+    [%poke wir [him dap.bow] %dns-bond our.bow him dom]
   :: +forward: sending binding request up the network
   ::
   ++  forward

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -8,22 +8,24 @@
           ==
 +=  card  $%  [%tend wire ~]
               [%poke wire dock poke]
+              [%hiss wire [~ ~] %httr %hiss hiss:eyre]
           ==
 :: +turf: a domain, TLD first
 ::
 +=  turf  (list @t)
 :: +authority: responsibility for a DNS zone
 ::
+:: +provider: DNS service provider
++=  provider
+  $%  [%gcloud project=@ta zone=@ta]
+  ==
 +=  authority
   $:  :: dom: authority over a domain
       ::
       dom=turf
-      :: zon: DNS zone name
-      ::
-      zon=@t
       :: pro: DNS provider (gcloud only for now)
       ::
-      pro=%gcloud
+      pro=provider
   ==
 :: +target: a ship is bound to a ...
 ::
@@ -73,7 +75,10 @@
       :: nem: authoritative state
       ::
       nem=(unit nameserver)
-  ==     
+  ==
+::
+++  gcloud
+  (need (de-purl:html 'https://www.googleapis.com/dns/v1/projects'))
 --
 ::
 |_  [bow=bowl:gall state]
@@ -82,8 +87,37 @@
 ++  poke-noun
   |=  a=*
   ::^-  (quip move _this)
+  ?:  ?=(%aut a)
+    :_  this  :_  ~
+    :*  ost.bow
+        %poke
+        /foo
+        [our.bow dap.bow]
+        %dns-authority
+        [/org/urbit/dyndns %gcloud %tonal-griffin-853 %dyndns]
+    ==
   ~&  +<+:this
   [~ this]
+::
+++  sigh-httr
+  |=  [wir=wire rep=httr:eyre]
+  ?-  wir
+      [%authority %confirm ~]
+    ?~  nem
+      ~&  [%strange-authority wire=wir response=rep]
+      [~ this]
+    ?.  =(200 p.rep)
+      ~&  [%authority-confirm-fail rep]
+      [~ this(nem ~)]
+    :: XX anything to do here? parse body?
+    :: abet:(~(confirm bind u.nem) httr
+    ~&  %authority-confirmed
+    [~ this]
+  ::
+      *
+    ~&  +<
+    [~ this]
+  ==
 ::
 ++  poke-dns-authority                                ::  configure
   |=  aut=authority
@@ -146,6 +180,7 @@
   =<  abet
   (~(rove tell [p (~(get by per) p)]) q)
 ::
+:: ++  prep  _[~ this]
 ++  prep
   |=  old=(unit state)
   ^-  (quip move _this)
@@ -173,9 +208,14 @@
   ::
   ++  init
     |=  aut=authority
-    ::  XX confirm credentials
-    ::  XX confirm zone
-    this(nam [aut ~ ~])
+    :: ?>  ?=(%gcloud pro.aut)
+    =/  wir=wire  /authority/confirm
+    =/  url=purl:eyre  gcloud
+    =.  q.q.url
+      (weld q.q.url /[project.pro.aut]/['managedZones']/[zone.pro.aut])
+    ~&  url
+    %-  emit(nam [aut ~ ~])
+    [%hiss wir [~ ~] %httr %hiss url %get ~ ~]
   ::
   ++  create
     |=  [him=ship tar=target]

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -205,7 +205,19 @@
     ~&  +<
     [~ this]
   ==
-:: XX sigh-tang
+:: +sigh-tang: failed to make http request
+::
+++  sigh-tang
+  |=  [wir=wire saw=tang]
+  ^-  (quip move _this)
+  ~&  [%sigh-tang wir]
+  ?+  wir
+        [((slog saw) ~) this]
+  ::
+      [%authority %confirm ~]
+    ~&  %authority-confirm-fail
+    [((slog saw) ~) this(nem ~)]
+  ==
 ::
 :: +poke-dns-authority: configure self as an authority
 ::

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -220,15 +220,16 @@
 ++  poke-dns-bind
   |=  [for=ship him=ship tar=target]
   ^-  (quip move _this)
-  ~&  [%bind src=src.bow for=for him=him tar=tar]
+  ~&  [%bind src=src.bow +<.$]
+  =/  lan  (clan:title him)
+  ?:  ?=(%czar lan)
+    ~|(%bind-galazy !!)
   ?:  =(for him)
     ~|(%bind-yoself !!)
-  ?:  ?&  ?=(%king (clan:title him))
+  ?:  ?&  ?=(%king lan)
           ?=(%indirect -.tar)
       ==
-    ~&  [%indirect-star +<]
-    :: XX crash?
-    [~ this]
+    ~|(%bind-indirect-star !!)
   :: always forward, there may be multiple authorities
   ::
   =^  zom=(list move)  ..this

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -1,0 +1,244 @@
+::
+:: moves and state
+::
+|%
++=  move  (pair bone card)
++=  poke  $%  [%dns-bind ship target]
+              [%dns-bound ship ship turf]
+          ==
++=  card  $%  [%tend wire ~]
+              [%poke wire dock poke]
+          ==
+:: +turf: a domain, TLD first
+::
++=  turf  (list @t)
+:: +authority: responsibility for a DNS zone
+::
++=  authority
+  $:  :: dom: authority over a domain
+      ::
+      dom=turf
+      :: zon: DNS zone name
+      ::
+      zon=@t
+      :: pro: DNS provider (gcloud only for now)
+      ::
+      pro=%gcloud
+  ==
+:: +target: a ship is bound to a ...
+::
++=  target
+  $%  :: %direct: an A record
+      [%direct %if p=@if]
+      :: %indirect: a CNAME
+      [%indirect p=ship]
+  ==
+:: +bound: an established binding, plus history
+::
++=  bound
+  $:  :: wen: established
+      ::
+      wen=@da
+      :: cur: current target
+      ::
+      cur=target
+      :: hit: historical targets
+      ::
+      hit=(list (pair @da target))
+  ==
+:: +nameserver: a b s o l u t e  p o w e r
+::
++=  nameserver
+  $:  aut=authority
+      pen=(map ship target)
+      bon=(map ship bound)
+  ==
+:: +relay: a good parent keeps track
+::
++=  relay
+  $:  wen=@da
+      wer=(unit @if)
+      bon=?
+  ==
+:: +state: complete app state
+::
++=  state
+  $:  :: dom: the set of our bindings
+      ::
+      dom=(set turf)
+      :: per: per-dependent ips &c
+      ::
+      per=(map ship relay)
+      :: nem: authoritative state
+      ::
+      nem=(unit nameserver)
+  ==     
+--
+::
+|_  [bow=bowl:gall state]
+++  this  .
+::
+++  poke-noun
+  |=  a=*
+  ::^-  (quip move _this)
+  ~&  +<+:this
+  [~ this]
+::
+++  poke-dns-authority                                ::  configure
+  |=  aut=authority
+  ^-  (quip move _this)
+  ~|  %authority-reset-wat-do
+  ?<  ?=(^ nem)
+  abet:(init:bind aut)
+::
+++  poke-dns-bind                                     ::  bind or forward
+  |=  [him=ship tar=target]
+  ^-  (quip move _this)
+  ~&  [%bind src=src.bow him=him tar=tar]
+  ?:  ?=(^ nem)
+    :: XX bind & forward?
+    abet:(~(create bind u.nem) him tar)
+  abet:(~(forward tell him ~) tar)
+::
+:: ++  coup-dns-bind                                     ::  retry?
+::   |=  [wir=wire saw=(unit tang)]
+::   ~&  [%coup-bind +<]
+::   ?~  saw
+::     [~ this]
+::   ?>  ?=(^ wir)
+::   ?-  i.wir
+::     %forward  !!  :: re-forward?
+::     %bind     !!  :: rebind?
+::     *  ~&(coup-dns-bind+wir [~ this])
+::   ==
+::
+++  poke-dns-bound                                    ::  confirm or forward
+  |=  [him=ship for=ship dom=turf]
+  ^-  (quip move _this)
+  ~&  [%bound +<]
+  ?.  =(our.bow for)
+    abet:(backward:tell him for dom)
+  =<  abet
+  (~(bake tell [him (~(get by per) him)]) dom)
+::
+++  rove                                              ::  hear lane change
+  |=  [wir=wire p=ship q=lane:ames]
+  ^-  (quip move _this)
+  ?.  =(our.bow (sein:title p))  :: XX check will
+    ~&  [%rove-false p]
+    [~ this]
+  ~&  [%rove wir p q]
+  ::  XX assert that we intend to be listening?
+  =<  abet
+  (~(rove tell [p (~(get by per) p)]) q)
+::
+++  prep
+  |=  old=(unit state)
+  ^-  (quip move _this)
+  ?^  old
+    [~ this(+<+ u.old)]
+  ?:  ?=(?(%czar %king) (clan:title our.bow))
+    abet:tend:tell
+  [~ this]
+::
+::  acting as zone authority
+::
+++  bind                                              ::  nameserver
+  =|  moz=(list move)
+  |_  nam=nameserver
+  ++  this  .
+  ::
+  ++  abet
+    ^-  (quip move _^this)
+    [(flop moz) ^this(nem `nam)]
+  ::
+  ++  init
+    |=  aut=authority
+    ::  XX confirm credentials
+    ::  XX confirm zone
+    this(nam [aut ~ ~])
+  ::
+  ++  create
+    |=  [him=ship tar=target]
+    this :: XX
+  ::
+  ++  confirm
+    |=  him=ship
+    this :: XX
+  --
+::
+::  acting as planet parent or relay
+::
+++  tell                                              ::  relay
+  =|  moz=(list move)
+  |_  [him=ship rel=(unit relay)]
+  ++  this  .
+  ::
+  ++  abet
+    ^-  (quip move _^this)
+    :-  (flop moz)
+    ?~  rel
+      ^this
+    ^this(per (~(put by per) him u.rel))
+  ::
+  ++  emit
+    |=  a=card
+    ^+  this
+    this(moz [[ost.bow a] moz])
+  ::
+  ++  tend                                            ::  listen
+    ^+  this
+    (emit [%tend /tend ~])
+  ::
+  ++  rove                                            ::  hear
+    |=  lan=lane:ames
+    ^+  this
+    =/  ip=(unit @if)
+      ?.(?=([%if *] lan) ~ `r.lan)
+    =.  rel  `[now.bow ip |]
+    %-  emit
+    :*  %poke
+        /bind/(scot %p him)/for/(scot %p our.bow)
+        [(sein:title our.bow) %dns]
+        %dns-bind
+        [him ?~(ip [%indirect our.bow] [%direct %if u.ip])]
+    ==
+  ::
+  ++  bake                                            ::  bound
+    |=  dom=turf
+    ^+  this
+    ?>  ?=(^ rel)
+    =.  bon.u.rel  &
+    :: XX save domain?
+    :: XX notify ship?
+    this
+  ::
+  ++  forward                                         ::  on to parent
+    |=  tar=target
+    ^+  this
+    ?:  ?=(%~zod our.bow)  ::  ~zod don't forward
+      ~&  [%zod-no-forward him tar]
+      this
+    =/  to=ship
+      ?-  (clan:title our.bow)
+        %czar  ~zod
+        *      (sein:title our.bow)
+      ==
+    %-  emit
+    :*  %poke
+        /foward/bind/(scot %p him)/for/(scot %p src.bow)
+        [to %dns]
+        [%dns-bind him tar]
+    ==
+  ::
+  ++  backward                                        ::  relay binding ack
+    |=  [him=ship for=ship dom=turf]
+    ^+  this
+    %-  emit
+    :*  %poke
+        /foward/bound/(scot %p him)/for/(scot %p for)
+        [for %dns]
+        [%dns-bound him for dom]
+    ==
+  --
+--

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -232,7 +232,7 @@
   :: always forward, there may be multiple authorities
   ::
   =^  zom=(list move)  ..this
-    abet:(~(forward tell him ~) tar)
+    abet:(~(forward tell him ~) for tar)
   =^  zam=(list move)  ..this
     ?~  nem  [~ this]
     abet:(~(create bind u.nem) for him tar)
@@ -426,7 +426,7 @@
   :: +forward: sending binding request up the network
   ::
   ++  forward
-    |=  tar=target
+    |=  [for=ship tar=target]
     ~&  [%forward tar]
     ^+  this
     ?:  ?=(%~zod our.bow)  ::  ~zod don't forward
@@ -438,8 +438,8 @@
         *      (sein:title our.bow)
       ==
     =/  wir=wire
-      /forward/bind/(scot %p him)/for/(scot %p src.bow)
+      /forward/bind/(scot %p him)/for/(scot %p for)
     %-  emit  :: XX for
-    [%poke wir [to dap.bow] %dns-bind src.bow him tar]
+    [%poke wir [to dap.bow] %dns-bind for him tar]
   --
 --

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -221,8 +221,14 @@
   |=  [for=ship him=ship tar=target]
   ^-  (quip move _this)
   ~&  [%bind src=src.bow for=for him=him tar=tar]
-  ~|  %bind-yoself
-  ?<  =(for him)
+  ?:  =(for him)
+    ~|(%bind-yoself !!)
+  ?:  ?&  ?=(%king (clan:title him))
+          ?=(%indirect -.tar)
+      ==
+    ~&  [%indirect-star +<]
+    :: XX crash?
+    [~ this]
   :: always forward, there may be multiple authorities
   ::
   =^  zom=(list move)  ..this
@@ -326,6 +332,10 @@
   ::
   ++  create
     |=  [for=ship him=ship tar=target]
+    :: XX defer %indirect where target isn't yet bound
+    ?>  ?|  ?=(%direct -.tar)
+            (~(has by bon.nam) p.tar)
+        ==
     =/  wir=wire
       /authority/create/(scot %p him)/for/(scot %p for)
     =/  req=hiss:eyre

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -250,19 +250,6 @@
     ?~  nem  [~ this]
     abet:(~(create bind u.nem) for him tar)
   [(weld zom zam) this]
-::
-:: ++  coup-dns-bind
-::   |=  [wir=wire saw=(unit tang)]
-::   ~&  [%coup-bind +<]
-::   ?~  saw
-::     [~ this]
-::   ?>  ?=(^ wir)
-::   ?-  i.wir
-::     %forward  !!  :: re-forward?
-::     %bind     !!  :: rebind?
-::     *  ~&(coup-dns-bind+wir [~ this])
-::   ==
-::
 :: +poke-dns-bond: process established dns binding
 ::
 ++  poke-dns-bond
@@ -282,6 +269,13 @@
     (~(bake tell [him (~(get by per) him)]) dom)
   ~&  [%strange-bond +<]
   [~ this]
+:: +coup: general poke acknowledgement or error
+::
+++  coup
+  |=  [wir=wire saw=(unit tang)]
+  ?~  saw  [~ this]
+  ~&  [%coup-fallthru wir]
+  [((slog u.saw) ~) this]
 :: +rove: hear %ames +lane change for child ships
 ::
 ++  rove

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -149,19 +149,8 @@
 ++  poke-noun
   |=  a=*
   ^-  (quip move _this)
-  ?+  a  ~&  +<+:this
-         [~ this]
-  ::
-      %aut
-    :_  this  :_  ~
-    :*  ost.bow
-        %poke
-        /foo
-        [our.bow dap.bow]
-        %dns-authority
-        [/org/urbit/dyndns %gcloud %tonal-griffin-853 %dyndns]
-    ==
-  ==
+  ~&  +<+:this
+  [~ this]
 :: +sigh-httr: accept http response
 ::
 ++  sigh-httr

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -3,8 +3,8 @@
 ::
 |%
 +=  move  (pair bone card)
-+=  poke  $%  [%dns-bind ship target]
-              [%dns-bound ship ship turf]
++=  poke  $%  [%dns-bind for=ship him=ship target]
+              [%dns-bond for=ship him=ship turf]
           ==
 +=  card  $%  [%tend wire ~]
               [%poke wire dock poke]
@@ -59,6 +59,7 @@
   $:  wen=@da
       wer=(unit @if)
       bon=?
+      tar=target
   ==
 :: +state: complete app state
 ::
@@ -92,13 +93,18 @@
   abet:(init:bind aut)
 ::
 ++  poke-dns-bind                                     ::  bind or forward
-  |=  [him=ship tar=target]
+  |=  [for=ship him=ship tar=target]
   ^-  (quip move _this)
   ~&  [%bind src=src.bow him=him tar=tar]
-  ?:  ?=(^ nem)
-    :: XX bind & forward?
+  =^  zom=(list move)  ..this
+  ^-  (quip move _this)
+    abet:(~(forward tell him ~) tar)
+  ?~  nem
+    [zom this]
+  :: XX =^ nest-fail
+  =/  zam=(quip move _this)
     abet:(~(create bind u.nem) him tar)
-  abet:(~(forward tell him ~) tar)
+  [(weld zom -.zam) +.zam]
 ::
 :: ++  coup-dns-bind                                     ::  retry?
 ::   |=  [wir=wire saw=(unit tang)]
@@ -112,14 +118,22 @@
 ::     *  ~&(coup-dns-bind+wir [~ this])
 ::   ==
 ::
-++  poke-dns-bound                                    ::  confirm or forward
-  |=  [him=ship for=ship dom=turf]
+++  poke-dns-bond                                    ::  confirm or forward
+  |=  [for=ship him=ship dom=turf]
   ^-  (quip move _this)
+  ?<  =(for him)
   ~&  [%bound +<]
-  ?.  =(our.bow for)
-    abet:(backward:tell him for dom)
-  =<  abet
-  (~(bake tell [him (~(get by per) him)]) dom)
+  ?:  =(our.bow him)
+    :: XX notify eyre/hood/acme etc
+    ~&  [%bound-us dom]
+    :-  ~
+    this(dom (~(put in ^dom) dom))
+  ?:  =(our.bow for)
+    ~&  [%bound-him him dom]
+    =<  abet
+    (~(bake tell [him (~(get by per) him)]) dom)
+  ~&  [%strange-bond +<]
+  [~ this]
 ::
 ++  rove                                              ::  hear lane change
   |=  [wir=wire p=ship q=lane:ames]
@@ -152,6 +166,11 @@
     ^-  (quip move _^this)
     [(flop moz) ^this(nem `nam)]
   ::
+  ++  emit
+    |=  a=card
+    ^+  this
+    this(moz [[ost.bow a] moz])
+  ::
   ++  init
     |=  aut=authority
     ::  XX confirm credentials
@@ -160,7 +179,13 @@
   ::
   ++  create
     |=  [him=ship tar=target]
-    this :: XX
+    =|  for=@p :: XX
+    %-  emit
+    :*  %poke
+        /foward/bound/(scot %p him)/for/(scot %p for)
+        [for %dns]
+        [%dns-bond him for *turf]
+    ==
   ::
   ++  confirm
     |=  him=ship
@@ -193,16 +218,25 @@
   ++  rove                                            ::  hear
     |=  lan=lane:ames
     ^+  this
-    =/  ip=(unit @if)
+    =/  adr=(unit @if)
       ?.(?=([%if *] lan) ~ `r.lan)
-    =.  rel  `[now.bow ip |]
-    %-  emit
-    :*  %poke
-        /bind/(scot %p him)/for/(scot %p our.bow)
-        [(sein:title our.bow) %dns]
-        %dns-bind
-        [him ?~(ip [%indirect our.bow] [%direct %if u.ip])]
-    ==
+    =/  tar=target
+      ?:  ?|  ?=(~ adr)
+              ?=(%duke (clan:title him))
+          ==
+        [%indirect our.bow]
+      [%direct %if u.adr]
+    =/  ler=relay
+      [now.bow adr | tar]
+    ?.  ?|  ?=(~ rel)
+            !=(tar tar.u.rel)
+        ==
+      this
+    :: we may be an authority, so we poke ourselves
+    =/  wir=wire
+      /bind/(scot %p him)/for/(scot %p our.bow)
+    %-  emit(rel `ler)
+    [%poke wir [our.bow %dns] %dns-bind our.bow him tar]
   ::
   ++  bake                                            ::  bound
     |=  dom=turf
@@ -224,21 +258,9 @@
         %czar  ~zod
         *      (sein:title our.bow)
       ==
-    %-  emit
-    :*  %poke
-        /foward/bind/(scot %p him)/for/(scot %p src.bow)
-        [to %dns]
-        [%dns-bind him tar]
-    ==
-  ::
-  ++  backward                                        ::  relay binding ack
-    |=  [him=ship for=ship dom=turf]
-    ^+  this
-    %-  emit
-    :*  %poke
-        /foward/bound/(scot %p him)/for/(scot %p for)
-        [for %dns]
-        [%dns-bound him for dom]
-    ==
+    =/  wir=wire
+      /forward/bind/(scot %p him)/for/(scot %p src.bow)
+    %-  emit  :: XX for
+    [%poke wir [to %dns] %dns-bind src.bow him tar]
   --
 --

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -1,3 +1,5 @@
+/-  dns
+=,  dns
 !:
 ::
 :: moves and state
@@ -14,62 +16,6 @@
               [%poke wire dock poke]
               [%hiss wire [~ ~] %httr %hiss hiss:eyre]
           ==
-:: +turf: a domain, TLD first
-::
-+=  turf  (list @t)
-:: +provider: DNS service provider (gcloud only for now)
-::
-+=  provider
-  $%  [%gcloud project=@ta zone=@ta]
-  ==
-:: +authority: responsibility for a DNS zone
-::
-+=  authority
-  $:  :: dom: authority over a fully-qualified domain
-      ::
-      dom=turf
-      :: pro: DNS service provider
-      ::
-      pro=provider
-  ==
-:: +target: a ship is bound to a ...
-::
-+=  target
-  $%  :: %direct: an A record
-      ::
-      [%direct %if p=@if]
-      :: %indirect: a CNAME record
-      ::
-      [%indirect p=ship]
-  ==
-:: +bound: an established binding, plus history
-::
-+=  bound
-  $:  :: wen: established
-      ::
-      wen=@da
-      :: cur: current target
-      ::
-      cur=target
-      :: hit: historical targets
-      ::
-      hit=(list (pair @da target))
-  ==
-:: +nameserver: a b s o l u t e  p o w e r
-::
-+=  nameserver
-  $:  aut=authority
-      pen=(map ship target)
-      bon=(map ship bound)
-  ==
-:: +relay: a good parent keeps track
-::
-+=  relay
-  $:  wen=@da
-      wer=(unit @if)
-      bon=?
-      tar=target
-  ==
 :: +state: complete app state
 ::
 +=  state

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -109,17 +109,6 @@
         %dns-authority
         [/org/urbit/dyndns %gcloud %tonal-griffin-853 %dyndns]
     ==
-  ::
-      %bin
-    :_  this  :_  ~
-    :*  ost.bow
-        %poke
-        /bar
-        [our.bow dap.bow]
-        %dns-bind
-        :: [for=~binzod him=~ridbyl-dovwyd tar=[%indirect p=~binzod]]
-        [for=~binzod him=~ridbyl-dovwyd tar=[%direct %if .8.8.8.8]]
-    ==
   ==
 :: +sigh-httr: accept http response
 ::
@@ -135,7 +124,6 @@
       ~&  [%authority-confirm-fail rep]
       [~ this(nem ~)]
     :: XX anything to do here? parse body?
-    ~&  %authority-confirmed
     [~ this]
   ::
       [%authority %create @ %for @ ~]
@@ -152,7 +140,6 @@
       [%check @ ~]
     =/  him=ship  (slav %p i.t.wir)
     ?:  =(200 p.rep)
-      ~&  %direct-confirm
       abet:~(bind tell [him (~(get by per) him)])
     :: XX specific messages per status code
     ~&  %direct-confirm-fail
@@ -276,7 +263,6 @@
   ::
   ++  emit
     |=  car=card
-    ~&  [%emit-bind car]
     ^+  this
     this(moz [[ost.bow car] moz])
   :: +init: establish zone authority (request confirmation)
@@ -342,7 +328,6 @@
   ::
   ++  emit
     |=  car=card
-    ~&  [%emit-tell car]
     ^+  this
     this(moz [[ost.bow car] moz])
   :: +listen: subscribe to %ames +lane changes for child ships

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -39,6 +39,58 @@
   |-  ^-  (list @t)
   ?~  t.hot  hot
   [i.hot sep $(hot t.hot)]
+:: +reserved: check if an ipv4 address is in a reserved range
+::
+++  reserved
+  |=  a=@if
+  ^-  ?
+  =/  b  (rip 3 a)
+  ?>  ?=([@ @ @ @ ~] b)
+  ?|  :: 0.0.0.0/8 (software)
+      ::
+      =(0 i.b)
+      :: 10.0.0.0/8 (private)
+      ::
+      =(10 i.b)
+      :: 100.64.0.0/10 (carrier-grade NAT)
+      ::
+      &(=(100 i.b) (gte 64 i.t.b) (lte 127 i.t.b))
+      :: 127.0.0.0/8 (localhost)
+      ::
+      =(127 i.b)
+      :: 169.254.0.0/16 (link-local)
+      ::
+      &(=(169 i.b) =(254 i.t.b))
+      :: 172.16.0.0/12 (private)
+      ::
+      &(=(172 i.b) (gte 16 i.t.b) (lte 31 i.t.b))
+      :: 192.0.0.0/24 (protocol assignment)
+      ::
+      &(=(192 i.b) =(0 i.t.b) =(0 i.t.t.b))
+      :: 192.0.2.0/24 (documentation)
+      ::
+      &(=(192 i.b) =(0 i.t.b) =(2 i.t.t.b))
+      :: 192.18.0.0/15 (reserved, benchmark)
+      ::
+      &(=(192 i.b) |(=(18 i.t.b) =(19 i.t.b)))
+      :: 192.51.100.0/24 (documentation)
+      ::
+      &(=(192 i.b) =(51 i.t.b) =(100 i.t.t.b))
+      :: 192.88.99.0/24 (reserved, ex-anycast)
+      ::
+      &(=(192 i.b) =(88 i.t.b) =(99 i.t.t.b))
+      :: 192.168.0.0/16 (private)
+      ::
+      &(=(192 i.b) =(168 i.t.b))
+      :: 203.0.113/24 (documentation)
+      ::
+      &(=(203 i.b) =(0 i.t.b) =(113 i.t.t.b))
+      :: 224.0.0.0/8 (multicast)
+      :: 240.0.0.0/4 (reserved, future)
+      :: 255.255.255.255/32 (broadcast)
+      ::
+      (gte 224 i.b)
+  ==
 :: |gcloud: provider-specific functions
 ::
 ++  gcloud
@@ -360,8 +412,7 @@
     ^+  this
     ?>  ?=(^ rel)
     ?>  ?=(%direct -.tar.u.rel)
-    :: XX check for reserved ip
-    ?:  |
+    ?:  (reserved p.tar.u.rel)
       (fail %reserved-ip)
     =/  wir=wire
       /check/(scot %p him)

--- a/gen/dns/authority.hoon
+++ b/gen/dns/authority.hoon
@@ -1,0 +1,30 @@
+::  DNS: configure zone authority
+::
+::::  /hoon/authority/dns/gen
+  ::
+/-  dns, sole
+=,  [dns sole]
+:-  %ask
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        [arg=$@(~ [dom=path ~])]
+        ~
+    ==
+^-  (sole-result [%dns-authority authority])
+=-  ?~  arg  -
+    (fun.q.q [%& dom.arg])
+%+  sole-lo
+  [%& %dns-domain "dns domain: "]
+%+  sole-go  thos:de-purl:html
+|=  hot=host:eyre
+?:  ?=($| -.hot)
+  ~|(%ips-unsupported !!)
+%+  sole-lo
+  [%& %project "gcloud project: "]
+%+  sole-go  urs:ab
+|=  project=@ta
+%+  sole-lo
+  [%& %zone "dns zone: "]
+%+  sole-go  urs:ab
+|=  zone=@ta
+%+  sole-so  %dns-authority
+[p.hot %gcloud project zone]

--- a/lib/hood/drum.hoon
+++ b/lib/hood/drum.hoon
@@ -80,7 +80,12 @@
   =+  myr=(clan:title our)
   ?:  ?=($pawn myr)
     [[%base %collections] [%base %hall] [%base %talk] [%base %dojo] ~]
-  [[%home %collections] [%home %hall] [%home %talk] [%home %dojo] ~]
+  :~  [%home %collections]
+      [%home %dns]
+      [%home %dojo]
+      [%home %hall]
+      [%home %talk]
+  ==
 ::
 ++  deft-fish                                           ::  default connects
   |=  our/ship

--- a/mar/dns/bind.hoon
+++ b/mar/dns/bind.hoon
@@ -1,0 +1,11 @@
+::
+::::  /mar/dns/bind/hoon
+  ::
+/-  dns
+=,  dns
+|_  [for=ship him=ship target]
+++  grab
+  |%
+  ++  noun  ,[for=ship him=ship target]
+  --
+--

--- a/mar/dns/bond.hoon
+++ b/mar/dns/bond.hoon
@@ -1,0 +1,11 @@
+::
+::::  /mar/dns/bond/hoon
+  ::
+/-  dns
+=,  dns
+|_  [for=ship him=ship turf]
+++  grab
+  |%
+  ++  noun  ,[for=ship him=ship turf]
+  --
+--

--- a/sec/com/googleapis.hoon
+++ b/sec/com/googleapis.hoon
@@ -29,6 +29,7 @@
   :~  'https://mail.google.com'
       'https://www.googleapis.com/auth/plus.me'
       'https://www.googleapis.com/auth/userinfo.email'
+      'https://www.googleapis.com/auth/ndev.clouddns.readwrite'
   ==
 ::
 ++  exchange-url  'https://www.googleapis.com/oauth2/v4/token'

--- a/sec/com/googleapis.hoon
+++ b/sec/com/googleapis.hoon
@@ -30,6 +30,7 @@
       'https://www.googleapis.com/auth/plus.me'
       'https://www.googleapis.com/auth/userinfo.email'
       'https://www.googleapis.com/auth/ndev.clouddns.readwrite'
+      'https://www.googleapis.com/auth/cloud-platform.read-only'
   ==
 ::
 ++  exchange-url  'https://www.googleapis.com/oauth2/v4/token'

--- a/sur/dns.hoon
+++ b/sur/dns.hoon
@@ -1,0 +1,58 @@
+|%
+:: +turf: a domain, TLD first
+::
++=  turf  (list @t)
+:: +provider: DNS service provider (gcloud only for now)
+::
++=  provider
+  $%  [%gcloud project=@ta zone=@ta]
+  ==
+:: +authority: responsibility for a DNS zone
+::
++=  authority
+  $:  :: dom: authority over a fully-qualified domain
+      ::
+      dom=turf
+      :: pro: DNS service provider
+      ::
+      pro=provider
+  ==
+:: +target: a ship is bound to a ...
+::
++=  target
+  $%  :: %direct: an A record
+      ::
+      [%direct %if p=@if]
+      :: %indirect: a CNAME record
+      ::
+      [%indirect p=ship]
+  ==
+:: +bound: an established binding, plus history
+::
++=  bound
+  $:  :: wen: established
+      ::
+      wen=@da
+      :: cur: current target
+      ::
+      cur=target
+      :: hit: historical targets
+      ::
+      hit=(list (pair @da target))
+  ==
+:: +nameserver: a b s o l u t e  p o w e r
+::
++=  nameserver
+  $:  aut=authority
+      pen=(map ship target)
+      bon=(map ship bound)
+  ==
+:: +relay: a good parent keeps track
+::
++=  relay
+  $:  wen=@da
+      wer=(unit @if)
+      bon=?
+      tar=target
+  ==
+--

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -445,6 +445,7 @@
         +>.$(hoc.saf (~(put by hoc.saf) her [[~31337.1.1 ~ wil] ~ *clot]))
       ::
       ++  lax                                           ::    lax:as:go
+        =|  rov=(unit lane)                             ::  maybe lane change
         |_  [her=ship dur=dore]                         ::  per client
         ++  cluy                                        ::    cluy:lax:as:go
           ^-  [p=life q=gens r=acru]                    ::  client crypto
@@ -518,6 +519,25 @@
                 [~ ryn]
               lun.wod.dur
             [~ ryn]
+          ::
+              rov
+            |-  ^-  (unit lane)
+            :: XX check will
+            ?:  ?|  !=(our (sein:title her))
+                    ?=(?(%earl %pawn) (clan:title her))
+                ==
+              ~
+            ?-  ryn
+              [%if *]  ?.  ?=([~ %if *] lun.wod.dur)
+                         `ryn
+                       ?:(=(r.u.lun.wod.dur r.ryn) ~ `ryn)
+              ::
+              [%ix *]  ?.  ?=([~ %ix *] lun.wod.dur)
+                         `ryn
+                       ?:(=(r.u.lun.wod.dur r.ryn) ~ `ryn)
+              ::
+              [%is *]  ?~(q.ryn ~ $(ryn u.q.ryn))
+            ==
           ==
         ::
         ++  wist                                        ::    wist:lax:as:go
@@ -1471,8 +1491,10 @@
           ==
         ::
         ++  zank                                        ::    zank:ho:um:am
+          =?  bin  ?=(^ rov.diz)
+              [[%maze her u.rov.diz] bin]
           %=  +>.$                                      ::  resolve
-            gus      (nux:gus diz)
+            gus      (nux:gus diz(rov ~))
             wab.weg  (~(put by wab.weg) her bah(sop abet:puz))
           ==
         --                                              ::  --ho:um:am
@@ -1553,9 +1575,14 @@
       (hunt lth doz rtn.sop.bah)
     ::
     ++  load
-      |=  old=fort
-      ~&  %ames-reload
-      ..^$(fox old)
+      =/  old-fort
+        (cork fort |=(fort [%0 gad=gad hop=hop bad=bad ton=ton zac=zac]))
+      |=  old=?(fort old-fort)
+      ?-  old
+        [%0 *]  $(old [%1 gad hop bad ton zac ~]:old)
+        [%1 *]  ~&  %ames-reload
+                ..^$(fox old)
+      ==
     ::
     ++  scry
       |=  [fur=(unit (set monk)) ren=@tas why=shop syd=desk lot=coin tyl=path]
@@ -1604,6 +1631,11 @@
       :_  fox
       :~  [s.bon %give %woot q.p.bon r.bon]
       ==
+    ::
+        %maze
+      :_  fox
+      %+  turn  ~(tap in ten.fox)
+      |=(hen=duct [hen %give %rove p.bon q.bon])
     ::
         %mead  :_(fox [[hen [%give %hear p.bon q.bon]] ~])
         %milk
@@ -1713,6 +1745,14 @@
         ::
             %sith
           (~(czar am [now fox]) p.kyz q.kyz r.kyz)
+        ::
+            %tend
+          :: XX exclude comets and moons? and planets?
+          :: ?>  &(?=(^ hen) ?=([@ @ *] i.hen))
+          :: =/  who=@p  (slav %p i.t.i.hen)
+          :: ?:  ?=((%earl %pawn) (clan:title who))
+          ::   [~ fox]
+          [~ fox(ten (~(put in ten.fox) hen))]
         ::
             %nuke
           :-  ~

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -636,7 +636,14 @@
     =.  our  ?~(hov our u.hov)  ::  XX
     =.  p.top  our              ::  XX necessary?
     ?-    -.kyz
-        $born  +>.$(ged hen)                            ::  register external
+        $born
+      %=  +>.$
+        ged  hen                                        ::  register external
+        mow  :_(mow [hen [%give %form [~ ?=(%king our) & &]]])
+      ==
+    ::
+        $live  +>.$             :: XX save ports
+    ::
         $serv
       =<  ~&([%serving (en-beam top)] .)
       ?^(p.kyz +>.$(top p.kyz) +>.$(q.top p.kyz))

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -794,9 +794,13 @@
             :+  %call  [%core (norm-beak bek) /wrap/[ext]/ren]
             [[%$ deps+!>(dep)] [%vale res]]
           ==
+      ::
+        $not  +>.$(mow :_(mow [ged [%give %that q.p.kyz p.u.mez q.u.mez]]))
       ==
     ::
       $wegh  !!                                         ::  handled elsewhere
+    ::
+      $wise  (ames-gram p.kyz [%not ~] q.kyz r.kyz)     ::  proxy notification
     ==
   ::
   ::++  axom                                              ::  old response

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1223,6 +1223,7 @@
         $ogre  `%c
         $perm  `%c
         $serv  `%e
+        $tend  `%a
         $them  `%e
         $wait  `%b
         $want  `%a

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -664,6 +664,7 @@
       $%  [%mass p=mass]                                ::  memory usage
           [%mack p=(unit tang)]                         ::  message ack
           [%sigh p=cage]                                ::  marked http response
+          [%that p=@p q=@ud r=?]                        ::  get proxied request
           [%thou p=httr]                                ::  raw http response
           [%thus p=@ud q=(unit hiss)]                   ::  http request+cancel
           [%veer p=@ta q=path r=@t]                     ::  drop-through
@@ -684,6 +685,7 @@
           [%wegh ~]                                     ::  report memory
           [%went p=sack q=path r=@ud s=coop]            ::  response confirm
           [%west p=sack q=[path *]]                     ::  network request
+          [%wise p=@p q=@ud r=?]                        ::  proxy notification
       ==                                                ::
     --  ::able
   ::
@@ -720,6 +722,8 @@
       ::
         [[%get-inner ~] p=@uvH q=beam r=mark]  ::TODO details?
         [[%got-inner ~] p=@uvH q=(each (cask) tang)]  ::TODO details?
+      ::
+        [[%not ~] p=@ud q=?]                            ::  proxy notification
     ==                                                  ::
   ++  hart  {p/? q/(unit @ud) r/host}                   ::  http sec+port+host
   ++  hate  {p/purl q/@p r/moth}                        ::  semi-cooked request

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -661,7 +661,8 @@
   ++  able  ^?
     |%
     +=  gift                                            ::  out result <-$
-      $%  [%mass p=mass]                                ::  memory usage
+      $%  [%form p=http-config]                         ::  configuration
+          [%mass p=mass]                                ::  memory usage
           [%mack p=(unit tang)]                         ::  message ack
           [%sigh p=cage]                                ::  marked http response
           [%that p=@p q=@ud r=?]                        ::  get proxied request
@@ -676,6 +677,7 @@
           [%crud p=@tas q=(list tank)]                  ::  XX rethink
           [%hiss p=(unit user) q=mark r=cage]           ::  outbound user req
           [%init p=@p]                                  ::  report install
+          [%live p=@ud q=(unit @ud)]                    ::  http/s ports
           [%serv p=$@(desk beam)]                       ::  set serving root
           [%them p=(unit hiss)]                         ::  outbound request
           [%they p=@ud q=httr]                          ::  inbound response
@@ -734,6 +736,24 @@
   ++  host  (each (list @t) @if)                        ::  http host
   ++  hoke  %+  each   {$localhost $~}                  ::  local host
             ?($.0.0.0.0 $.127.0.0.1)                    ::
+  :: +http-config: full http-server configuration
+  ::
+  +=  http-config
+    $:  :: secure: PEM-encoded RSA private key and certificate chain
+        ::
+        secure=(unit [key=wain certificate=wain])
+        :: proxy: reverse TCP proxy HTTP(s)
+        ::
+        proxy=?
+        :: log: keep HTTP(s) access logs
+        ::
+        log=?
+        :: redirect: send 301 redirects to upgrade HTTP to HTTPS
+        ::
+        ::   Note: requires certificate.
+        ::
+        redirect=?
+    ==
   ++  httq                                              ::  raw http request
     $:  p/meth                                          ::  method
         q/@t                                            ::  unparsed url

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -135,6 +135,7 @@
           {$init p/@p}                                  ::  report install
           {$mack p/(unit tang)}                         ::  
           {$mass p/mass}                                ::  memory usage
+          {$rove p/ship q/lane}                         ::  lane change
           {$send p/lane q/@}                            ::  transmit packet
           {$woot p/ship q/coop}                         ::  reaction message
       ==                                                ::
@@ -161,6 +162,7 @@
           {$nuke p/@p}                                  ::  toggle auto-block
           {$make p/(unit @t) q/@ud r/@ s/?}             ::  wild license
           {$sith p/@p q/@uw r/?}                        ::  imperial generator
+          {$tend $~}                                    ::  watch lane changes
           {$wake $~}                                    ::  timer activate
           {$wegh $~}                                    ::  report memory
           {$west p/sack q/path r/*}                     ::  network request
@@ -203,6 +205,7 @@
   ++  boon                                              ::  fort output
     $%  {$beer p/ship q/@uvG}                           ::  gained ownership
         {$cake p/sock q/soap r/coop s/duct}             ::  e2e message result
+        {$maze p/ship q/lane}                           ::  lane change
         {$mead p/lane q/rock}                           ::  accept packet
         {$milk p/sock q/soap r/*}                       ::  e2e pass message
         {$ouzo p/lane q/rock}                           ::  transmit packet
@@ -240,12 +243,13 @@
         wid/@ud                                         ::  logical wdow msgs
     ==                                                  ::
   ++  fort                                              ::  formal state
-    $:  $0                                              ::  version
+    $:  $1                                              ::  version
         gad/duct                                        ::  client interface
         hop/@da                                         ::  network boot date
         bad/(set @p)                                    ::  bad ships
         ton/town                                        ::  security
         zac/(map ship corn)                             ::  flows by server
+        ten/(set duct)                                  ::  watch lanes
     ==                                                  ::
   ++  gcos                                              ::  id description
     $%  {$czar $~}                                      ::  8-bit ship


### PR DESCRIPTION
This PR includes:

- new `%eyre` moves for the reverse reverse TCP proxy (`%wise` and `%that`)
- new `%eyre` moves for http(s) server config (`%form` and `%live`)
- new `%ames` moves for monitoring child-ship IP address changes (`%rove` and `%tend`)
- the dynamic DNS app and related components

These changes are all additive -- they do not necessarily require a breach. They are properly paired with an updated vere, however (I'll link those changes shortly). If run on a current-or-older vere, server configuration and reverse-proxy notification effects will simply be ignored.