### PR TITLE
removes dead +mz:nl, updates +bif syntax

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1272,7 +1272,7 @@
     ~/  %bif
     |*  b/*
     ^+  [l=a r=a]
-    =<  [+< +>]
+    =<  +
     |-  ^+  a
     ?~  a
       [b ~ ~]
@@ -1475,7 +1475,7 @@
     ~/  %bif
     |*  {b/* c/*}
     ^+  [l=a r=a]
-    =<  [+< +>]
+    =<  +
     |-  ^+  a
     ?~  a
       [[b c] ~ ~]
@@ -1921,12 +1921,7 @@
   ++  my                                                  ::  construct map
     |*  a/(list (pair))
     =>  .(a ^+((le a) a))
-    (~(gas by `(map _p.i.-.a _q.i.-.a)`~) a)
-  ::                                                      ::
-  ++  mz                                                  ::  construct map
-    |*  a/(list (pair))
-    =>  .(a ^+((le a) a))
-    (~(gas by ~) a)
+    (~(gas by `(map _p.i.-.a _q.i.-.a)`~) a)                                                 
   ::                                                      ::
   ++  si                                                  ::  construct set
     |*  a/(list)


### PR DESCRIPTION
`+mz:nl` was determined by ~sorreg to be dead code, and there doesn't seem to be any possible `a` that will nest in it.

Also, `+bif:in` and `+bif:by` had the weird syntactical construct of `=<  [+< +>]`. I simplified it to the more straightforward `=< +`.