### PR TITLE
crashes `++  rad` when arg of `0` is used

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3418,7 +3418,7 @@
   |_  a/@
   ++  rad                                               ::  random in range
     |=  b/@  ^-  @
-    ~_  leaf+"seed-zero"
+    ~_  leaf+"rad-underflow"
     ?<  =(0 b)
     =+  c=(raw (met 0 b))
     ?:((lth c b) c $(a +(a)))

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3418,6 +3418,8 @@
   |_  a/@
   ++  rad                                               ::  random in range
     |=  b/@  ^-  @
+    ~_  leaf+"seed-zero"
+    ?<  =(0 b)
     =+  c=(raw (met 0 b))
     ?:((lth c b) c $(a +(a)))
   ::


### PR DESCRIPTION
This addresses the problem @rmariani describes here:  https://github.com/urbit/urbit/issues/1016