### PR TITLE
adds letsencrypt client :acme, integrates with :dns app and %eyre

### DIFF
--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1775,7 +1775,7 @@
   :: XX or re-use order-id?
   =?  fal.hit  ?=(^ rod)  [u.rod fal.hit]
   :: XX check registration, defer
-  new-order:effect(pen `(sy dom))
+  new-order:effect(rod ~, pen `(sy dom))
 ::
 ++  test
   =,  tester:tester

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1800,9 +1800,9 @@
     |=  [wir=wire rep=httr]
     ^+  this
     ?.  =(200 p.rep)
-      :: XX retry immediately? backoff?
+      :: XX count retries, backoff
       ~&  [%test-trial-fail wir rep]
-      this
+      (retry:effect /test-trial (add now.bow ~m10))
     ?>  ?=(^ rod)
     ?>  ?=(^ active.aut.u.rod)
     :: XX check content type and response body
@@ -1844,6 +1844,7 @@
         ~&(unknown-retry+wir this)
       :: XX do the needful
       [%directory ~]  directory:effect
+      [%test-trial ~]  test-trial:effect
     ==
   --
 :: +sigh-tang: handle http request failure

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -290,34 +290,33 @@
   ::  +de:der: decode atom to +spec:asn1
   ::
   ++  de
-    =<  |=  [len=@ud dat=@ux]
-        ^-  (unit spec:asn1)
-        :: XX refactor into +parse
-        =/  a  (rip 3 dat)
-        =/  b  ~|  %der-invalid-len
-            (sub len (lent a))
-        (rust `(list @D)`(weld a (reap b 0)) parse)
+    |=  [len=@ud dat=@ux]
+    ^-  (unit spec:asn1)
+    :: XX refactor into +parse
+    =/  a  (rip 3 dat)
+    =/  b  ~|  %der-invalid-len
+        (sub len (lent a))
+    (rust `(list @D)`(weld a (reap b 0)) parse)
+  ::  +parse:der: DER parser combinator
+  ::
+  ++  parse
+    =<  ^-  $-(nail (like spec:asn1))
+        ;~  pose
+          (stag %int (bass 256 (sear int ;~(pfix (tag 2) till))))
+          (stag %bit (^boss 256 (cook tail ;~(pfix (tag 3) till)))) :: XX test
+          (stag %oct (boss 256 ;~(pfix (tag 4) till)))
+          (stag %nul (cold ~ ;~(plug (tag 5) (tag 0))))
+          (stag %obj (^boss 256 ;~(pfix (tag 6) till)))
+          (stag %seq (sear recur ;~(pfix (tag 48) till)))
+          (stag %set (sear recur ;~(pfix (tag 49) till)))
+          (stag %con ;~(plug (sear context next) till))
+        ==
     |%
-    ::  +parse:de:der: DER parser combinator
-    ::
-    ++  parse
-      %+  cook  |*(a=* `spec:asn1`a)   ::  XX fix
-      :: ^-  $-(nail (like spec:asn1))
-      ;~  pose
-        (stag %int (bass 256 (sear int ;~(pfix (tag 2) till))))
-        (stag %bit (^boss 256 (cook tail ;~(pfix (tag 3) till)))) :: XX test
-        (stag %oct (boss 256 ;~(pfix (tag 4) till)))
-        (stag %nul (cold ~ ;~(plug (tag 5) (tag 0))))
-        (stag %obj (^boss 256 ;~(pfix (tag 6) till)))
-        (stag %seq (sear recur ;~(pfix (tag 48) till)))
-        (stag %set (sear recur ;~(pfix (tag 49) till)))
-        (stag %con ;~(plug (sear context next) till))
-      ==
-    ::  +tag:de:der: parse tag byte
+    ::  +tag:parse:der: parse tag byte
     ::
     ++  tag
       |=(a=@D (just a))
-    ::  +int:de:der: sear unsigned big-endian bytes
+    ::  +int:parse:der: sear unsigned big-endian bytes
     ::
     ++  int
       |=  a=(list @D)
@@ -326,11 +325,11 @@
       ?:  ?=([@ ~] a)  `a
       ?.  =(0 i.a)  `a
       ?.((gth i.t.a 127) ~ `t.a)
-    ::  +recur:de:der: parse bytes for a list of +spec:asn1
+    ::  +recur:parse:der: parse bytes for a list of +spec:asn1
     ::
     ++  recur
       |=(a=(list @) (rust a (star parse)))
-    ::  +context:de:der: decode context-specific tag byte
+    ::  +context:parse:der: decode context-specific tag byte
     ::
     ++  context
       |=  a=@D
@@ -339,7 +338,7 @@
       :+  ~
         =(1 (cut 0 [5 1] a))
       (dis 0x1f a)
-    ::  +boss:de:der: shadowed to count as well
+    ::  +boss:parse:der: shadowed to count as well
     ::
     ::    Use for parsing +octs more broadly?
     ::
@@ -350,7 +349,7 @@
         :-  (lent waq)
         (reel waq |=([p=@ q=@] (add p (mul wuc q))))
       tyd
-    ::  +till:de:der: parser combinator for len-prefixed bytes
+    ::  +till:parse:der: parser combinator for len-prefixed bytes
     ::
     ::  advance until
     ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1091,9 +1091,10 @@
     ?>  ?=([%1 *] der)
     =/  aut=auth  (~(got by aut.der) i)
     ?>  ?=([%1 *] aut)
-    =/  bod=[typ=@t sas=@t url=purl tok=@t]
-      (challenge:grab (need (de-json:html q:(need r.rep))))
-    ?>  ?=(%pending sas.bod)
+    :: XX 204 assuming pending?
+    :: =/  bod=[typ=@t sas=@t url=purl tok=@t]
+    ::   (challenge:grab (need (de-json:html q:(need r.rep))))
+    :: ?>  ?=(%pending sas.bod)
     =.  sas.cal.aut  %pend
     =.  der  der(aut (~(put by aut.der) i aut))
     =.  rod  (~(put by rod) ider der)
@@ -1121,8 +1122,9 @@
     ==
   ::
       %fin
-    =/  bod=[aut=(list purl) fin=purl exp=@t sas=@t]
-      (order:grab (need (de-json:html q:(need r.rep))))
+    :: XX rep body missing authorizations
+    :: =/  bod=[aut=(list purl) fin=purl exp=@t sas=@t]
+    ::   (order:grab (need (de-json:html q:(need r.rep))))
     :: XX check status? (i don't think failures get here)
     abet:poll-order
   ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -853,14 +853,14 @@
     reg.dir
   `[%o (my [['termsOfServiceAgreed' b+&] ~])]
 ::
-++  order
+++  new-order
   ^+  this
   ?~  reg.act
     this          :: XX pending registration assumed
   %-  emil
   %+  turn
-    (skim ~(tap by rod) |=(a=[@ud ^order] ?=([@ %0 *] a)))
-  |=  [i=@ud rod=^order]
+    (skim ~(tap by rod) |=(a=[@ud order] ?=([@ %0 *] a)))
+  |=  [i=@ud rod=order]
   ^-  card
   ?>  ?=([%0 *] rod)
   %^  request  /acme/der/(scot %ud i)
@@ -881,8 +881,8 @@
   =/  aut=(list (trel @ud @ud purl))
     %-  zing
     %+  turn
-      (skim ~(tap by rod) |=(a=[@ud ^order] ?=([@ %1 *] a)))
-    |=  [ider=@ud rod=^order]
+      (skim ~(tap by rod) |=(a=[@ud order] ?=([@ %1 *] a)))
+    |=  [ider=@ud rod=order]
     ?>  ?=([%1 *] rod)
     %+  turn
       ~(tap by aut.rod)
@@ -894,45 +894,80 @@
   ^-  card
   (request /acme/aut/(scot %ud i)/der/(scot %ud ider) aut ~)
 ::
-++  challenge
+++  save-challenge
   ^+  this
   %-  emil
   =/  cal=(list (trel @ud @ud trial))
     %-  zing
     %+  turn
-      (skim ~(tap by rod) |=(a=[@ud ^order] ?=([@ %1 *] a)))
-    |=  [ider=@ud rod=^order]
+      (skim ~(tap by rod) |=(a=[@ud order] ?=([@ %1 *] a)))
+    |=  [ider=@ud rod=order]
     ?>  ?=([%1 *] rod)
     %+  turn
       ~(tap by aut.rod)
     |=  [i=@ud aut=auth]
     ?>  ?=([%1 *] aut)
     [i ider cal.aut]
-  %-  zing
   %+  turn  cal
   |=  [i=@ud ider=@ud cal=trial]
-  ^-  (list card)
-  :~  :^    %well
-          /acme/wel/(scot %ud i)/der/(scot %ud ider)
-        /acme-challenge/[tok.cal]
-      :+  ~
-        /text/plain
-      %-  as-octs:mimes:html
-      (rap 3 [tok.cal '.' (pass:thumb:jwk key.act) ~])
-      ::
-      %^    request
-          /acme/cal/(scot %ud i)/der/(scot %ud ider)
-        cal.cal
-      `[%o ~]
-  ==
+  ^-  card
+  :^    %well
+      /acme/wel/(scot %ud i)/der/(scot %ud ider)
+    /acme-challenge/[tok.cal]
+  :+  ~
+    /text/plain
+  %-  as-octs:mimes:html
+  (rap 3 [tok.cal '.' (pass:thumb:jwk key.act) ~])
 ::
-++  finalize
+++  test-challenge
+  ^+  this
+  %-  emil
+  =/  cal=(list [@ud @ud turf trial])
+    %-  zing
+    %+  turn
+      (skim ~(tap by rod) |=(a=[@ud order] ?=([@ %1 *] a)))
+    |=  [ider=@ud rod=order]
+    ?>  ?=([%1 *] rod)
+    %+  turn
+      ~(tap by aut.rod)
+    |=  [i=@ud aut=auth]
+    ?>  ?=([%1 *] aut)
+    [i ider dom.aut cal.aut]
+  %+  turn  cal
+  |=  [i=@ud ider=@ud dom=turf cal=trial]
+  ^-  card
+  =/  wir=wire  /acme/tcal/(scot %ud i)/der/(scot %ud ider)
+  =/  pat=path  /'.well-known'/acme-challenge/[tok.cal]
+  =/  pul=purl  [[| ~ [%& dom]] [~ pat] ~]
+  (request wir pul ~)
+::
+++  finalize-challenge
+  ^+  this
+  %-  emil
+  =/  cal=(list (trel @ud @ud purl))
+    %-  zing
+    %+  turn
+      (skim ~(tap by rod) |=(a=[@ud order] ?=([@ %1 *] a)))
+    |=  [ider=@ud rod=order]
+    ?>  ?=([%1 *] rod)
+    %+  turn
+      ~(tap by aut.rod)
+    |=  [i=@ud aut=auth]
+    ?>  ?=([%1 *] aut)
+    [i ider cal.cal.aut]
+  %+  turn  cal
+  |=  [i=@ud ider=@ud cal=purl]
+  ^-  card
+  =/  wir=wire  /acme/cal/(scot %ud i)/der/(scot %ud ider)
+  (request wir cal `[%o ~])
+::
+++  finalize-order
   ^+  this
   %-  emil
   =/  csr=(list (trel @ud purl @ux))
     %+  turn
-      (skim ~(tap by rod) |=(a=[@ud ^order] ?=([@ %2 *] a)))
-    |=  [i=@ud rod=^order]
+      (skim ~(tap by rod) |=(a=[@ud order] ?=([@ %2 *] a)))
+    |=  [i=@ud rod=order]
     ?>  ?=([%2 *] rod)
     [i fin.rod csr.rod]
   %+  turn  csr
@@ -948,8 +983,8 @@
   %-  emil
   =/  url=(list (pair @ud purl))
     %+  turn
-      (skim ~(tap by rod) |=(a=[@ud ^order] ?=([@ %2 *] a)))
-    |=  [i=@ud rod=^order]
+      (skim ~(tap by rod) |=(a=[@ud order] ?=([@ %2 *] a)))
+    |=  [i=@ud rod=order]
     ?>  ?=([%2 *] rod)
     [i der.rod]
   %+  turn  url
@@ -966,6 +1001,8 @@
   =?  non  ?=(^ ron)  q.i.ron
   ?.  ?=(%2 (div p.rep 100))
     ~&  %lack-of-success
+    ?:  ?=(%tcal i.t.wir)
+      abet:test-challenge  :: XX sleep?
     =/  bod=[typ=@t det=@t]
       (error:grab (need (de-json:html q:(need r.rep))))
     ?:  =('urn:ietf:params:acme:error:badNonce' typ.bod)
@@ -989,13 +1026,13 @@
     ?.  ?=([%next ^] t.t.wir)
       register
     ?+  i.t.t.t.wir  this
-      %der  order
+      %der  new-order
       %aut  authorize
-      %cal  challenge
+      %cal  finalize-challenge
     ==
   ::
       %reg
-    =<  abet:order
+    =<  abet:new-order
     =/  bod=[id=@t wen=@t sas=@t]  :: XX @da
       (acct:grab (need (de-json:html q:(need r.rep))))
     =/  loc=@t
@@ -1006,7 +1043,7 @@
       %der
     =<  abet:authorize
     =/  i=@ud  (slav %ud (head t.t.wir))
-    =/  der=^order  (~(got by rod) i)
+    =/  der=order  (~(got by rod) i)
     ?>  ?=([%0 *] der)
     =/  loc=@t
       q:(head (skim q.rep |=((pair @t @t) ?=(%location p))))
@@ -1015,15 +1052,15 @@
       (order:grab (need (de-json:html q:(need r.rep))))
     =/  aut  %-  ~(gas by *(map @ud auth))
              (spun aut.bod |=([a=purl b=@ud] [[b %0 a] +(b)]))
-    =/  dor=^order  [%1 dom.der exp.bod url fin.bod aut]
+    =/  dor=order  [%1 dom.der exp.bod url fin.bod aut]
     this(rod (~(put by rod) i dor))
   ::
       %aut
-    =<  abet:challenge
+    =<  abet:test-challenge:save-challenge
     ?>  ?=([@ %der @ *] t.t.wir)
     =/  i  (slav %ud i.t.t.wir)
     =/  ider  (slav %ud i.t.t.t.t.wir)
-    =/  der=^order  (~(got by rod) ider)
+    =/  der=order  (~(got by rod) ider)
     ?>  ?=([%1 *] der)
     =/  aut=auth  (~(got by aut.der) i)
     ?>  ?=([%0 *] aut)
@@ -1035,12 +1072,16 @@
     =.  der  der(aut (~(put by aut.der) i tau))
     this(rod (~(put by rod) ider der))
   ::
+      %tcal
+    :: XX check content type and response body
+    abet:finalize-challenge
+  ::
       %cal
-    =<  abet:finalize
+    =<  abet:finalize-order
     ?>  ?=([@ %der @ *] t.t.wir)
     =/  i  (slav %ud i.t.t.wir)
     =/  ider  (slav %ud i.t.t.t.t.wir)
-    =/  der=^order  (~(got by rod) ider)
+    =/  der=order  (~(got by rod) ider)
     ?>  ?=([%1 *] der)
     =/  aut=auth  (~(got by aut.der) i)
     ?>  ?=([%1 *] aut)
@@ -1050,10 +1091,10 @@
     =.  sas.cal.aut  %pend
     =.  der  der(aut (~(put by aut.der) i aut))
     =.  rod  (~(put by rod) ider der)
-    =/  fin=(list (pair @ud ^order))
+    =/  fin=(list (pair @ud order))
       %+  skim
         ~(tap by rod)
-      |=  a=[@ud ^order]
+      |=  a=[@ud order]
       ?&  ?=([@ %1 *] a)
           %+  levy
             ~(tap by aut.a)
@@ -1064,7 +1105,7 @@
     %=  this
       rod  %-  ~(gas by rod)
            %+  turn  fin
-           |=  [i=@ud der=^order]
+           |=  [i=@ud der=order]
            ^+  [i der]
            ?>  ?=([%1 *] der)
            =/  k=key:rsa  rekey  :: XX reuse
@@ -1101,7 +1142,7 @@
       %cer    :: XX send configuration to eyre
     =<  abet
     =/  i=@ud  (slav %ud (head t.t.wir))
-    =/  der=^order  (~(got by rod) i)
+    =/  der=order  (~(got by rod) i)
     =/  cer=wain
       (to-wain:format q:(need r.rep))
     ?>  ?=([%2 *] der)
@@ -1118,17 +1159,17 @@
   ?+  a  ~&  +<+.this
          [~ this]
     %init   abet:init
-    %order  abet:order
+    %order  abet:new-order
     %auth   abet:authorize
-    %trial  abet:challenge
-    %final  abet:finalize
+    %trial  abet:test-challenge
+    %final  abet:finalize-order
     %poll   abet:poll-order
     %our    abet:(add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
     %test   test
   ==
 ::
 ++  poke-path
-  |=(a=path (add-order a ~))
+  |=(a=path abet:(add-order a ~))
 ::
 :: ++  prep  _[~ this]
 ++  prep
@@ -1156,7 +1197,7 @@
 ++  add-order
   |=  dom=(list turf)
   ^+  this
-  order(rod (~(put by rod) ~(wyt by rod) [%0 dom]))
+  new-order(rod (~(put by rod) ~(wyt by rod) [%0 dom]))
 ::
 ++  test
   =,  tester:tester

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -802,6 +802,8 @@
 ::
 ++  order
   ^+  this
+  ?~  reg.act
+    this          :: XX pending registration assumed
   %-  emil
   %+  turn
     (skim ~(tap by der) |=(a=[@ud ^order] ?=([@ %0 *] a)))
@@ -901,20 +903,6 @@
   |=  [i=@ud der=purl]
   ^-  card
   (request /acme/por/(scot %ud i) der ~)
-::
-++  poke-noun
-  |=  a=*
-  ^-  (quip move _this)
-  ?+  a  ~&  +<+.this
-         [~ this]
-    %init   abet:init
-    %order  abet:order
-    %auth   abet:authorize
-    %trial  abet:challenge
-    %final  abet:finalize
-    %poll   abet:poll-order
-    %test   test
-  ==
 ::
 ++  sigh-httr
   |=  [wir=wire rep=httr:eyre]
@@ -1071,6 +1059,24 @@
     ==
   ==
 ::
+++  poke-noun
+  |=  a=*
+  ^-  (quip move _this)
+  ?+  a  ~&  +<+.this
+         [~ this]
+    %init   abet:init
+    %order  abet:order
+    %auth   abet:authorize
+    %trial  abet:challenge
+    %final  abet:finalize
+    %poll   abet:poll-order
+    %our    abet:(add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
+    %test   test
+  ==
+::
+++  poke-path
+  |=(a=path (add-order a ~))
+::
 :: ++  prep  _[~ this]
 ++  prep
   |=  old=(unit acme)
@@ -1088,12 +1094,16 @@
   $(i +(i), eny.bow +(eny.bow))
 ::
 ++  init
-  =/  key=key:rsa  rekey
-  =/  dom=turf  /org/urbit/(crip +:(scow %p our.bow))
-  =/  dor=^order  [%0 [dom ~]]
   =/  url
-    (de-purl:html 'https://acme-staging-v02.api.letsencrypt.org/directory')
-  directory(bas (need url), act `acct`[key ~], der [[0 dor] ~ ~])
+    'https://acme-staging-v02.api.letsencrypt.org/directory'
+  directory(bas (need (de-purl:html url)), act [rekey ~])
+  :: XX wait for DNS binding confirmation?
+  :: (add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
+::
+++  add-order
+  |=  dom=(list turf)
+  ^+  this
+  order(der (~(put by der) ~(wyt by der) [%0 dom]))
 ::
 ++  test
   =,  tester:tester

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -253,10 +253,10 @@
       :: ^-  $-(nail (like spec:asn1))
       ;~  pose
         (stag %int (bass 256 (sear int ;~(pfix (tag 2) till))))
-        (stag %bit (boss 256 (cook tail ;~(pfix (tag 3) till)))) :: XX test
-        (stag %oct (cook oct ;~(pfix (tag 4) till)))
+        (stag %bit (^boss 256 (cook tail ;~(pfix (tag 3) till)))) :: XX test
+        (stag %oct (boss 256 ;~(pfix (tag 4) till)))
         (stag %nul (cold ~ ;~(plug (tag 5) (tag 0))))
-        (stag %obj (boss 256 ;~(pfix (tag 6) till)))
+        (stag %obj (^boss 256 ;~(pfix (tag 6) till)))
         (stag %seq (sear recur ;~(pfix (tag 48) till)))
         (stag %set (sear recur ;~(pfix (tag 49) till)))
         (stag %con ;~(plug (sear context next) till))
@@ -274,13 +274,6 @@
       ?:  ?=([@ ~] a)  `a
       ?.  =(0 i.a)  `a
       ?.((gth i.t.a 127) ~ `t.a)
-    :: +oct:de:der: cook bytes to capture length
-    ::
-    ++  oct
-      |=  a=(list @D)
-      ^-  [len=@ud oct=@ux]
-      :: XX do this in a parser combinator instead
-      [(lent a) (scan a (boss 256 (star next)))]
     ::  +recur:de:der: parse bytes for a list of +spec:asn1
     ::
     ++  recur
@@ -294,6 +287,17 @@
       :+  ~
         =(1 (cut 0 [5 1] a))
       (dis 0x1f a)
+    ::  +boss:de:der: shadowed to count as well
+    ::
+    ::    Use for parsing +octs more broadly?
+    ::
+    ++  boss
+      |*  [wuc=@ tyd=rule]
+      %+  cook
+        |=  waq=(list @)
+        :-  (lent waq)
+        (reel waq |=([p=@ q=@] (add p (mul wuc q))))
+      tyd
     ::  +till:de:der: parser combinator for len-prefixed bytes
     ::
     ::  advance until

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -504,13 +504,16 @@
           [%seq [%obj sha-256:obj:asn1] [%nul ~] ~]
           [%oct 32 (shax m)]
       ==
-    =/  t=(list @)  ~(ren raw:en:der pec)
-    =/  tlen  (lent t)
+    ::  note: this asn.1 digest is rendered raw here, as we require
+    ::  big-endian bytes, and the product of +en:der is little-endian
+    ::
+    =/  t=(list @D)  ~(ren raw:en:der pec)
+    =/  tlen=@ud  (lent t)
     ?:  (lth emlen (add 11 tlen))
       ~|(%emsa-too-short !!)
-    =/  ps  (reap (sub emlen (add 3 tlen)) 0xff)
-    %+  rep  3
-    (flop (weld [0x0 0x1 ps] [0x0 t]))  :: note: big-endian
+    =/  ps=(list @D)
+      (reap (sub emlen (add 3 tlen)) 0xff)
+    (rep 3 (flop (weld [0x0 0x1 ps] [0x0 t])))
   ::  +sign:rs256: sign message
   ::
   ::    An RSA signature is the primitive decryption of the message hash.

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1705,6 +1705,7 @@
     %new-order       (new-order:event t.wir rep)
     %finalize-order  (finalize-order:event t.wir rep)
     %check-order     (check-order:event t.wir rep)
+    %certificate     (certificate:event t.wir rep)
     %get-authz       (get-authz:event t.wir rep)
     :: XX check/finalize-authz ??
     %test-trial      (test-trial:event t.wir rep)

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1917,8 +1917,110 @@
     %poll   check-order:effect
     %our    (add-order (sy /org/urbit/(crip +:(scow %p our.bow)) ~))
     %rule   install:effect
+    %fake   fake
+    %none   none
     %test   test
   ==
+++  none
+  ^+  this
+  (emit %rule /uninstall %cert ~)
+++  fake
+  ^+  this
+  =/  key=wain
+    :~  '-----BEGIN RSA PRIVATE KEY-----'
+        'MIIEpAIBAAKCAQEAisQPzzmGWNZSNNAwY59XrqK/bU0NKNZS2ETOiJeSpzPAHYl+'
+        'c39V96/QUR0tra2zQI4QD6kpMYX/7R5nwuvsA4o7ypfYupNrlzLPThCKEHpZomDD'
+        '0Bb3T8u7YGrMjEX5cOmZIU2T/iy4GK/wWuBIy2TEp/0J+RoSCIr8Df/A7GIM8bwn'
+        'v23Vq0kE2xBqqaT5LjvuQoXfiLJ42F33DDno9lVikKEyt55D/08rH41KpXvn3tWZ'
+        '46tZK6Ds7Zr1hEV1LbDx1CXDzQ6gKObBe54DWDV3h7TJhr0BSW68dFJhro7Y60Ns'
+        'zTcFqY1RC9F0ePtsnKGFzMOe/U+fPvsGe2oWvwIDAQABAoIBACCf19ewfpWETe98'
+        'wuOpIsQ8HyVjaCShvvh5tNUITcJhuFk5ajFdTqjc/O0VHxgmLm6O99e2vaiXCISH'
+        'EX4SWXq7lTMcYCf9YN47Y+HGoa8eFNTIS0ExJRPtojAY695O1UZmpUnfI1wux1mG'
+        'g8vZz0OCfXnBVAbsyjCX/IqOBp2MVzfMyMuaF/oQ2xiX4AZ1hDIMDpUTGw7OKX15'
+        'JAUlTZUhzifmijPg1gViD8Lf5w42nlwYPC5j6wWKpJSx76CNUxLdJAaaZb3QYE96'
+        'zu/jOCdy25sPHIux3XTdV6fqZ2iTvt31+bcnSAvmbDpmcujsZPVRXRu5OO/0xBh6'
+        'GGlTLAECgYEAwSyNkbNk0mBRxet68IW02wXYaxIEVUWqhSeE2MGaXg4h9VSgh83q'
+        '7wly0ujy9Sj79aF2frkpMbIoeeGIOTIYI4RCYuBKx+/NNWFoggu4UK5xOMr0dfQK'
+        '2Ggr2agUH3KExvOpAW3rvWzepLl8ppySLNipLcFQHOJ0kxwPd2ig3Z8CgYEAt+WM'
+        'JoW9dLxUu/zTih5Dacubl+fnnm8BsypKmv88mzcqEVwXOo6Z6bmlw0NeWxmlwHu7'
+        'vs+XQ8MDUDvQvIul8sFagZk7RvWcXTlaHtPQ1D8/ztrg5d58TwxpwXshBytfR6NA'
+        'tIZa+tNvzQF5AKVlB+lZEWF6E6FoI5NmGDAZ8uECgYB4FV4cCMzQCphK1Muj4TpA'
+        'PS3/wT94Usph4+Mta4yuk1KA047HXTaCSflbKvx9cnDOjQTAWhJFll6bBZxNEdr3'
+        'mSw7kvppt6R1Xow861Q0s3wmteOpv39Ob9Nyho2bzvDDTIzvGonFQ3xUIgpe+E3W'
+        'GwlwLA/FJPEa0gK7VAtMOQKBgQCgcPtX2LM0l+Ntp+V/yWuTb/quC7w+tCbNhAZX'
+        'OHxOB1ECmFAD3MpX6oq+05YM8VF1n/5rOX6Ftiy74ZP6C/Sa2Sr3ixL2k+76PsFr'
+        'x+2YYB5xgPFaXEQkS3YxQhXMxYB5ZetcFSRnVfVi7Pf/Ik4FGweEbIEvg1DySPV4'
+        'AO+CwQKBgQCFnjHsFeNZVvtiL2wONT6osjRCpMvaUiVecMW9oUBtjpLHI2gQr7+4'
+        'dvCm2Sj7uq9OWO0rBz1px/kI+ONjhwsFPLK5v8hyVDoIE791Qg3qAY1a6JOXRl9P'
+        '6TBc3dQ2qUVqt8gi9RLCDFJU18Td6La4mkJSP5YrioGtwUJow0F07Q=='
+        '-----END RSA PRIVATE KEY-----'
+    ==
+
+  =/  cert=wain
+    :~  '-----BEGIN CERTIFICATE-----'
+        'MIIF8jCCBNqgAwIBAgITAPrPc8Udwmv5dJ+hx2Uh+gZF1TANBgkqhkiG9w0BAQsF'
+        'ADAiMSAwHgYDVQQDDBdGYWtlIExFIEludGVybWVkaWF0ZSBYMTAeFw0xODA3MDMx'
+        'ODAyMTZaFw0xODEwMDExODAyMTZaMB8xHTAbBgNVBAMTFHpvZC5keW5kbnMudXJi'
+        'aXQub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAisQPzzmGWNZS'
+        'NNAwY59XrqK/bU0NKNZS2ETOiJeSpzPAHYl+c39V96/QUR0tra2zQI4QD6kpMYX/'
+        '7R5nwuvsA4o7ypfYupNrlzLPThCKEHpZomDD0Bb3T8u7YGrMjEX5cOmZIU2T/iy4'
+        'GK/wWuBIy2TEp/0J+RoSCIr8Df/A7GIM8bwnv23Vq0kE2xBqqaT5LjvuQoXfiLJ4'
+        '2F33DDno9lVikKEyt55D/08rH41KpXvn3tWZ46tZK6Ds7Zr1hEV1LbDx1CXDzQ6g'
+        'KObBe54DWDV3h7TJhr0BSW68dFJhro7Y60NszTcFqY1RC9F0ePtsnKGFzMOe/U+f'
+        'PvsGe2oWvwIDAQABo4IDIjCCAx4wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQG'
+        'CCsGAQUFBwMBBggrBgEFBQcDAjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBTokXAU'
+        'vPwcrbkLxcVBCNNQ588pfjAfBgNVHSMEGDAWgBTAzANGuVggzFxycPPhLssgpvVo'
+        'OjB3BggrBgEFBQcBAQRrMGkwMgYIKwYBBQUHMAGGJmh0dHA6Ly9vY3NwLnN0Zy1p'
+        'bnQteDEubGV0c2VuY3J5cHQub3JnMDMGCCsGAQUFBzAChidodHRwOi8vY2VydC5z'
+        'dGctaW50LXgxLmxldHNlbmNyeXB0Lm9yZy8wHwYDVR0RBBgwFoIUem9kLmR5bmRu'
+        'cy51cmJpdC5vcmcwgf4GA1UdIASB9jCB8zAIBgZngQwBAgEwgeYGCysGAQQBgt8T'
+        'AQEBMIHWMCYGCCsGAQUFBwIBFhpodHRwOi8vY3BzLmxldHNlbmNyeXB0Lm9yZzCB'
+        'qwYIKwYBBQUHAgIwgZ4MgZtUaGlzIENlcnRpZmljYXRlIG1heSBvbmx5IGJlIHJl'
+        'bGllZCB1cG9uIGJ5IFJlbHlpbmcgUGFydGllcyBhbmQgb25seSBpbiBhY2NvcmRh'
+        'bmNlIHdpdGggdGhlIENlcnRpZmljYXRlIFBvbGljeSBmb3VuZCBhdCBodHRwczov'
+        'L2xldHNlbmNyeXB0Lm9yZy9yZXBvc2l0b3J5LzCCAQIGCisGAQQB1nkCBAIEgfME'
+        'gfAA7gB1ALDMg+Wl+X1rr3wJzChJBIcqx+iLEyxjULfG/SbhbGx3AAABZGGGG6QA'
+        'AAQDAEYwRAIgJHrIawVea5/++wteocdbt1QUBxysW7uJqYgvnOWOQMgCIGRlioyE'
+        'vzunUm/HZre3fF2jBsJr45C1tz5FTe/cYQwmAHUA3Zk0/KXnJIDJVmh9gTSZCEmy'
+        'Sfe1adjHvKs/XMHzbmQAAAFkYYYjLQAABAMARjBEAiAWovIKERYeNbJlAKvNorwn'
+        'RnSFP0lJ9sguwcpbcsYJ1gIgRJxTolkMOr0Fwq62q4UYnpREY8zu4hiL90Mhntky'
+        'EwYwDQYJKoZIhvcNAQELBQADggEBAMYxvA+p4Qj0U23AHAe61W3+M6T1M0BfrGE2'
+        'jJCaq4c3d7b9NEN1qFJHl8t/+Z/7RHUIzbm4CIOZynSM8mBxg2NgXymvXQkRrrBo'
+        'fhO9u8Yxizx4+KOtiigt9JBVlpyCm6I9uifM+7rZYh45s2IkfDBPKd+M1tfIUOne'
+        'YgUt1YguEkM2xqRG16JyHA0Xwn6mn+4pWiTdfNzlqol6vyGT7WfIvmV7cdGoYKjB'
+        'wOt/g1wWMTwhSWBCVqCyn+f2rl8u3wbXrIUeRng2ryNVXO03nukTp7OLN3HUO6PR'
+        'hC4NdS4o2geBNZr8RJiORtCelDaJprY7lhh2MFzVpsodc2eB5sQ='
+        '-----END CERTIFICATE-----'
+        ''
+        '-----BEGIN CERTIFICATE-----'
+        'MIIEqzCCApOgAwIBAgIRAIvhKg5ZRO08VGQx8JdhT+UwDQYJKoZIhvcNAQELBQAw'
+        'GjEYMBYGA1UEAwwPRmFrZSBMRSBSb290IFgxMB4XDTE2MDUyMzIyMDc1OVoXDTM2'
+        'MDUyMzIyMDc1OVowIjEgMB4GA1UEAwwXRmFrZSBMRSBJbnRlcm1lZGlhdGUgWDEw'
+        'ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDtWKySDn7rWZc5ggjz3ZB0'
+        '8jO4xti3uzINfD5sQ7Lj7hzetUT+wQob+iXSZkhnvx+IvdbXF5/yt8aWPpUKnPym'
+        'oLxsYiI5gQBLxNDzIec0OIaflWqAr29m7J8+NNtApEN8nZFnf3bhehZW7AxmS1m0'
+        'ZnSsdHw0Fw+bgixPg2MQ9k9oefFeqa+7Kqdlz5bbrUYV2volxhDFtnI4Mh8BiWCN'
+        'xDH1Hizq+GKCcHsinDZWurCqder/afJBnQs+SBSL6MVApHt+d35zjBD92fO2Je56'
+        'dhMfzCgOKXeJ340WhW3TjD1zqLZXeaCyUNRnfOmWZV8nEhtHOFbUCU7r/KkjMZO9'
+        'AgMBAAGjgeMwgeAwDgYDVR0PAQH/BAQDAgGGMBIGA1UdEwEB/wQIMAYBAf8CAQAw'
+        'HQYDVR0OBBYEFMDMA0a5WCDMXHJw8+EuyyCm9Wg6MHoGCCsGAQUFBwEBBG4wbDA0'
+        'BggrBgEFBQcwAYYoaHR0cDovL29jc3Auc3RnLXJvb3QteDEubGV0c2VuY3J5cHQu'
+        'b3JnLzA0BggrBgEFBQcwAoYoaHR0cDovL2NlcnQuc3RnLXJvb3QteDEubGV0c2Vu'
+        'Y3J5cHQub3JnLzAfBgNVHSMEGDAWgBTBJnSkikSg5vogKNhcI5pFiBh54DANBgkq'
+        'hkiG9w0BAQsFAAOCAgEABYSu4Il+fI0MYU42OTmEj+1HqQ5DvyAeyCA6sGuZdwjF'
+        'UGeVOv3NnLyfofuUOjEbY5irFCDtnv+0ckukUZN9lz4Q2YjWGUpW4TTu3ieTsaC9'
+        'AFvCSgNHJyWSVtWvB5XDxsqawl1KzHzzwr132bF2rtGtazSqVqK9E07sGHMCf+zp'
+        'DQVDVVGtqZPHwX3KqUtefE621b8RI6VCl4oD30Olf8pjuzG4JKBFRFclzLRjo/h7'
+        'IkkfjZ8wDa7faOjVXx6n+eUQ29cIMCzr8/rNWHS9pYGGQKJiY2xmVC9h12H99Xyf'
+        'zWE9vb5zKP3MVG6neX1hSdo7PEAb9fqRhHkqVsqUvJlIRmvXvVKTwNCP3eCjRCCI'
+        'PTAvjV+4ni786iXwwFYNz8l3PmPLCyQXWGohnJ8iBm+5nk7O2ynaPVW0U2W+pt2w'
+        'SVuvdDM5zGv2f9ltNWUiYZHJ1mmO97jSY/6YfdOUH66iRtQtDkHBRdkNBsMbD+Em'
+        '2TgBldtHNSJBfB3pm9FblgOcJ0FSWcUDWJ7vO0+NTXlgrRofRT6pVywzxVo6dND0'
+        'WzYlTWeUVsO40xJqhgUQRER9YLOLxJ0O6C8i0xFxAMKOtSdodMB3RIwt7RFQ0uyt'
+        'n5Z5MqkYhlMI3J1tPRTp1nEt9fyGspBOO05gi148Qasp+3N+svqKomoQglNoAxU='
+        '-----END CERTIFICATE-----'
+    ==
+  (emit %rule /install %cert `[key cert])
 :: +poke-path: for debugging
 ::
 ++  poke-path

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -704,11 +704,15 @@
         ['status' so]
     ==
   ::
+  ++  finalizing-order
+    %-  ot
+    :~  ['expires' so] :: XX (su iso-8601)
+        ['status' so]
+    ==
+  ::
   ++  final-order
     %-  ot
-    :~  ['authorizations' (ar json-purl)]
-        ['finalize' json-purl]
-        ['expires' so] :: XX (su iso-8601)
+    :~  ['expires' so] :: XX (su iso-8601)
         ['status' so]
         ['certificate' json-purl]
     ==
@@ -1124,6 +1128,7 @@
   ::
       %fin
     :: XX rep body missing authorizations
+    :: XX finalizing-order
     :: =/  bod=[aut=(list purl) fin=purl exp=@t sas=@t]
     ::   (order:grab (need (de-json:html q:(need r.rep))))
     :: XX check status? (i don't think failures get here)
@@ -1133,15 +1138,15 @@
     =/  i=@ud  (slav %ud (head t.t.wir))
     =/  raw=json
       (need (de-json:html q:(need r.rep)))
-    =/  bod=[aut=(list purl) fin=purl exp=@t sas=@t]
-      (order:grab raw)
+    =/  bod=[exp=@t sas=@t]
+      (finalizing-order:grab raw)
     ?+  sas.bod
         ~&(poll-order-status+sas.bod abet)
       %invalid     abet          :: XX check authz, retry order?
       %pending     abet:poll-order
       %processing  abet:poll-order
       %valid       =<  abet
-                   =/  bod=[aut=(list purl) fin=purl exp=@t sas=@t cer=purl]
+                   =/  bod=[exp=@t sas=@t cer=purl]
                      (final-order:grab raw)  :: XX json reparser unit
                    %-  emit                  :: XX accept hed
                    (request /acme/cer/(scot %ud i) cer.bod ~)

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1928,11 +1928,9 @@
 ++  prep
   |=  old=(unit acme)
   ^-  (quip move _this)
-  ?^  old
-    [~ this(+<+ u.old)]
-  ?:  ?=(?(%earl %pawn) (clan:title our.bow))
+  ?~  old
     [~ this]
-  abet:init
+  [~ this(+<+ u.old)]
 ::
 ++  rekey                             :: XX do something about this
   |=  eny=@
@@ -1958,12 +1956,26 @@
 ++  add-order
   |=  dom=(set turf)
   ^+  this
-  :: XX we may have pending moves out for this order
-  :: XX put dates in wires, check against order creation date?
-  :: XX or re-use order-id?
+  ?:  ?=(?(%earl %pawn) (clan:title our.bow))
+    this
+  :: set pending order
+  ::
+  =.  pen  `dom
+  :: archive active order if exists
+  ::
+  ::   XX we may have pending moves out for this order
+  ::   put dates in wires, check against order creation date?
+  ::   or re-use order-id?
+  ::
   =?  fal.hit  ?=(^ rod)  [u.rod fal.hit]
-  =<  ?~(reg.act this new-order:effect)
-  this(rod ~, pen `dom)
+  =.  rod  ~
+  :: if registered, create order
+  ::
+  ?^  reg.act
+    new-order:effect
+  :: if initialized, defer
+  ::
+  ?.(=(act *acct) this init)
 ::
 ++  test
   =,  tester:tester

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -456,7 +456,7 @@
       ^-  spec:asn1
       :-  %seq
       %+  turn  hot
-      |=(h=(list @t) [%con [& 2] (rip 3 (en-host h))])
+      |=(h=(list @t) [%con [& 2] (rip 3 (join '.' h))])
     ::                                                  ::  +cert:spec:pkcs10
     ++  cert                                            ::  cert request info
       |=  csr                                           ::  XX rename
@@ -661,16 +661,16 @@
   |=  [a=* b=*]
   ^-  ?
   (fall (bind (both (find ~[a] lit) (find ~[b] lit)) com) |)
-::                                                    ::  +en-host
-++  en-host                                           ::  rendor host
-  |=  hot=(list @t)
+::                                                    ::  +join
+++  join                                              ::  join cords w/ sep
+  |=  [sep=@t hot=(list @t)]
   ^-  @t
   =|  out=(list @t)
   ?>  ?=(^ hot)
   |-  ^-  @t
   ?~  t.hot
     (rap 3 [i.hot out])
-  $(out ['.' i.hot out], hot t.hot)
+  $(out [sep i.hot out], hot t.hot)
 ::
 :::: acme api response json reparsers
 ::
@@ -877,7 +877,7 @@
     :-  %a
     %+  turn
       dom.rod
-    |=(a=turf [%o (my type+s+'dns' value+s+(en-host a) ~)])
+    |=(a=turf [%o (my type+s+'dns' value+s+(join '.' a) ~)])
   ==
 ::
 ++  authorize

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1797,7 +1797,7 @@
             test-rs256
             test-jwk
             test-jws
-            test-jws-fail
+            test-jws-2
             test-csr
           ==
       ?~(out this ((slog out) this))
@@ -2323,13 +2323,11 @@
         :-  exp-ws
         (en-base64url (swp 3 (~(sign rs256 k) inp-ws)))
     ==
-  :: XX this test should fail, but doesn't.
-  :: XX fix the bug and make it fail.
   ::
-  ::   urn:ietf:params:acme:error:malformed
-  ::   JWS verification error
-  ::
-  ++  test-jws-fail
+  ++  test-jws-2
+    :: captured from an in-the-wild failure
+    :: relevant sha-256 has a significant leading zero
+    :: which was not being captured in the asn.1 digest ...
     =/  kpem=wain
       :~  '-----BEGIN RSA PRIVATE KEY-----'
           'MIIEogIBAAKCAQEAkmWLu+9gyzCbrGAHTFE6Hs7CtVQofONmpnhmE7JQkmdS+aph'
@@ -2394,12 +2392,12 @@
         ==
       =/  signature=@t
         %+  rap  3
-        :~  'ZuQgIjhNY3UbmnPwBfleJRrmc2CCrwQ2eKkw1594_MaBwGZdSg6'
-            'UaDljoJ9SKXpd_2-glsQuZG1YgpFzZIk66rip6D80Xu0ZJg9AR8KEqLSMHavONj4CR'
-            'c6USw9Ov3LnfQgvt9W5xb8rc2NNl-ESCNRKkOBmwhNNM1kiOY1AbQa8Ko0uNFHSn3a'
-            'Rm_PLGlaTcP-k8j6ZlyOBCp3CuyxBJ68I92cWH3aSEHf4mYQo6IE0qqhk6Dv1Cyayt'
-            '7Ds8ocmhvESxo-iiiecBTkEaw_YCYJle_Re6F2hyyEnLVULowMJdyrYvb2YXjjj9d9'
-            '9m3SSTy_L3kTohpktQxRSwWlmcg'
+        :~  'cukOS_KIWTolvORyJoIu5eejdLoFi6xpd06Y6nW565zFMKZi44BepsWIZXw4yxYjxs'
+            '8xFdoKOxtXhBS5BT0mbkHSUGokAPTUiF5b1wjm00ZiKRYwnIotizsLPzHAJKwhMlFs'
+            'x6oAu25mmremBgnNtVD_cskQBbkTBgiTL6alrkrmwxlP2gSqyX6uEO-UCY71QB_xYj'
+            '4IOoX2k0jdXJevXDAJSUWfs5cZkm8Ug_q4GVTRWhZmFHMnMzonmCC4Ui7nDa9oKJH5'
+            'Npyn74FCcqbz111AK-Aul1dNhz3ojE1VOk3eVjH69lSGsaMleYR5fi60Jdc5ZbpPPy'
+            't-CZRp1F0k6w'
         ==
       [%o (my payload+s+payload protected+s+protected signature+s+signature ~)]
     %-  expect-eq  !>

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -668,7 +668,7 @@
       --
     --
   --
-::  |pkcs8: asymmetric cryptography (rfc5208)
+::  |pkcs8: asymmetric cryptography (rfc5208, rfc5958)
 ::
 ::    RSA-only for now.
 ::
@@ -682,6 +682,9 @@
       |%
       ::  +pass:spec:pkcs8: public key ASN.1
       ::
+      ::    Technically not part of pkcs8, but standardized later in
+      ::    the superseding RFC. Included here for symmetry.
+      ::
       ++  pass
         |=  k=key:rsa
         ^-  spec:asn1
@@ -693,13 +696,19 @@
         ==
       ::  +ring:spec:pkcs8: private key ASN.1
       ::
-      ++  ring  !!
+      ++  ring
+        |=  k=key:rsa
+        ^-  spec:asn1
+        :~  %seq
+            [%seq [[%obj rsa:obj:asn1] [%nul ~] ~]]
+            [%oct (ring:en:der:pkcs1 k)]
+        ==
       --
-    ::  |de:spec:pkcs8:
+    ::  |de:spec:pkcs8: ASN.1 decoding for asymmetric keys
     ::
     ++  de
       |%
-      ::  +pass:de:spec:pkcs8:
+      ::  +pass:de:spec:pkcs8: decode public key ASN.1
       ::
       ++  pass
         |=  a=spec:asn1
@@ -711,9 +720,18 @@
             ==
           ~
         (pass:de:der:pkcs1 (div len.i.t.seq.a 8) bit.i.t.seq.a)
-      ::  +ring:de:spec:pkcs8:
+      ::  +ring:de:spec:pkcs8: decode private key ASN.1
       ::
-      ++  ring  !!
+      ++  ring
+        |=  a=spec:asn1
+        ^-  (unit key:rsa)
+        ?.  ?=([%seq [%seq *] [%oct *] ~] a)
+          ~
+        ?.  ?&  ?=([[%obj *] [%nul ~] ~] seq.i.seq.a)
+                =(rsa:obj:asn1 obj.i.seq.i.seq.a)
+            ==
+          ~
+        (ring:de:der:pkcs1 [len oct]:i.t.seq.a)
       --
     --
   ::  |der:pkcs8: DER encoding for asymmetric keys
@@ -726,12 +744,12 @@
     ++  en
       |%
       ++  pass  |=(k=key:rsa `[len=@ud dat=@ux]`(en:^der (pass:en:spec k)))
-      ++  ring  !! ::|=(k=key:rsa `@ux`(en:^der (ring:spec k)))
+      ++  ring  |=(k=key:rsa `[len=@ud dat=@ux]`(en:^der (ring:en:spec k)))
       --
     ++  de
       |%
       ++  pass  |=([len=@ud dat=@ux] `(unit key:rsa)`(biff (de:^der len dat) pass:de:spec))
-      ++  ring  !! ::|=(a=@ `(unit key:rsa)`(biff (de:^der a) ring:de:spec))
+      ++  ring  |=([len=@ud dat=@ux] `(unit key:rsa)`(biff (de:^der len dat) ring:de:spec))
       --
     --
   ::  |pem:pkcs8: PEM encoding for asymmetric keys
@@ -744,12 +762,12 @@
     ++  en
       |%
       ++  pass  |=(k=key:rsa (en:^pem 'PUBLIC KEY' (pass:en:der k)))
-      ++  ring  !! ::|=(k=key:rsa (en:^pem 'PUBLIC KEY' (ring:en:der k)))
+      ++  ring  |=(k=key:rsa (en:^pem 'PRIVATE KEY' (ring:en:der k)))
       --
     ++  de
       |%
       ++  pass  |=(mep=wain (biff (de:^pem 'PUBLIC KEY' mep) pass:de:der))
-      ++  ring  !! ::|=(mep=wain (biff (de:^pem 'PRIVATE KEY' mep) ring:de:der))
+      ++  ring  |=(mep=wain (biff (de:^pem 'PRIVATE KEY' mep) ring:de:der))
       --
     --
   --
@@ -2165,10 +2183,48 @@
           'FwIDAQAB'
           '-----END PUBLIC KEY-----'
       ==
+    =/  pri=wain
+      :~  '-----BEGIN PRIVATE KEY-----'
+          'MIIEujANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDaMmnx2AArLlxLMMTg'
+          'P5pRspmxCgyEhYjYgWUT4A7QYIEyKDmrHHYggA9UhxKLl+M4u1Mee4hljD6zTqp5'
+          'vxAgpG+RlojCcDcvPlRSvGCH3qx7N1cIJIbsWd0gWyRxP7MbTQkv589F2U+O3VWD'
+          'ZveSd6jloAowg/I5PNxjn3RRNz6W5DceGBKI0XeflhCHbh3eRLZg5ShJdDXf5hGW'
+          'PE18GBdtX4Lv+A7yYXGmRp+GaCQgY15aWpP2gAhFr6A7HXe48CD4lv/yU9X1sZoW'
+          'oa/G8EynfFQBKXNgeIOe1wHkyI49FboGggYjmoMVJhFkGTL1ysTtYBiCq0+2DbXO'
+          '/HAXAgMBAAECggEAfSrsYaKyPhMjOLLqTWXPBcy5o7iLA76CiQh5TlR6ywiBNJ+k'
+          'rUbvcKdlo+y0M8XWv+Wdwd/Fl9NC6KNY4ew7uS37Hn5HR5sN3RkZUDjl+ys+sJRH'
+          'ZdFmYNEQK459MkYDXcbsXUHSQlRt8huAAZggrzHbfpY3Iiue2TzThIalOCy0Kxnn'
+          'WsrkYvp2JlVBt5TzTqg/VmHH/J7/81GZLkbSKKX/8fjWlXlYaiY5fSar38dgFmoK'
+          'dyrMuSLoUV2ZfKSPPyye9dRHjRLwH5rQX8s37nj09J7Z2n2HQfHgcIk6wv0LIJCK'
+          'aqqoTwo9DgFTPyrf4yHHXETJrEiU0f0QKCjUIQKBgQD6aLu9BHOy1gl6tuEK1p4W'
+          's5H+fwN+3sXIU37khXsfaibLqB/TOvUZaOamHlHSww+Avy5VEYA1SuS5lm4KvfmJ'
+          'jrNCl0IUHgP237NtO9OavG3ahVoTXr90gnpvxwfNHZCsSHy7Dn+sQrNYEIc1LwW9'
+          'cc+9e+dpxNnktlErSyyyEQKBgQDfEZCcOWZHDJW2j/UNAwueMgxrNDvX2q0I7+l/'
+          'gEd6pwNicjBhvnMsGPac9XwP2mozWkY5W46BwL0iKatsd54bCnWJJMfgC/EMiPoj'
+          'KuZvPZ1veUZ0dWT3Eu9OJjOfYoraxjGYWXcNEEW60VDZjF12odsTcOz3pj+5FeGq'
+          'PsjXpwKBgQDUBU3Acz6LU5LfJm1RQfrE+fJJa73H9FO+lIPCdgqTxMtocMfRj//r'
+          'LdjtGorpS2Oa/UT7nj/R38HeKbKuwb/BauP5JB0871Un+KzxdlBqmdThyztDX1v4'
+          'CGomrny6faf7V7zUnSgY8LjtfcEdlNzlVLIym/CKq7RaZMxBPftwIQKBgAIwRu3x'
+          'djpuOi3PXcUh6YRE03Bd09R7VcVHrU/N72WZq+PUYPskhjbBi/HgSrZRG0ejtBqt'
+          '9kj5niFurTrkNY3oXVzaGoftNhE8as/bhOVEgn3sf69202XFLsnigBEpQ1mAJk5r'
+          'WkqrhTOfCB8KTIR0dBTNv9VyMR/cwhkMgqXzAoGAGuwiOIO+mR+emZDt96EQkiL5'
+          'XhIayQvEUfdlO+eAUWhivLd0vmBDqYWwN+ufiKAhwTLpsyklDeVvBK3LNxZkswmB'
+          '0jbcVOU9dMQbs9yVlK7EGlCm+DcyJU7OpVOuGdj5N6ZxJxLHk7p/fZoN85RZYLOb'
+          'D+DO8nFRiUmqOp3t2VM='
+          '-----END PRIVATE KEY-----'
+      ==
     =/  k=key:rsa
       (need (ring:de:pem:pkcs1 kpem))
-    %-  expect-eq  !>
-      [pub (pass:en:pem:pkcs8 k)]
+    ;:  weld
+      %-  expect-eq  !>
+        [pub (pass:en:pem:pkcs8 k)]
+      %-  expect-eq  !>
+        [`k(sek ~) (pass:de:pem:pkcs8 pub)]
+      %-  expect-eq  !>
+        [pri (ring:en:pem:pkcs8 k)]
+      %-  expect-eq  !>
+        [`k (ring:de:pem:pkcs8 pri)]
+    ==
   ::
   ++  test-rsa-pem-zero
     :: intentional bad values to test significant trailing zeros

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -156,45 +156,37 @@
       %+  cook  |*(a=* `spec:asn1`a)
       :: ^-  $-(nail (like spec:asn1))
       ;~  pose
-        %+  stag  %int
-        %+  bass  256
-        %+  sear
-          |=  a=(list @)
-          ^-  (unit (list @))
-          ?~  a  ~
-          ?:  ?=([@ ~] a)  `a
-          ?.  =(0 i.a)  `a
-          ?.((gth i.t.a 127) ~ `t.a)
-        ;~(pfix (just `@`2) till)
-        ::
-        (stag %bit (boss 256 (cook tail ;~(pfix (just `@`3) till)))) :: XX test
-        (stag %oct (boss 256 ;~(pfix (just `@`4) till)))
-        (stag %nul (cold ~ ;~(plug (just `@`5) (just `@`0))))
-        (stag %obj (boss 256 ;~(pfix (just `@`6) till)))
-        ::
-        %+  stag  %seq
-        %+  sear
-          |=(a=(list @) (rust a (star decode))) :: XX plus? curr?
-        ;~(pfix (just `@`48) till)
-        ::
-        %+  stag  %set
-        %+  sear
-          |=(a=(list @) (rust a (star decode))) :: XX plus? curr?
-        ;~(pfix (just `@`49) till)
-        ::
-        %+  stag  %con
-        ;~  plug
-          %+  sear
-            |=  a=@
-            ^-  (unit [? @udC])
-            ?.  =(1 (cut 0 [7 1] a))  ~
-            :+  ~
-              =(1 (cut 0 [5 1] a))
-            (dis 0x1f a)
-          next
-          till
-        ==
+        (stag %int (bass 256 (sear int ;~(pfix (tag 2) till))))
+        (stag %bit (boss 256 (cook tail ;~(pfix (tag 3) till)))) :: XX test
+        (stag %oct (boss 256 ;~(pfix (tag 4) till)))
+        (stag %nul (cold ~ ;~(plug (tag 5) (tag 0))))
+        (stag %obj (boss 256 ;~(pfix (tag 6) till)))
+        (stag %seq (sear recur ;~(pfix (tag 48) till)))
+        (stag %set (sear recur ;~(pfix (tag 49) till)))
+        (stag %con ;~(plug (sear context next) till))
       ==
+    ::
+    ++  tag                                             :: tag byte
+      |=(a=@ (just a))
+    ::
+    ++  int                                             :: @u big endian
+      |=  a=(list @)
+      ^-  (unit (list @))
+      ?~  a  ~
+      ?:  ?=([@ ~] a)  `a
+      ?.  =(0 i.a)  `a
+      ?.((gth i.t.a 127) ~ `t.a)
+    ::
+    ++  recur
+      |=(a=(list @) (rust a (star decode))) :: XX plus? curr?
+    ::
+    ++  context                                         :: context-specific tag
+      |=  a=@
+      ^-  (unit [? @udC])
+      ?.  =(1 (cut 0 [7 1] a))  ~
+      :+  ~
+        =(1 (cut 0 [5 1] a))
+      (dis 0x1f a)
     ::
     ++  till                                            ::  len-prefixed bytes
       |=  tub/nail

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1797,6 +1797,7 @@
             test-rs256
             test-jwk
             test-jws
+            test-jws-fail
             test-csr
           ==
       ?~(out this ((slog out) this))
@@ -2322,6 +2323,88 @@
         :-  exp-ws
         (en-base64url (swp 3 (~(sign rs256 k) inp-ws)))
     ==
+  :: XX this test should fail, but doesn't.
+  :: XX fix the bug and make it fail.
+  ::
+  ::   urn:ietf:params:acme:error:malformed
+  ::   JWS verification error
+  ::
+  ++  test-jws-fail
+    =/  kpem=wain
+      :~  '-----BEGIN RSA PRIVATE KEY-----'
+          'MIIEogIBAAKCAQEAkmWLu+9gyzCbrGAHTFE6Hs7CtVQofONmpnhmE7JQkmdS+aph'
+          'WwZQfp9p6RU6vSoBaPXD96uqMXhvoOXz9/Ub5TRwLmQzfHZdksfU3pEZ8qFMikZU'
+          'p5v+CyBnLq9YR0VXN+/JVatmYb1hhC1k101X9m+IU3DR3U+kyCZnXuOd10xVX05H'
+          '0pXl+nI25bZyMJFnz1Xfw1rTnhtU/w7bgCWYdMii5jLkl5zfoY2gulpPu7QeYa4K'
+          '3fTqklDNFK7kQQ1l4O3461fbSO0cnG4t8Vk3026ageA54+Qx8O8UDi8k18Z1NF+B'
+          'pbPUZn55/InuZ8iGyHBZ4GRFIPG0iOdWM7gHCwIDAQABAoIBAAMQN/9SS6MJMULq'
+          'CsXHxyl5sHtXa/BgWLHP+j2/FtRX++EkR0s+ln2FobZa+l5Q9m4Ljn5PbqSMAFfM'
+          'Y6u0hNyj9om04oOl8bILl4Vcvqgp51oFvAEGOW15/o69+6bS3aBx7cqwfnsivInr'
+          'nIXDvHcyey3kh9WCKNx3rxNVgfuTCkw0+K2qXkMTh2c3Iz2efR2f78qbNWQcBe1+'
+          's83fABafxACYuXzfOYoO01GBCJnHrmXxJVePLXwxLkLeJHOQJQgPnagVbUH4kbUp'
+          'OLd9h1dOVYKpyVaxbQiAH3U/ekOXCCv18a47/PQSbueolzSzMzwVPSZdf+88lzuq'
+          'ZZyDXDECgYEAk5zt4cO7X+8IIeNXx8/2pztT9WmC1kqw4RtInoVXm62K1B0pPndW'
+          'm0nMVFEDuSwdn61G5amlaOT0dTFHlMFydC9H+1L5PMK7d+6ArSeAtMWoUhz+jkcO'
+          'B9KoMfZ9CtP2r5589zDGir8kaY8Fia5Z7TohpJDidmuumgDabl+qH+kCgYEA/eP6'
+          'lIGVHF8EIrfewjLM+8i1RE/hzItOpegrwDUVeYfZlPM59xUyC9REdgvmnTssxPcL'
+          '2+EB11wvcImSPLuwN0kXUkh9qZUkr9hvYlikALNH1f8WhCJ0kT6pUeA7LbjU4/bM'
+          'fsgcOh1POW2piIMERl1TuNRZg7JdKuCJKax3qtMCgYB2dxcifOc/0qIAMGgeX/Rf'
+          'ueljp03tlPvnbPIW5oSs19X27YBQNY44Cj4F3Q7T6WfM4k9nuYKacEUQWIBODgJA'
+          '5EEsniaQcOfrFGoIjQ9qBMdVPxe8L6I+/P0nO96Wdg4gW12HNIniiAw8+x9Co75f'
+          '+KtPW0ekKj9yMQUcV4I9IQKBgE06bruDmzbRFDH3WjQaPc4M5E6OOfH9IgRHVh+W'
+          'Rhz8nMu5HJWzBdEhVV3PCuwi1uBnAV112RiIOwnxXuFIejam7ggics8Fxe4TWPZC'
+          'Xki0QBKxEElLLcgMlnaITZf/1AovxU5/Uk6/IZ0nZV1X9RHuS4w6U6xCsiJbwH1D'
+          'r/bvAoGAV/Vx+Z2BD7QhmHofu98OMW6EGSjWMgOI4iXdcQ80Urz9akHkOM4KGojq'
+          'UDobbxxkJt1K5Dzux+vnp1siiIkcLdVdtMzqo7KcKYWonMqZmppNqIFCXQHscCRD'
+          'r6f1TIjlurYrazLAkRsmjE5uYM13/E1UdxplWSkdCbivIWqoqTM='
+          '-----END RSA PRIVATE KEY-----'
+      ==
+    =/  k=key:rsa
+      (need (ring:de:pem:pkcs1 kpem))
+    =/  kid=@t
+      'https://acme-staging-v02.api.letsencrypt.org/acme/acct/6336694'
+    =/  non=@t
+      'a5Pwh6GcuqRSvHTQouW96XNg3iiMORMkBf_wSLOf0M4'
+    =/  url=purl
+      :-  [sec=%.y por=~ hot=[%.y p=/org/letsencrypt/api/acme-staging-v02]]
+      :_  query=~
+      :-  ext=~
+      %+  weld
+        /acme/challenge
+      /'efJn0ywfjIi3M7yT-6H8Mdq85R2LnI8XsTG3DaaY8Gc'/'138087558'
+    =/  protected-header=json
+      :-  %o  %-  my  :~
+        nonce+s+non
+        url+s+(crip (en-purl:html url))
+        kid+s+kid
+      ==
+    =/  bod=json
+      [%o ~]
+    =/  exp=json
+      =/  payload=@t  'e30'
+      =/  protected=@t
+        %+  rap  3
+        :~  'eyJhbGci'
+            'OiJSUzI1NiIsImtpZCI6Imh0dHBzOi8vYWNtZS1zdGFnaW5nLXYwMi5hcGkubGV0c2'
+            'VuY3J5cHQub3JnL2FjbWUvYWNjdC82MzM2Njk0Iiwibm9uY2UiOiJhNVB3aDZHY3Vx'
+            'UlN2SFRRb3VXOTZYTmczaWlNT1JNa0JmX3dTTE9mME00IiwidXJsIjoiaHR0cHM6Ly'
+            '9hY21lLXN0YWdpbmctdjAyLmFwaS5sZXRzZW5jcnlwdC5vcmcvYWNtZS9jaGFsbGVu'
+            'Z2UvZWZKbjB5d2ZqSWkzTTd5VC02SDhNZHE4NVIyTG5JOFhzVEczRGFhWThHYy8xMz'
+            'gwODc1NTgifQ'
+        ==
+      =/  signature=@t
+        %+  rap  3
+        :~  'ZuQgIjhNY3UbmnPwBfleJRrmc2CCrwQ2eKkw1594_MaBwGZdSg6'
+            'UaDljoJ9SKXpd_2-glsQuZG1YgpFzZIk66rip6D80Xu0ZJg9AR8KEqLSMHavONj4CR'
+            'c6USw9Ov3LnfQgvt9W5xb8rc2NNl-ESCNRKkOBmwhNNM1kiOY1AbQa8Ko0uNFHSn3a'
+            'Rm_PLGlaTcP-k8j6ZlyOBCp3CuyxBJ68I92cWH3aSEHf4mYQo6IE0qqhk6Dv1Cyayt'
+            '7Ds8ocmhvESxo-iiiecBTkEaw_YCYJle_Re6F2hyyEnLVULowMJdyrYvb2YXjjj9d9'
+            '9m3SSTy_L3kTohpktQxRSwWlmcg'
+        ==
+      [%o (my payload+s+payload protected+s+protected signature+s+signature ~)]
+    %-  expect-eq  !>
+      :-  exp
+      (sign:jws k protected-header bod)
   ::
   ++  test-csr
     =/  kpem=wain

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1189,18 +1189,23 @@
   [~ this(+<+ u.old)]
 ::
 ++  rekey                             :: XX do something about this
+  |=  eny=@
   =|  i=@
   |-  ^-  key:rsa
-  =/  k  (new-key:rsa 2.048 eny.bow)
+  =/  k  (new-key:rsa 2.048 eny)
   =/  m  (met 0 n.pub.k)
   ?:  =(0 (mod m 8))  k
   ~&  [%key iter=i width=m]
-  $(i +(i), eny.bow +(eny.bow))
+  $(i +(i), eny +(eny))
 ::
 ++  init
   =/  url
     'https://acme-staging-v02.api.letsencrypt.org/directory'
-  directory(bas (need (de-purl:html url)), act [rekey ~], cey rekey)
+  %=  directory
+    bas  (need (de-purl:html url))
+    act  [(rekey (shas %act eny.bow)) ~]
+    cey  (rekey (shas %act eny.bow))
+  ==
   :: XX wait for DNS binding confirmation?
   :: (add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
 ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1510,8 +1510,7 @@
     ^+  this
     ~|  %install-effect-fail
     ?>  ?=(^ liv)
-    :: XX use pkcs8
-    =/  key=wain  (ring:en:pem:pkcs1 key.u.liv)
+    =/  key=wain  (ring:en:pem:pkcs8 key.u.liv)
     (emit %rule /install %cert `[key `wain`cer.u.liv])
   :: +get-authz: get next ACME service domain authorization object
   ::
@@ -2021,7 +2020,9 @@
         'n5Z5MqkYhlMI3J1tPRTp1nEt9fyGspBOO05gi148Qasp+3N+svqKomoQglNoAxU='
         '-----END CERTIFICATE-----'
     ==
-  (emit %rule /install %cert `[key cert])
+  =/  k=key:rsa  (need (ring:de:pem:pkcs1 key))
+  =/  k8=wain  (ring:en:pem:pkcs8 k)
+  (emit %rule /install %cert `[k8 cert])
 :: +poke-path: for debugging
 ::
 ++  poke-path

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -75,14 +75,14 @@
 ::
 ::  |asn1: small selection of types and constants for ASN.1
 ::
-::  a minimal representation of some basic ASN.1 types,
-::  created to support PKCS keys, digests, and cert requests
+::    A minimal representation of some basic ASN.1 types,
+::    created to support PKCS keys, digests, and cert requests.
 ::
 ++  asn1
   |%
   ::  +bespoke:asn1: context-specific, generic ASN.1 tag type
   ::
-  ::  note that explicit implies constructed (ie, bit 5 is set in DER)
+  ::    Note that *explicit* implies *constructed* (ie, bit 5 is set in DER).
   ::
   +=  bespoke
     ::  imp: & is implicit, | is explicit
@@ -94,16 +94,16 @@
   +=  spec
     $%  ::  %int: arbitrary-sized, unsigned integers
         ::
-        ::  unsigned integers, represented as having a positive sign.
-        ::  negative integers would be two's complement in DER,
-        ::  but we don't need them.
+        ::    Unsigned integers, represented as having a positive sign.
+        ::    Negative integers would be two's complement in DER,
+        ::    but we don't need them.
         ::
         [%int int=@u]
         ::  %bit: very minimal support for bit strings
         ::
-        ::  specifically, values must already be padded and byte-aligned.
-        ::  note that leading zeros are significant in ASN.1 bit strings,
-        ::  so atomic encoding would be insufficient for complete support.
+        ::    Specifically, values must already be padded and byte-aligned.
+        ::    Note that leading zeros are significant in ASN.1 bit strings,
+        ::    so atomic encoding would be insufficient for complete support.
         ::
         [%bit bit=@ux]
         ::  %oct: octets in little-endian byte order
@@ -114,8 +114,8 @@
         [%nul ~]
         ::  %obj: object identifiers, pre-packed
         ::
-        ::  object identifiers are technically a sequence of integers,
-        ::  represented here in their already-encoded form.
+        ::    Object identifiers are technically a sequence of integers,
+        ::    represented here in their already-encoded form.
         ::
         [%obj obj=@ux]
         ::  %seq: a list of specs
@@ -123,15 +123,15 @@
         [%seq seq=(list spec)]
         ::  %set: a logical set of specs
         ::
-        ::  implemented here as a list for the sake of simplicity.
-        ::  must be already deduplicated and sorted!
+        ::    Implemented here as a list for the sake of simplicity.
+        ::    must be already deduplicated and sorted!
         ::
         [%set set=(list spec)]
         ::  %con: context-specific
         ::
-        ::  general supported for context-specific tags.
-        ::  bes: custom tag number, implicit or explicit
-        ::  con: already-encoded bytes
+        ::    General support for context-specific tags.
+        ::    bes: custom tag number, implicit or explicit
+        ::    con: already-encoded bytes
         ::
         [%con bes=bespoke con=(list @D)]
     ==
@@ -150,9 +150,9 @@
   --
 ::  |der: distinguished encoding rules for ASN.1
 ::
-::  DER is a tag-length-value binary encoding for ASN.1, designed
-::  so that there is only one (distinguished) valid encoding for an
-::  instance of a type.
+::    DER is a tag-length-value binary encoding for ASN.1, designed
+::    so that there is only one (distinguished) valid encoding for an
+::    instance of a type.
 ::
 ++  der
   |%
@@ -291,11 +291,14 @@
       ?~  q.tub
         (fail tub)
       ::  fuz: first byte - length, or length of the length
+      ::
       =*  fuz  i.q.tub
       ::  nex: offset of value bytes from fuz
       ::  len: length of value bytes
+      ::
       =+  ^-  [nex=@ len=@]
         ::  faz: meaningful bits in fuz
+        ::
         =/  faz  (end 0 7 fuz)
         ?:  =(0 (cut 0 [7 1] fuz))
           [0 faz]
@@ -305,17 +308,19 @@
           ==
         (fail tub)
       ::  zuf: value bytes
+      ::
       =/  zuf  (swag [nex len] t.q.tub)
       ?.  =(len (lent zuf))
         (fail tub)
       ::  zaf:  product nail
+      ::
       =/  zaf  [p.p.tub (add +(nex) q.p.tub)]
       [zaf `[zuf zaf (slag (add nex len) t.q.tub)]]
     --
   --
 ::  |rsa: primitive, textbook RSA
 ::
-::  unpadded, unsafe, unsuitable for encryption!
+::    Unpadded, unsafe, unsuitable for encryption!
 ::
 ++  rsa
   |%
@@ -323,8 +328,10 @@
   ::
   +=  key
     $:  ::  pub:  public parameters (n=modulus, e=pub-exponent)
+        ::
         pub=[n=@ux e=@ux]
         ::  sek:  secret parameters (d=private-exponent, p/q=primes)
+        ::
         sek=(unit [d=@ux p=@ux q=@ux])
     ==
   ::  +elcm:rsa: carmichael totient
@@ -332,7 +339,7 @@
   ++  elcm
     |=  [a=@ b=@]
     (div (mul a b) d:(egcd a b))
-  ::  +new-key:rsa
+  ::  +new-key:rsa: write somethingXXX
   ::
   ++  new-key
     =/  e  `@ux`65.537
@@ -346,7 +353,7 @@
     [[n e] `[d p q]]
   ::  +en:rsa: primitive RSA encryption
   ::
-  ::  ciphertext = message^e (mod n)
+  ::    ciphertext = message^e (mod n)
   ::
   ++  en
     |=  [m=@ k=key]
@@ -355,7 +362,7 @@
     (~(exp fo n.pub.k) e.pub.k m)
   ::  +de:rsa: primitive RSA decryption
   ::
-  ::  message = ciphertext^d (mod e)
+  ::    message = ciphertext^d (mod e)
   ::
   ++  de
     |=  [m=@ k=key]
@@ -371,7 +378,7 @@
   |_  k=key:rsa
   ::  +emsa:rs256: message digest
   ::
-  ::  padded, DER encoded sha-256 hash (EMSA-PKCS1-v1_5)
+  ::    Padded, DER encoded sha-256 hash (EMSA-PKCS1-v1_5).
   ::
   ++  emsa
     |=  m=@
@@ -390,14 +397,14 @@
     (flop (weld [0x0 0x1 ps] [0x0 t]))  :: note: big-endian
   ::  +sign:rs256: sign message
   ::
-  ::  an RSA signature is the primitive decryption of the message hash
+  ::    An RSA signature is the primitive decryption of the message hash.
   ::
   ++  sign
     |=(m=@ (de:rsa (emsa m) k))
   ::  +verify:rs256: verify signature
   ::
-  ::  RSA signature verification confirms that the primitive encryption
-  ::  of the signature matches the message hash
+  ::    RSA signature verification confirms that the primitive encryption
+  ::    of the signature matches the message hash.
   ::
   ++  verify
     |=  [s=@ m=@]
@@ -405,8 +412,8 @@
   --
 ::  |pem: generic PEM implementation (rfc7468)
 ::
-::  PEM is the base64 encoding of DER encoded data, with BEGIN and
-::  END labels indicating some type.
+::    PEM is the base64 encoding of DER encoded data, with BEGIN and
+::    END labels indicating some type.
 ::
 ++  pem
   |%
@@ -511,7 +518,7 @@
     --
   ::  |der:pkcs1: DER encoding for RSA keys
   ::
-  ::  en(coding) and de(coding) for public (pass) and private (ring) keys
+  ::    En(coding) and de(coding) for public (pass) and private (ring) keys.
   ::
   ++  der
     |%
@@ -528,7 +535,7 @@
     --
   ::  |pem:pkcs1: PEM encoding for RSA keys
   ::
-  ::  en(coding) and de(coding) for public (pass) and private (ring) keys
+  ::    En(coding) and de(coding) for public (pass) and private (ring) keys.
   ::
   ++  pem
     |%
@@ -546,7 +553,7 @@
   --
 ::  |pkcs8: asymmetric cryptography (rfc5208)
 ::
-::  only implemented for RSA keys
+::    RSA-only for now.
 ::
 ++  pkcs8
   |%
@@ -592,8 +599,8 @@
     --
   ::  |der:pkcs8: DER encoding for asymmetric keys
   ::
-  ::  en(coding) and de(coding) for public (pass) and private (ring) keys
-  ::  RSA-only for now
+  ::    En(coding) and de(coding) for public (pass) and private (ring) keys.
+  ::    RSA-only for now.
   ::
   ++  der
     |%
@@ -610,8 +617,8 @@
     --
   ::  |pem:pkcs8: PEM encoding for asymmetric keys
   ::
-  ::  en(coding) and de(coding) for public (pass) and private (ring) keys
-  ::  RSA-only for now
+  ::    En(coding) and de(coding) for public (pass) and private (ring) keys.
+  ::    RSA-only for now.
   ::
   ++  pem
     |%
@@ -629,7 +636,7 @@
   --
 ::  |pkcs10: certificate signing requests (rfc2986)
 ::
-::  only implemented for RSA keys with subject-alternate names
+::    Only implemented for RSA keys with subject-alternate names.
 ::
 ++  pkcs10
   =>  |%
@@ -663,8 +670,10 @@
             [%int 0]
             [%seq ~]
             (pass:en:spec:pkcs8 key)
-            :+  %con  [| 0]
-            =-  ~(ren raw:en:^der -)
+            :+  %con
+              `bespoke:asn1`[| 0]
+            %~  ren
+              raw:en:^der
             :~  %seq
                 [%obj csr-ext:obj:asn1]
                 :~  %set
@@ -682,7 +691,7 @@
         %+  turn  hot
         :: implicit, context-specific tag #2 (IA5String)
         :: XX sanitize string?
-        |=(h=(list @t) [%con [& 2] (rip 3 (join '.' h))])
+        |=(h=(list @t) [%con `bespoke:asn1`[& 2] (rip 3 (join '.' h))])
       --
     ::  |de:spec:pkcs10: ASN.1 decoding for certificate signing requests
     ++  de  !!
@@ -704,7 +713,7 @@
   --
 ::  +en-json-sort: json encoding with sorted object keys
 ::
-::  to be included in %zuse, with sorting optional?
+::    to be included in %zuse, with sorting optional?
 ::
 ++  en-json-sort                                 ::  XX rename
   |^  |=([sor=$-(^ ?) val=json] (apex val sor ""))
@@ -757,8 +766,8 @@
 ::
 ::  |jwk: json representations of cryptographic keys (rfc7517)
 ::
-::  url-safe base64 encoding of key parameters in big-endian byte order
-::  RSA-only for now
+::    Url-safe base64 encoding of key parameters in big-endian byte order.
+::    RSA-only for now
 ::
 ++  jwk
   |%
@@ -853,7 +862,7 @@
   --
 ::  |jws: json web signatures (rfc7515)
 ::
-::  flattened signature only
+::    Note: flattened signature form only.
 ::
 ++  jws
   |%
@@ -878,15 +887,15 @@
       [%o (~(put by p.pro) %alg s+'RS256')]
     ::  +encode:sign:jws: encode json for signing
     ::
-    ::  alphabetically sort object keys, url-safe base64 encode
-    ::  the serialized json
+    ::    Alphabetically sort object keys, url-safe base64 encode
+    ::    the serialized json.
     ::
     ++  encode
       |=  jon=json
       (en-base64url (crip (en-json-sort aor jon)))
     ::  +sign:sign:jws: compute signature
     ::
-    ::  url-safe base64 encode in big-endian byte order
+    ::    Url-safe base64 encode in big-endian byte order.
     ::
     ++  sign
       |=  [protect=cord payload=cord]
@@ -899,7 +908,7 @@
   --
 ::  +eor: explicit sort order comparator
 ::
-::  lookup :a and :b in :lit, pass their indices to :com
+::    Lookup :a and :b in :lit, and pass their indices to :com.
 ::
 ++  eor
   |=  [com=$-([@ @] ?) lit=(list)]

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -703,6 +703,7 @@
         |=  k=key:rsa
         ^-  spec:asn1
         :~  %seq
+            [%int 0]
             [%seq [[%obj rsa:obj:asn1] [%nul ~] ~]]
             [%oct (ring:en:der:pkcs1 k)]
         ==
@@ -728,13 +729,13 @@
       ++  ring
         |=  a=spec:asn1
         ^-  (unit key:rsa)
-        ?.  ?=([%seq [%seq *] [%oct *] ~] a)
+        ?.  ?=([%seq [%int %0] [%seq *] [%oct *] ~] a)
           ~
-        ?.  ?&  ?=([[%obj *] [%nul ~] ~] seq.i.seq.a)
-                =(rsa:obj:asn1 obj.i.seq.i.seq.a)
+        ?.  ?&  ?=([[%obj *] [%nul ~] ~] seq.i.t.seq.a)
+                =(rsa:obj:asn1 obj.i.seq.i.t.seq.a)
             ==
           ~
-        (ring:de:der:pkcs1 [len oct]:i.t.seq.a)
+        (ring:de:der:pkcs1 [len oct]:i.t.t.seq.a)
       --
     --
   ::  |der:pkcs8: DER encoding for asymmetric keys
@@ -2351,32 +2352,32 @@
       ==
     =/  pri=wain
       :~  '-----BEGIN PRIVATE KEY-----'
-          'MIIEujANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDaMmnx2AArLlxLMMTg'
-          'P5pRspmxCgyEhYjYgWUT4A7QYIEyKDmrHHYggA9UhxKLl+M4u1Mee4hljD6zTqp5'
-          'vxAgpG+RlojCcDcvPlRSvGCH3qx7N1cIJIbsWd0gWyRxP7MbTQkv589F2U+O3VWD'
-          'ZveSd6jloAowg/I5PNxjn3RRNz6W5DceGBKI0XeflhCHbh3eRLZg5ShJdDXf5hGW'
-          'PE18GBdtX4Lv+A7yYXGmRp+GaCQgY15aWpP2gAhFr6A7HXe48CD4lv/yU9X1sZoW'
-          'oa/G8EynfFQBKXNgeIOe1wHkyI49FboGggYjmoMVJhFkGTL1ysTtYBiCq0+2DbXO'
-          '/HAXAgMBAAECggEAfSrsYaKyPhMjOLLqTWXPBcy5o7iLA76CiQh5TlR6ywiBNJ+k'
-          'rUbvcKdlo+y0M8XWv+Wdwd/Fl9NC6KNY4ew7uS37Hn5HR5sN3RkZUDjl+ys+sJRH'
-          'ZdFmYNEQK459MkYDXcbsXUHSQlRt8huAAZggrzHbfpY3Iiue2TzThIalOCy0Kxnn'
-          'WsrkYvp2JlVBt5TzTqg/VmHH/J7/81GZLkbSKKX/8fjWlXlYaiY5fSar38dgFmoK'
-          'dyrMuSLoUV2ZfKSPPyye9dRHjRLwH5rQX8s37nj09J7Z2n2HQfHgcIk6wv0LIJCK'
-          'aqqoTwo9DgFTPyrf4yHHXETJrEiU0f0QKCjUIQKBgQD6aLu9BHOy1gl6tuEK1p4W'
-          's5H+fwN+3sXIU37khXsfaibLqB/TOvUZaOamHlHSww+Avy5VEYA1SuS5lm4KvfmJ'
-          'jrNCl0IUHgP237NtO9OavG3ahVoTXr90gnpvxwfNHZCsSHy7Dn+sQrNYEIc1LwW9'
-          'cc+9e+dpxNnktlErSyyyEQKBgQDfEZCcOWZHDJW2j/UNAwueMgxrNDvX2q0I7+l/'
-          'gEd6pwNicjBhvnMsGPac9XwP2mozWkY5W46BwL0iKatsd54bCnWJJMfgC/EMiPoj'
-          'KuZvPZ1veUZ0dWT3Eu9OJjOfYoraxjGYWXcNEEW60VDZjF12odsTcOz3pj+5FeGq'
-          'PsjXpwKBgQDUBU3Acz6LU5LfJm1RQfrE+fJJa73H9FO+lIPCdgqTxMtocMfRj//r'
-          'LdjtGorpS2Oa/UT7nj/R38HeKbKuwb/BauP5JB0871Un+KzxdlBqmdThyztDX1v4'
-          'CGomrny6faf7V7zUnSgY8LjtfcEdlNzlVLIym/CKq7RaZMxBPftwIQKBgAIwRu3x'
-          'djpuOi3PXcUh6YRE03Bd09R7VcVHrU/N72WZq+PUYPskhjbBi/HgSrZRG0ejtBqt'
-          '9kj5niFurTrkNY3oXVzaGoftNhE8as/bhOVEgn3sf69202XFLsnigBEpQ1mAJk5r'
-          'WkqrhTOfCB8KTIR0dBTNv9VyMR/cwhkMgqXzAoGAGuwiOIO+mR+emZDt96EQkiL5'
-          'XhIayQvEUfdlO+eAUWhivLd0vmBDqYWwN+ufiKAhwTLpsyklDeVvBK3LNxZkswmB'
-          '0jbcVOU9dMQbs9yVlK7EGlCm+DcyJU7OpVOuGdj5N6ZxJxLHk7p/fZoN85RZYLOb'
-          'D+DO8nFRiUmqOp3t2VM='
+          'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDaMmnx2AArLlxL'
+          'MMTgP5pRspmxCgyEhYjYgWUT4A7QYIEyKDmrHHYggA9UhxKLl+M4u1Mee4hljD6z'
+          'Tqp5vxAgpG+RlojCcDcvPlRSvGCH3qx7N1cIJIbsWd0gWyRxP7MbTQkv589F2U+O'
+          '3VWDZveSd6jloAowg/I5PNxjn3RRNz6W5DceGBKI0XeflhCHbh3eRLZg5ShJdDXf'
+          '5hGWPE18GBdtX4Lv+A7yYXGmRp+GaCQgY15aWpP2gAhFr6A7HXe48CD4lv/yU9X1'
+          'sZoWoa/G8EynfFQBKXNgeIOe1wHkyI49FboGggYjmoMVJhFkGTL1ysTtYBiCq0+2'
+          'DbXO/HAXAgMBAAECggEAfSrsYaKyPhMjOLLqTWXPBcy5o7iLA76CiQh5TlR6ywiB'
+          'NJ+krUbvcKdlo+y0M8XWv+Wdwd/Fl9NC6KNY4ew7uS37Hn5HR5sN3RkZUDjl+ys+'
+          'sJRHZdFmYNEQK459MkYDXcbsXUHSQlRt8huAAZggrzHbfpY3Iiue2TzThIalOCy0'
+          'KxnnWsrkYvp2JlVBt5TzTqg/VmHH/J7/81GZLkbSKKX/8fjWlXlYaiY5fSar38dg'
+          'FmoKdyrMuSLoUV2ZfKSPPyye9dRHjRLwH5rQX8s37nj09J7Z2n2HQfHgcIk6wv0L'
+          'IJCKaqqoTwo9DgFTPyrf4yHHXETJrEiU0f0QKCjUIQKBgQD6aLu9BHOy1gl6tuEK'
+          '1p4Ws5H+fwN+3sXIU37khXsfaibLqB/TOvUZaOamHlHSww+Avy5VEYA1SuS5lm4K'
+          'vfmJjrNCl0IUHgP237NtO9OavG3ahVoTXr90gnpvxwfNHZCsSHy7Dn+sQrNYEIc1'
+          'LwW9cc+9e+dpxNnktlErSyyyEQKBgQDfEZCcOWZHDJW2j/UNAwueMgxrNDvX2q0I'
+          '7+l/gEd6pwNicjBhvnMsGPac9XwP2mozWkY5W46BwL0iKatsd54bCnWJJMfgC/EM'
+          'iPojKuZvPZ1veUZ0dWT3Eu9OJjOfYoraxjGYWXcNEEW60VDZjF12odsTcOz3pj+5'
+          'FeGqPsjXpwKBgQDUBU3Acz6LU5LfJm1RQfrE+fJJa73H9FO+lIPCdgqTxMtocMfR'
+          'j//rLdjtGorpS2Oa/UT7nj/R38HeKbKuwb/BauP5JB0871Un+KzxdlBqmdThyztD'
+          'X1v4CGomrny6faf7V7zUnSgY8LjtfcEdlNzlVLIym/CKq7RaZMxBPftwIQKBgAIw'
+          'Ru3xdjpuOi3PXcUh6YRE03Bd09R7VcVHrU/N72WZq+PUYPskhjbBi/HgSrZRG0ej'
+          'tBqt9kj5niFurTrkNY3oXVzaGoftNhE8as/bhOVEgn3sf69202XFLsnigBEpQ1mA'
+          'Jk5rWkqrhTOfCB8KTIR0dBTNv9VyMR/cwhkMgqXzAoGAGuwiOIO+mR+emZDt96EQ'
+          'kiL5XhIayQvEUfdlO+eAUWhivLd0vmBDqYWwN+ufiKAhwTLpsyklDeVvBK3LNxZk'
+          'swmB0jbcVOU9dMQbs9yVlK7EGlCm+DcyJU7OpVOuGdj5N6ZxJxLHk7p/fZoN85RZ'
+          'YLObD+DO8nFRiUmqOp3t2VM='
           '-----END PRIVATE KEY-----'
       ==
     =/  k=key:rsa

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1567,7 +1567,7 @@
   ::
   ++  finalize-trial
     ^+  this
-    ~|  %test-trial-effect-fail
+    ~|  %finalize-trial-effect-fail
     ?.  ?=(^ reg.act)  ~|(%no-account !!)
     ?.  ?=(^ rod)      ~|(%no-active-order !!)
     ?.  ?=(^ active.aut.u.rod)  ~|(%no-active-authz !!)

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -539,7 +539,7 @@
     ==
   --
 ::
-++  jwk
+++  jwk                                                 :: rfc7517
   |%
   ++  en
     |%
@@ -604,12 +604,47 @@
         q+(cu de-base64url so)
       ==
     --
+  ::
+  ++  thumb                                             :: rfc7638
+    |%
+    ++  ring  !!
+    ++  pass
+      |=  k=key:rsa
+      (en-base64url (shax (crip (en-json-sort aor (pass:en k)))))
+    --
   --
 ::
-++  thumbprint
-  |=  jon=json
-  :: XX restrict keys to canonical set
-  (en-base64url (shax `@`(crip `tape`(en-json-sort aor jon))))
+++  jws                                                 :: rfc7515
+  |%
+  ++  sign
+    |=  [k=key:rsa pro=json lod=json]
+    |^  ^-  json
+        =.  pro  header
+        =/  protect=cord  (encode pro)
+        =/  payload=cord  (encode lod)
+        :-  %o  %-  my  :~
+          protected+s+protect
+          payload+s+payload
+          signature+s+(sign protect payload)
+        ==
+    ::
+    ++  header
+      ?>  ?=([%o *] pro)
+      ^-  json
+      [%o (~(put by p.pro) %alg s+'RS256')]
+    ::
+    ++  encode
+      |=  jon=json
+      (en-base64url (crip (en-json-sort aor jon)))
+    ::
+    ++  sign
+      |=  [protect=cord payload=cord]
+      %-  en-base64url
+      (swp 3 (~(sign rs256 k) (rap 3 ~[protect '.' payload])))
+    --
+  ::
+  ++  verify  !!
+  --
 ::
 ++  eor                                               ::  explicit order
   |=  [com=$-([@ @] ?) lit=(list)]
@@ -767,42 +802,29 @@
 ++  abet
   [(flop mov) this(mov ~)]
 ::
-++  jws-body
-  |=  [url=purl bod=json]
-  ^-  octs
-  :: ?>  ?=(^ key.act)
-  =*  enc  (corl en-base64url (corl crip (cury en-json-sort aor)))
-  =/  payload=cord  (enc bod)
-  =/  protect=cord
-    %-  enc
+++  request
+  |=  [wir=wire url=purl bod=(unit json)]
+  |^  ^-  card
+      [%hiss wir [~ ~] %httr %hiss url moth]
+  ::
+  ++  moth
+    ?~  bod
+      [%get ~ ~]
+    [%post (my content-type+['application/jose+json' ~] ~) `body]
+  ::
+  ++  body
+    ?>  ?=(^ bod)
+    ^-  octs
+    =;  pro=json
+      (as-octt:mimes:html (en-json:html (sign:jws key.act pro u.bod)))
     :-  %o  %-  my  :~
-      alg+s+'RS256'
       nonce+s+non
       url+s+(crip (en-purl:html url))
       ?^  reg.act
         kid+s+kid.u.reg.act
       jwk+(pass:en:jwk key.act)
     ==
-  %-  (corl as-octt:mimes:html en-json:html)
-  ^-  json
-  :-  %o  %-  my  :~
-    protected+s+protect
-    payload+s+payload
-    :+  %signature  %s
-    %-  en-base64url
-    %+  swp  3
-    (~(sign rs256 key.act) (rap 3 ~[protect '.' payload]))
-  ==
-::
-++  request
-  |=  [wir=wire url=purl bod=(unit json)]
-  ^-  card
-  =/  lod
-    ?~  bod
-      [%get ~ ~]
-    =/  hed  (my content-type+['application/jose+json' ~] ~)
-    [%post hed `(jws-body url u.bod)]
-  [%hiss wir [~ ~] %httr %hiss url lod]
+  --
 ::
 ++  directory
   (emit (request /acme/dir/(scot %p our.bow) bas ~))
@@ -884,7 +906,7 @@
       :+  ~
         /text/plain
       %-  as-octs:mimes:html
-      (rap 3 [tok.cal '.' (thumbprint (pass:en:jwk key.act)) ~])
+      (rap 3 [tok.cal '.' (pass:thumb:jwk key.act) ~])
       ::
       %^    request
           /acme/cal/(scot %ud i)/der/(scot %ud ider)
@@ -1571,7 +1593,7 @@
         (pass:en:jwk k)
       %-  expect-eq  !>
         :-  'NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs'
-        (thumbprint jk)
+        (pass:thumb:jwk k)
     ==
   ::
   ++  test-jws

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -402,6 +402,37 @@
         ::
         sek=(unit [d=@ux p=@ux q=@ux])
     ==
+  ::  +ramp: make rabin-miller probabilistic prime
+  ::
+  ::    XX replace +ramp:number?
+  ::    a: bitwidth
+  ::    b: snags (XX small primes to check divisibility?)
+  ::    c: entropy
+  ::
+  ++  ramp
+    |=  [a=@ b=(list @) c=@]
+    =.  c  (shas %ramp c)
+    :: XX what is this value?
+    ::
+    =|  d=@
+    |-  ^-  @ux
+    :: XX what is this condition?
+    ::
+    ?:  =((mul 100 a) d)
+      ~|(%ar-ramp !!)
+    :: e: prime candidate
+    ::
+    ::   Sets low bit, as prime must be odd.
+    ::   Sets high bit, as +raw:og only gives up to :a bits.
+    ::
+    =/  e  :(con 1 (lsh 0 (dec a) 1) (~(raw og c) a))
+    :: XX what algorithm is this modular remainder check?
+    ::
+    ?:  ?&  (levy b |=(f/@ !=(1 (mod e f))))
+            (pram:number e)
+        ==
+      e
+    $(c +(c), d (shax d))
   ::  +elcm:rsa: carmichael totient
   ::
   ++  elcm
@@ -414,8 +445,8 @@
     |=  [wid=@ eny=@]
     ^-  key
     =/  diw  (rsh 0 1 wid)
-    =/  p=@ux  (ramp:number diw [3 5 ~] eny)
-    =/  q=@ux  (ramp:number diw [3 5 ~] +(eny))
+    =/  p=@ux  (ramp diw [3 5 ~] eny)
+    =/  q=@ux  (ramp diw [3 5 ~] +(eny))
     =/  n=@ux  (mul p q)
     =/  d=@ux  (~(inv fo (elcm (dec p) (dec q))) e)
     [[n e] `[d p q]]

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1172,6 +1172,7 @@
 +=  card
   $%  [%hiss wire [~ ~] %httr %hiss hiss:eyre]
       [%well wire path (unit mime)]
+      [%rule wire %cert (unit [wain wain])]
   ==
 :: +nonce-next: next effect to emit upon receiving nonce
 ::
@@ -1501,6 +1502,15 @@
     ?.  ?=(^ rod)      ~|(%no-active-order !!)
     =/  hed  (my accept+['applicate/x-pem-file' ~] ~)
     (emit (request /acme/certificate/(scot %da now.bow) url %get hed ~))
+  :: +install: tell %eyre about our certificate
+  ::
+  ++  install
+    ^+  this
+    ~|  %install-effect-fail
+    ?>  ?=(^ liv)
+    :: XX use pkcs8
+    =/  key=wain  (ring:en:pem:pkcs1 key.u.liv)
+    (emit %rule /install %cert `[key `wain`cer.u.liv])
   :: +get-authz: get next ACME service domain authorization object
   ::
   ++  get-authz
@@ -1743,11 +1753,10 @@
     =/  cer=wain  (to-wain:format q:(need r.rep))
     =/  fig=config
       :: XX expiration date
-      [dom.u.rod key.u.rod cer *@da ego.u.rod]
+      [dom.u.rod key.u.rod cer (add now.bow ~d90) ego.u.rod]
     =?  fig.hit  ?=(^ liv)  [u.liv fig.hit]
-    this(liv `fig, rod ~)
-    :: XX send configuration to eyre
-    :: XX other subscribers?
+    :: XX set renewal timer
+    install:effect(liv `fig, rod ~)
   :: +get-authz: accept ACME service authorization object
   ::
   ++  get-authz
@@ -1864,6 +1873,11 @@
     %finalize-trial  finalize-trial:event
     ::  XX delete-trial?
   ==
+:: +poke-acme-order: create new order for a set of domains
+::
+++  poke-acme-order
+  |=(a=(set turf) abet:(add-order ~(tap in a)))
+:: +poke-noun: for debugging
 ::
 ++  poke-noun
   |=  a=*
@@ -1882,8 +1896,10 @@
     %final  finalize-order:effect
     %poll   check-order:effect
     %our    (add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
+    %rule   install:effect
     %test   test
   ==
+:: +poke-path: for debugging
 ::
 ++  poke-path
   |=(a=path abet:(add-order a ~))

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -287,7 +287,13 @@
   ::  +de:der: decode atom to +spec:asn1
   ::
   ++  de
-    =<  |=([len=@ud dat=@ux] `(unit spec:asn1)`(rush dat parse))
+    =<  |=  [len=@ud dat=@ux]
+        ^-  (unit spec:asn1)
+        :: XX refactor into +parse
+        =/  a  (rip 3 dat)
+        =/  b  ~|  %der-invalid-len
+            (sub len (lent a))
+        (rust `(list @D)`(weld a (reap b 0)) parse)
     |%
     ::  +parse:de:der: DER parser combinator
     ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1720,6 +1720,9 @@
   =<  abet
   ?+  a
       ~&(+<+.this this)
+    %dbug  ~&  [%private (ring:en:pem:pkcs1 key.act)]
+           ~&  [%public (pass:en:pem:pkcs1 key.act)]
+           this
     %init   init
     %reg    register:effect
     %order  new-order:effect

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1855,6 +1855,14 @@
   ~&  [%sigh-tang wir]
   :: XX take evasive action
   [((slog saw) ~) this]
+:: +sigh-recoverable-error: handle http rate-limit response
+::
+++  sigh-recoverable-error
+  |=  [wir=wire %429 %rate-limit lim=(unit @da)]
+  ^-  (quip move _this)
+  ~&  [%sigh-recoverable wir lim]
+  :: XX retry
+  [~ this]
 :: +sigh-httr: accept http response
 ::
 ++  sigh-httr

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -62,38 +62,41 @@
   ::  +parse:base64: parse base64 cord to +octs
   ::
   ++  parse
-    %+  sear  reduce
-    ;~  plug
-      %-  plus  ;~  pose
-        (cook |=(a=@ (sub a 'A')) (shim 'A' 'Z'))
-        (cook |=(a=@ (sub a 'G')) (shim 'a' 'z'))
-        (cook |=(a=@ (add a 4)) (shim '0' '9'))
-        (cold 62 (just ?:(url '-' '+')))
-        (cold 63 (just ?:(url '_' '/')))
-      ==
-      (stun 0^2 (cold %0 tis))
-    ==
-  ::  +reduce: reduce, measure, and swap base64 digits
-  ::
-  ++  reduce
-    |=  [dat=(list @) dap=(list @)]
-    ^-  (unit [len=@ud dat=@])
-    =/  lat  (lent dat)
-    =/  lap  (lent dap)
-    =/  dif  (~(dif fo 4) 0 lat)
-    ?:  &(pad !=(dif lap))
-      ::  padding required and incorrect
-      ~&(%base-64-padding-err-one ~)
-    ?:  &(!pad !=(0 lap))
-      ::  padding not required but present
-      ~&(%base-64-padding-err-two ~)
-    =/  len  (sub (mul 3 (div (add lat dif) 4)) dif)
-    :+  ~  len
-    %+  swp  3
-    ::  %+  base  64
-    %+  roll
-      (weld dat (reap dif 0))
-    |=([p=@ q=@] (add p (mul 64 q)))
+    =<  ^-  $-(nail (like octs))
+        %+  sear  reduce
+        ;~  plug
+          %-  plus  ;~  pose
+            (cook |=(a=@ (sub a 'A')) (shim 'A' 'Z'))
+            (cook |=(a=@ (sub a 'G')) (shim 'a' 'z'))
+            (cook |=(a=@ (add a 4)) (shim '0' '9'))
+            (cold 62 (just ?:(url '-' '+')))
+            (cold 63 (just ?:(url '_' '/')))
+          ==
+          (stun 0^2 (cold %0 tis))
+        ==
+    |%
+    ::  +reduce:parse:base64: reduce, measure, and swap base64 digits
+    ::
+    ++  reduce
+      |=  [dat=(list @) dap=(list @)]
+      ^-  (unit octs)
+      =/  lat  (lent dat)
+      =/  lap  (lent dap)
+      =/  dif  (~(dif fo 4) 0 lat)
+      ?:  &(pad !=(dif lap))
+        ::  padding required and incorrect
+        ~&(%base-64-padding-err-one ~)
+      ?:  &(!pad !=(0 lap))
+        ::  padding not required but present
+        ~&(%base-64-padding-err-two ~)
+      =/  len  (sub (mul 3 (div (add lat dif) 4)) dif)
+      :+  ~  len
+      %+  swp  3
+      ::  %+  base  64
+      %+  roll
+        (weld dat (reap dif 0))
+      |=([p=@ q=@] (add p (mul 64 q)))
+    --
   --
 ::  +en-base64url: url-safe base64 encoding, without padding
 ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -790,6 +790,7 @@
       act=acct                                          ::  service account
       non=@t                                            ::  nonce from last
       rod=(map @ud order)                               ::  active orders
+      cey=key:rsa                                       ::  cert key
       liv=(map (list turf) config)                      ::  active config
       hit=history                                       ::  a foreign country
   ==                                                    ::
@@ -1113,9 +1114,9 @@
            |=  [i=@ud der=order]
            ^+  [i der]
            ?>  ?=([%1 *] der)
-           =/  k=key:rsa  rekey  :: XX reuse
-           =/  csr=@ux  (en:der:pkcs10 k dom.der)
-           [i %2 dom.der exp.der der.der fin.der k csr]
+           :: =/  k=key:rsa  rekey  :: XX reuse
+           =/  csr=@ux  (en:der:pkcs10 cey dom.der)
+           [i %2 dom.der exp.der der.der fin.der cey csr]
       :: XX save pending authz somewhere instead of just dropping them
     ==
   ::
@@ -1196,7 +1197,7 @@
 ++  init
   =/  url
     'https://acme-staging-v02.api.letsencrypt.org/directory'
-  directory(bas (need (de-purl:html url)), act [rekey ~])
+  directory(bas (need (de-purl:html url)), act [rekey ~], cey rekey)
   :: XX wait for DNS binding confirmation?
   :: (add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
 ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1438,7 +1438,7 @@
   :: +directory: accept ACME service directory, trigger registration
   ::
   ++  directory
-    |=  rep=httr
+    |=  [wir=wire rep=httr]
     ^+  this
     ?.  =(200 p.rep)
       :: XX never happened yet, wat do?
@@ -1696,20 +1696,21 @@
   =?  nonces  ?=(^ nonhed)  [q.i.nonhed nonces]
   =<  abet
   ~|  [%sigh-fail wir rep]
+  %.  [t.wir rep]
   ?+  i.t.wir
       ~&([%unknown-wire i.t.wir] !!)
-    %directory       (directory:event rep)
-    %nonce           (nonce:event t.wir rep)
-    %register        (register:event t.wir rep)
+    %directory       directory:event
+    %nonce           nonce:event
+    %register        register:event
     :: XX rekey
-    %new-order       (new-order:event t.wir rep)
-    %finalize-order  (finalize-order:event t.wir rep)
-    %check-order     (check-order:event t.wir rep)
-    %certificate     (certificate:event t.wir rep)
-    %get-authz       (get-authz:event t.wir rep)
+    %new-order       new-order:event
+    %finalize-order  finalize-order:event
+    %check-order     check-order:event
+    %certificate     certificate:event
+    %get-authz       get-authz:event
     :: XX check/finalize-authz ??
-    %test-trial      (test-trial:event t.wir rep)
-    %finalize-trial  (finalize-trial:event t.wir rep)
+    %test-trial      test-trial:event
+    %finalize-trial  finalize-trial:event
     ::  XX delete-trial?
   ==
 ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -875,17 +875,18 @@
   ::  |en:jwk: encoding of json cryptographic keys
   ::
   ++  en
+    =>  |%
+        ::  +numb:en:jwk: base64-url encode big-endian number
+        ::
+        ++  numb  (corl en-base64url en:octn)
+        --
     |%
     ::  +pass:en:jwk: json encode public key
     ::
     ++  pass
       |=  k=key:rsa
       ^-  json
-      :-  %o  %-  my  :~
-        kty+s+'RSA'
-        n+s+(en-base64url (en:octn n.pub.k))
-        e+s+(en-base64url (en:octn e.pub.k))
-      ==
+      [%o (my kty+s+'RSA' n+s+(numb n.pub.k) e+s+(numb e.pub.k) ~)]
     ::  +ring:en:jwk: json encode private key
     ::
     ++  ring
@@ -895,55 +896,44 @@
       ?>  ?=(^ sek.k)
       :-  %o  %-  my  :~
         kty+s+'RSA'
-        n+s+(en-base64url (en:octn n.pub.k))
-        e+s+(en-base64url (en:octn e.pub.k))
-        d+s+(en-base64url (en:octn d.u.sek.k))
-        p+s+(en-base64url (en:octn p.u.sek.k))
-        q+s+(en-base64url (en:octn q.u.sek.k))
+        n+s+(numb n.pub.k)
+        e+s+(numb e.pub.k)
+        d+s+(numb d.u.sek.k)
+        p+s+(numb p.u.sek.k)
+        q+s+(numb q.u.sek.k)
       ==
     --
   ::  |de:jwk: decoding of json cryptographic keys
   ::
   ++  de
+    =,  dejs-soft:format
+    =>  |%
+        ::  +numb:de:jwk: parse base64-url big-endian number
+        ::
+        ++  numb  (cu (cork de-base64url (lift de:octn)) so)
+        --
     |%
     ::  +pass:de:jwk: decode json public key
     ::
     ++  pass
-      =,  dejs-soft:format
       %+  ci
-        |=  [kty=@t n=(unit octs) e=(unit octs)]
+        =/  a  (unit @ux)
+        |=  [kty=@t n=a e=a]
         ^-  (unit key:rsa)
-        =/  pub  (both (bind n de:octn) (bind e de:octn))
+        =/  pub  (both n e)
         ?~(pub ~ `[u.pub ~])
-      %-  ot  :~
-        kty+(su (jest 'RSA'))
-        n+(cu de-base64url so)
-        e+(cu de-base64url so)
-      ==
+      (ot kty+(su (jest 'RSA')) n+numb e+numb ~)
     ::  +ring:de:jwk: decode json private key
     ::
     ++  ring
-      =,  dejs-soft:format
       %+  ci
-        |=  $:  kty=@t
-                n=(unit octs)
-                e=(unit octs)
-                d=(unit octs)
-                p=(unit octs)
-                q=(unit octs)
-            ==
+        =/  a  (unit @ux)
+        |=  [kty=@t n=a e=a d=a p=a q=a]
         ^-  (unit key:rsa)
-        =/  pub  (both (bind n de:octn) (bind e de:octn))
-        =/  sek  :(both (bind d de:octn) (bind p de:octn) (bind q de:octn))
+        =/  pub  (both n e)
+        =/  sek  :(both d p q)
         ?:(|(?=(~ pub) ?=(~ sek)) ~ `[u.pub sek])
-      %-  ot  :~
-        kty+(su (jest 'RSA'))
-        n+(cu de-base64url so)
-        e+(cu de-base64url so)
-        d+(cu de-base64url so)
-        p+(cu de-base64url so)
-        q+(cu de-base64url so)
-      ==
+      (ot kty+(su (jest 'RSA')) n+numb e+numb d+numb p+numb q+numb ~)
     --
   ::  |thumb:jwk: "thumbprint" json-encoded key (rfc7638)
   ::

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1184,7 +1184,7 @@
   ==
 ::
 ++  poke-path
-  |=(a=path abet:new-order:(add-order a ~))
+  |=(a=path abet:(add-order a ~))
 ::
 :: ++  prep  _[~ this]
 ++  prep

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -4,8 +4,8 @@
 ::::  libraries
 ::
 |%                                                      ::  +base64
-++  base64                                              ::  rfc4648
-  =+  [pad=& url=|]                                     ::  [pad? url-safe?]
+++  base64                                              ::  [pad? url-safe?]
+  =+  [pad=& url=|]                                     ::
   |%                                                    ::  +en:base64
   ++  en                                                ::  encode base64
     |=  tig=@
@@ -1012,6 +1012,7 @@
     :: XX challenge is not pending
     :: XX order can't be finalized
     abet:this
+  ~|  sigh-fail+rep
   ?+  i.t.wir  !!
       %dir
     =<  abet:(nonce /next/reg)
@@ -1033,12 +1034,16 @@
   ::
       %reg
     =<  abet:new-order
-    =/  bod=[id=@t wen=@t sas=@t]  :: XX @da
-      (acct:grab (need (de-json:html q:(need r.rep))))
     =/  loc=@t
       q:(head (skim q.rep |=((pair @t @t) ?=(%location p))))
-    ?>  ?=(%valid sas.bod)
-    this(reg.act `[wen.bod loc])
+    =/  wen=@t              :: XX @da
+      ?~  r.rep
+        (scot %da now.bow)
+      =/  bod=[id=@t wen=@t sas=@t]
+        (acct:grab (need (de-json:html q.u.r.rep)))
+      ?>  ?=(%valid sas.bod)
+      wen.bod
+    this(reg.act `[wen loc])
   ::
       %der
     =<  abet:authorize
@@ -1159,6 +1164,7 @@
   ?+  a  ~&  +<+.this
          [~ this]
     %init   abet:init
+    %reg    abet:register
     %order  abet:new-order
     %auth   abet:authorize
     %trial  abet:test-challenge
@@ -1169,7 +1175,7 @@
   ==
 ::
 ++  poke-path
-  |=(a=path abet:(add-order a ~))
+  |=(a=path abet:new-order:(add-order a ~))
 ::
 :: ++  prep  _[~ this]
 ++  prep

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -141,6 +141,7 @@
   ::
   ++  decode
     %+  cook  |*(a=* `spec:asn1`a)
+    :: ^-  $-(nail (like spec:asn1))
     ;~  pose
       %+  stag  %int
       %+  bass  256
@@ -678,8 +679,8 @@
     %-  en-base64url
     %+  swp  3
     (~(sign rs256 u.key) (rap 3 ~[protect '.' payload]))
-  == 
-::  
+  ==
+::
 ++  request
   |=  [wir=wire url=purl bod=(unit json)]
   =/  lod
@@ -753,7 +754,7 @@
           ;:  weld
             test-base64
             test-asn1
-            test-rsakey
+            :: test-rsakey
             test-rsa
             test-rsapem
             test-rsa-pkcs8
@@ -1135,7 +1136,7 @@
       %-  expect-eq  !>
         [emsa1 `@ux`(~(emsa rs256 k1) inp1)]
       %-  expect-eq  !>
-        [& (~(verify rs256 k2) sig inp2)] 
+        [& (~(verify rs256 k2) sig inp2)]
       %-  expect-eq  !>
         [exp2 sig]
       :: save kpem2 to private.pem
@@ -1172,7 +1173,6 @@
   ::
   ++  test-jws
     ::  rfc7515 appendix 2
-    ^-  wall
     =/  pt=@t
       %+  rap  3
       :~  '4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi'

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1031,6 +1031,7 @@
       %der  new-order
       %aut  authorize
       %cal  finalize-challenge
+      %fin  finalize-order
     ==
   ::
       %reg

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -844,8 +844,8 @@
 ++  nonce
   |=  nex=wire
   ^+  this
-  ?>  |(?=(~ nex) ?=([%next *] nex))
-  (emit (request (weld `wire`/acme/non nex) non.dir ~))
+  ?>  ?=([%next *] nex)
+  (emit (request (weld `wire`/acme/non `wire`nex) non.dir ~))
 ::
 ++  register
   %-  emit(reg.act ~)
@@ -1006,17 +1006,15 @@
     =/  bod=[typ=@t det=@t]
       (error:grab (need (de-json:html q:(need r.rep))))
     ?:  =('urn:ietf:params:acme:error:badNonce' typ.bod)
-      =/  nex=wire
-        ?.  ?=(?(%der %aut %cal) i.t.wir)
-          ~
-        /next/[i.t.wir]
-      abet:(nonce nex)
+      ?.  ?=(?(%reg %der %aut %cal %fin) i.t.wir)
+        ~&(unrecoverable-bad-nonce+wir abet:this)
+      abet:(nonce /next/[i.t.wir])
     :: XX challenge is not pending
     :: XX order can't be finalized
-    [~ this]
+    abet:this
   ?+  i.t.wir  !!
       %dir
-    =<  abet:(nonce ~)
+    =<  abet:(nonce /next/reg)
     =/  bod=^directory
       (directory:grab (need (de-json:html q:(need r.rep))))
     this(dir bod)
@@ -1024,8 +1022,10 @@
       %non
     =<  abet
     ?.  ?=([%next ^] t.t.wir)
-      register
-    ?+  i.t.t.t.wir  this
+      ~&(unrecognized-nonce-wire+wir this)
+    =*  nex  i.t.t.t.wir
+    ?+  nex  ~&(unknown-nonce-next+nex this)
+      %reg  register
       %der  new-order
       %aut  authorize
       %cal  finalize-challenge
@@ -1197,7 +1197,12 @@
 ++  add-order
   |=  dom=(list turf)
   ^+  this
-  new-order(rod (~(put by rod) ~(wyt by rod) [%0 dom]))
+  :: XX temporarily force one at a time
+  :: new-order(rod (~(put by rod) ~(wyt by rod) [%0 dom]))
+  %=  new-order
+    rod.hit  (weld ~(val by rod) rod.hit)
+    rod      (~(put by ^+(rod ~)) ~(wyt by rod) [%0 dom])
+  ==
 ::
 ++  test
   =,  tester:tester

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -812,6 +812,8 @@
             [%int 0]
             [%seq ~]
             (pass:en:spec:pkcs8 key)
+            :: explicit, context-specific tag #0 (extensions)
+            ::
             :+  %con
               `bespoke:asn1`[| 0]
             %~  ren

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1655,7 +1655,8 @@
         (acct:grab (need (de-json:html q.u.r.rep)))
       ?>  ?=(%valid sas.bod)
       wen.bod
-    this(reg.act `[wen loc])
+    =.  reg.act  `[wen loc]
+    ?~(pen this new-order:effect)
   :: XX rekey
   ::
   ::  +new-order: order created, begin processing authorizations
@@ -1893,7 +1894,9 @@
 :: +poke-acme-order: create new order for a set of domains
 ::
 ++  poke-acme-order
-  |=(a=(set turf) abet:(add-order ~(tap in a)))
+  |=  a=(set turf)
+  ~&  [%poke-acme a]
+  abet:(add-order a)
 :: +poke-noun: for debugging
 ::
 ++  poke-noun
@@ -1912,14 +1915,14 @@
     %trial  test-trial:effect
     %final  finalize-order:effect
     %poll   check-order:effect
-    %our    (add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
+    %our    (add-order (sy /org/urbit/(crip +:(scow %p our.bow)) ~))
     %rule   install:effect
     %test   test
   ==
 :: +poke-path: for debugging
 ::
 ++  poke-path
-  |=(a=path abet:(add-order a ~))
+  |=(a=path abet:(add-order (sy a ~)))
 ::
 :: ++  prep  _[~ this]
 ++  prep
@@ -1951,18 +1954,16 @@
     act  [(rekey eny.bow) ~]
     cey  (rekey (mix eny.bow (shaz now.bow)))
   ==
-  :: XX wait for DNS binding confirmation?
-  :: (add-order /org/urbit/(crip +:(scow %p our.bow)) ~)
 ::
 ++  add-order
-  |=  dom=(list turf)
+  |=  dom=(set turf)
   ^+  this
   :: XX we may have pending moves out for this order
   :: XX put dates in wires, check against order creation date?
   :: XX or re-use order-id?
   =?  fal.hit  ?=(^ rod)  [u.rod fal.hit]
-  :: XX check registration, defer
-  new-order:effect(rod ~, pen `(sy dom))
+  =<  ?~(reg.act this new-order:effect)
+  this(rod ~, pen `dom)
 ::
 ++  test
   =,  tester:tester

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1171,6 +1171,7 @@
 ::
 +=  card
   $%  [%hiss wire [~ ~] %httr %hiss hiss:eyre]
+      [%wait wire @da]
       [%well wire path (unit mime)]
       [%rule wire %cert (unit [wain wain])]
   ==
@@ -1585,7 +1586,10 @@
   ::
   :: +retry: retry effect after timeout
   ::
-  ++  retry  !!
+  ++  retry
+    |=  [wir=wire wen=@da]
+    :: XX validate wire and date
+    (emit %wait [%acme wir] wen)
   --
 :: |event: accept event, emit next effect(s)
 ::
@@ -1833,8 +1837,13 @@
   :: +retry: retry effect after timeout
   ::
   ++  retry
-    :: XX implement wire parsing / next effect
-    !!
+    |=  wir=wire
+    ^+  this
+    ?+  wir
+        ~&(unknown-retry+wir this)
+      :: XX do the needful
+      [%directory ~]  directory:effect
+    ==
   --
 :: +sigh-tang: handle http request failure
 ::
@@ -1873,6 +1882,14 @@
     %finalize-trial  finalize-trial:event
     ::  XX delete-trial?
   ==
+:: +wake: timer wakeup event
+::
+++  wake
+  |=  [wir=wire ~]
+  ^-  (quip move _this)
+  ~&  [%wake wir]
+  ?>  ?=([%acme *] wir)
+  abet:(retry:event t.wir)
 :: +poke-acme-order: create new order for a set of domains
 ::
 ++  poke-acme-order
@@ -1928,7 +1945,7 @@
 ++  init
   =/  url
     'https://acme-staging-v02.api.letsencrypt.org/directory'
-  =<  directory:effect
+  =<  (retry:effect /directory +(now.bow))
   %=  this
     bas  (need (de-purl:html url))
     act  [(rekey eny.bow) ~]

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1660,9 +1660,9 @@
     =*  aut  u.active.aut.u.rod
     =/  bod=[typ=@t sas=@t url=purl tok=@t]
       (challenge:grab (need (de-json:html q:(need r.rep))))
-    :: XX what if it's not?
-    ?>  ?=(%pending sas.bod)
-    ~!  aut
+    :: XX check for other possible values in 200 response
+    :: note: may have already been validated
+    ?>  ?=(?(%pending %valid) sas.bod)
     =/  rod-aut=order-auth
       aut.u.rod(active ~, done [+.aut(sas.cal %pend) done.aut.u.rod])
     ?~  pending.aut.u.rod

--- a/app/acme.hoon
+++ b/app/acme.hoon
@@ -1208,8 +1208,8 @@
     'https://acme-staging-v02.api.letsencrypt.org/directory'
   %=  directory
     bas  (need (de-purl:html url))
-    act  [(rekey (shas %act eny.bow)) ~]
-    cey  (rekey (shas %act eny.bow))
+    act  [(rekey eny.bow) ~]
+    cey  (rekey (mix eny.bow (shaz now.bow)))
   ==
   :: XX wait for DNS binding confirmation?
   :: (add-order /org/urbit/(crip +:(scow %p our.bow)) ~)

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -56,17 +56,16 @@
 ++  reserved
   |=  a=@if
   ^-  ?
-  =/  b  (rip 3 a)
-  ?>  ?=([@ @ @ @ ~] b)
-  ?|  :: 0.0.0.0/8 (software)
-      ::
-      =(0 i.b)
-      :: 10.0.0.0/8 (private)
+  =/  b  (flop (rip 3 a))
+  :: 0.0.0.0/8 (software)
+  ::
+  ?.  ?=([@ @ @ @ ~] b)  &
+  ?|  :: 10.0.0.0/8 (private)
       ::
       =(10 i.b)
       :: 100.64.0.0/10 (carrier-grade NAT)
       ::
-      &(=(100 i.b) (gte 64 i.t.b) (lte 127 i.t.b))
+      &(=(100 i.b) (gte i.t.b 64) (lte i.t.b 127))
       :: 127.0.0.0/8 (localhost)
       ::
       =(127 i.b)
@@ -75,7 +74,7 @@
       &(=(169 i.b) =(254 i.t.b))
       :: 172.16.0.0/12 (private)
       ::
-      &(=(172 i.b) (gte 16 i.t.b) (lte 31 i.t.b))
+      &(=(172 i.b) (gte i.t.b 16) (lte i.t.b 31))
       :: 192.0.0.0/24 (protocol assignment)
       ::
       &(=(192 i.b) =(0 i.t.b) =(0 i.t.t.b))
@@ -101,7 +100,7 @@
       :: 240.0.0.0/4 (reserved, future)
       :: 255.255.255.255/32 (broadcast)
       ::
-      (gte 224 i.b)
+      (gte i.b 224)
   ==
 :: |gcloud: provider-specific functions
 ::

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -424,6 +424,7 @@
       [%direct %if u.adr]
     ?.  ?|  ?=(~ rel)
             !=(tar tar.u.rel)
+            !bon.u.rel
         ==
       this
     =.  rel  `[wen=now.bow adr bon=| try=0 tar]

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -298,6 +298,9 @@
 ++  rove
   |=  [wir=wire p=ship q=lane:ames]
   ^-  (quip move _this)
+  :: XX move to %ames
+  ?:  =(our.bow p)
+    [~ this]
   ?.  =(our.bow (sein:title p))  :: XX check will
     ~&  [%rove-false p]
     [~ this]

--- a/app/dns.hoon
+++ b/app/dns.hoon
@@ -14,6 +14,7 @@
           ==
 +=  card  $%  [%tend wire ~]
               [%poke wire dock poke]
+              [%rule wire %turf %put turf]
               [%hiss wire [~ ~] %httr %hiss hiss:eyre]
           ==
 :: +state: complete app state
@@ -259,9 +260,8 @@
   ?:  =(for him)
     ~|(%bond-yoself !!)
   ?:  =(our.bow him)
-    :: XX notify eyre/hood/acme etc
     ~&  [%bound-us dom]
-    :-  ~
+    :-  [[ost.bow %rule /bound %turf %put dom] ~]
     this(dom (~(put in ^dom) dom))
   ?:  =(our.bow for)
     ~&  [%bound-him him dom]

--- a/lib/hood/drum.hoon
+++ b/lib/hood/drum.hoon
@@ -81,6 +81,7 @@
   ?:  ?=($pawn myr)
     [[%base %collections] [%base %hall] [%base %talk] [%base %dojo] ~]
   :~  [%home %collections]
+      [%home %acme]
       [%home %dns]
       [%home %dojo]
       [%home %hall]

--- a/lib/oauth1.hoon
+++ b/lib/oauth1.hoon
@@ -102,7 +102,7 @@
   |=  a/$@(@t purl)  ^-  hiss
   (post-quay (parse-url a) oauth-callback+oauth-callback ~)
 ::
-++  our-host  .^(hart %e /(scot %p our)/host/fake)
+++  our-host  .^(hart %e /(scot %p our)/host/real)
 ++  oauth-callback
   ~&  [%oauth-warning "Make sure this urbit ".
                       "is running on {(en-purl:html our-host `~ ~)}"]

--- a/lib/oauth2.hoon
+++ b/lib/oauth2.hoon
@@ -101,7 +101,7 @@
   %+  rap  3  :-  (wack a)
   (turn b |=(c/knot (cat 3 '_' (wack c))))
 ::
-++  our-host  .^(hart %e /(scot %p our)/host/fake)
+++  our-host  .^(hart %e /(scot %p our)/host/real)
 ++  redirect-uri
   %-    crip    %-  en-purl
   %^  into-url:interpolate  'https://our-host/~/ac/:domain/:user/in'

--- a/mar/acme/order.hoon
+++ b/mar/acme/order.hoon
@@ -1,0 +1,9 @@
+::
+::::  /mar/acme/order/hoon
+  ::
+|_  a=(set (list @t))
+++  grab
+  |%
+  ++  noun  (set (list @t))
+  --
+--

--- a/mar/recoverable-error.hoon
+++ b/mar/recoverable-error.hoon
@@ -15,6 +15,7 @@
   ++  noun  recoverable-error
   ++  httr
     |=  a/^httr  ^-  recoverable-error
+    ~&  [%recoverable-httr a]
     ~!  a
     ?+  p.a  ~|(non-recoverable+p.a !!)
       $429  :+  p.a  %rate-limit

--- a/sur/dns.hoon
+++ b/sur/dns.hoon
@@ -53,6 +53,7 @@
   $:  wen=@da
       wer=(unit @if)
       bon=?
+      try=@ud
       tar=target
   ==
 --

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -671,10 +671,9 @@
         |=(a=host ?>(?=(%& -.a) p.a))
       =/  dif/(set (list @t))  (~(dif in mod) dom)
       =?  dom  ?=(^ dif)  (~(uni in dom) mod)
-      ~&  [%eyre %acme-order dom]
-      :: =?  mow  ?=(^ dif)
-      ::   =/  cmd  [%acme %poke `cage`[%acme-order !>(dom)]]
-      ::   [[hen %pass ~ %g %deal [our our] cmd] mow]
+      =?  mow  ?=(^ dif)
+        =/  cmd  [%acme %poke `cage`[%acme-order !>(dom)]]
+        :_(mow [hen %pass /acme/order %g %deal [our our] cmd])
       %=  +>.$
         ged  hen                                        ::  register external
         mow  :_(mow [hen [%give %form fig]])
@@ -687,10 +686,8 @@
       ?-  -.p.kyz
           $cert
         ?:  =(secure.fig p.p.kyz)  +>.$
-        %=  +>.$
-          secure.fig  p.p.kyz
-          mow         :_(mow [hen [%give %form fig]])
-        ==
+        =.  secure.fig  p.p.kyz
+        +>.$(mow :_(mow [ged [%give %form fig]]))
       ::
           $turf
         =/  mod/(set (list @t))
@@ -698,13 +695,10 @@
             (~(put in dom) q.p.kyz)
           (~(del in dom) q.p.kyz)
         ?:  =(dom mod)  +>.$
-        ~&  [%eyre %acme-order dom]
-        :: =.  mow
-        ::   =/  cmd  [%acme %poke `cage`[%acme-order !>(dom)]]
-        ::   [[hen %pass ~ %g %deal [our our] cmd] mow]
+        =/  cmd  [%acme %poke `cage`[%acme-order !>(mod)]]
         %=  +>.$
           dom  mod
-          mow  :_(mow [hen [%give %form fig]])
+          mow  :_(mow [hen %pass /acme/order %g %deal [our our] cmd])
         ==
       ==
     ::

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -864,12 +864,12 @@
             [[%$ deps+!>(dep)] [%vale res]]
           ==
       ::
-        $not  +>.$(mow :_(mow [ged [%give %that q.p.kyz p.u.mez q.u.mez]]))
+        $not  +>.$(mow :_(mow [ged [%give %that q.p.kyz p.u.mez]]))
       ==
     ::
       $wegh  !!                                         ::  handled elsewhere
     ::
-      $wise  (ames-gram p.kyz [%not ~] q.kyz r.kyz)     ::  proxy notification
+      $wise  (ames-gram p.kyz [%not ~] q.kyz)           ::  proxy notification
     ==
   ::
   ::++  axom                                              ::  old response

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -669,7 +669,7 @@
           [%mass p=mass]                                ::  memory usage
           [%mack p=(unit tang)]                         ::  message ack
           [%sigh p=cage]                                ::  marked http response
-          [%that p=@p q=@ud r=?]                        ::  get proxied request
+          [%that p=@p q=prox]                           ::  get proxied request
           [%thou p=httr]                                ::  raw http response
           [%thus p=@ud q=(unit hiss)]                   ::  http request+cancel
           [%veer p=@ta q=path r=@t]                     ::  drop-through
@@ -693,7 +693,7 @@
           [%well p=path q=(unit mime)]                  ::  put/del .well-known
           [%went p=sack q=path r=@ud s=coop]            ::  response confirm
           [%west p=sack q=[path *]]                     ::  network request
-          [%wise p=@p q=@ud r=?]                        ::  proxy notification
+          [%wise p=ship q=prox]                         ::  proxy notification
       ==                                                ::
     --  ::able
   ::
@@ -731,7 +731,7 @@
         [[%get-inner ~] p=@uvH q=beam r=mark]  ::TODO details?
         [[%got-inner ~] p=@uvH q=(each (cask) tang)]  ::TODO details?
       ::
-        [[%not ~] p=@ud q=?]                            ::  proxy notification
+        [[%not ~] p=prox]                               ::  proxy notification
     ==                                                  ::
   ++  hart  {p/? q/(unit @ud) r/host}                   ::  http sec+port+host
   ++  hate  {p/purl q/@p r/moth}                        ::  semi-cooked request
@@ -807,6 +807,22 @@
   ++  octs  {p/@ud q/@t}                                ::  octet-stream
   ++  oryx  @t                                          ::  CSRF secret
   ++  pork  {p/(unit @ta) q/(list @t)}                  ::  fully parsed url
+  :: +prox: proxy notification
+  ::
+  ::   Used on both the proxy (ward) and upstream sides for
+  ::   sending/receiving proxied-request notifications.
+  ::
+  +=  prox
+    $:  :: por: tcp port
+        ::
+        por=@ud
+        :: sek: secure?
+        ::
+        sek=?
+        :: non: authentication nonce
+        ::
+        non=@uvJ
+    ==
   ++  purf  (pair purl (unit @t))                       ::  url with fragment
   ++  purl  {p/hart q/pork r/quay}                      ::  parsed url
   ++  quay  (list {p/@t q/@t})                          ::  parsed url query


### PR DESCRIPTION
This PR adds the new LetsEncrypt client app `:acme`, and builds on the `:dns` app and `%eyre` changes in #752.