### PR TITLE
crash `++ rad` when arg of `0` is used

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3418,6 +3418,7 @@
   |_  a/@
   ++  rad                                               ::  random in range
     |=  b/@  ^-  @
+    ~_  leaf+"rad-zero"
     =+  c=(raw (met 0 b))
     ?:((lth c b) c $(a +(a)))
   ::

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3419,6 +3419,7 @@
   ++  rad                                               ::  random in range
     |=  b/@  ^-  @
     ~_  leaf+"rad-zero"
+    ?<  =(0 b)
     =+  c=(raw (met 0 b))
     ?:((lth c b) c $(a +(a)))
   ::


### PR DESCRIPTION
(I messed up a previous version of the PR, so I closed that and am trying again with this one.)

@rmariani ran into an endless loop when he tried passing `0` to `rad:og`: https://github.com/urbit/urbit/issues/1016#ref-pullrequest-342508381

This edit causes `rad:og` to crash with a `rad-zero` when the sample is `0`.