### PR TITLE
+expect-schematic in ford test lib

### DIFF
--- a/lib/test/ford.hoon
+++ b/lib/test/ford.hoon
@@ -1,0 +1,429 @@
+/+  tester
+=,  ford
+=,  tester:tester
+|%
+++  expect-schematic
+  |=  [expected=schematic actual=vase]
+  ^-  tang
+  ::
+  ?^    -.expected
+    ::  specialize :actual's type to be an autocons
+    ::
+    =.  actual
+      %+  slap  actual
+      ^-  hoon
+      :+  %wtbn
+        [%wtts [%base %cell] [%& 2]~]
+      [%wing [%& 1]~]
+    ::
+    %+  weld
+      $(expected -.expected, actual (slap actual [%limb %head]))
+    $(expected +.expected, actual (slap actual [%limb %tail]))
+  ::
+  =.  actual  (specialize-by-tag -.expected actual)
+  ::
+  ?-    -.expected
+      %$
+    %+  weld
+      ^-  tang
+      %+  expect-eq
+        `vase`[`type`[%atom %tas ~] `term`p.literal.expected]
+      `vase`(slap actual `hoon`[%wing ~[%p %literal]])
+    ::
+    %+  expect-eq
+      q.literal.expected
+    ((hard vase) q:(slap actual [%wing ~[%q %literal]]))
+  ::
+      %pin
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%atom %da ~] date.expected]
+      (slap actual [%limb %date])
+    ::
+    $(expected schematic.expected, actual (slap actual [%limb %schematic]))
+  ::
+      %alts
+    =.  actual  (slap actual [%limb %choices])
+    ::
+    =|  res=tang
+    |-  ^+  res
+    ?~  choices.expected
+      ::  make sure there aren't any extra :choices in :actual
+      ::
+      =.  actual  (assert-null actual)
+      ::  no more choices; produce any errors we got
+      ::
+      res
+    ::  :expected isn't empty yet; make sure :actual isn't either
+    ::
+    =.  actual  (assert-not-null actual)
+    ::  recurse on the first sub-schematic
+    ::
+    =.  res
+      %+  weld  res
+      ^$(expected i.choices.expected, actual (slap actual [%limb %i]))
+    ::  recurse on the rest of the sub-schematics
+    ::
+    $(choices.expected t.choices.expected, actual (slap actual [%limb %t]))
+  ::
+      %bake
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%atom %tas ~] renderer.expected]
+      (slap actual [%limb %renderer])
+    ::
+    %+  weld
+      %+  expect-eq
+        [-:!>(*coin) query-string.expected]
+      (slap actual [%limb %query-string])
+    ::
+    %+  expect-eq
+      [-:!>(*rail) path-to-render.expected]
+    (slap actual [%limb %path-to-render])
+  ::
+      %bunt
+    ::
+    %-  expect-eq
+    :_  %+  slap  actual
+        ^-  hoon
+        [%clhp [%limb %disc] [%limb %mark]]
+    ^-  vase
+    :_  [disc mark]:expected
+    ^-  type
+    :+  %cell
+      [%face %disc -:!>(*disc)]
+    [%face %mark -:!>(*term)]
+  ::
+      %call
+    %+  weld
+      $(expected gate.expected, actual (slap actual [%limb %gate]))
+    $(expected sample.expected, actual (slap actual [%limb %sample]))
+  ::
+      %cast
+    ;:  weld
+      %+  expect-eq
+        [-:!>(*disc) disc.expected]
+      (slap actual [%limb %disc])
+    ::
+      %+  expect-eq
+        [-:!>(*term) mark.expected]
+      (slap actual [%limb %mark])
+    ::
+      $(expected input.expected, actual (slap actual [%limb %input]))
+    ==
+  ::
+      %core
+    %+  expect-eq
+      [-:!>(*rail) source-path.expected]
+    (slap actual [%limb %source-path])
+  ::
+      %diff
+    %+  weld
+      %+  expect-eq
+        [[%face %disc -:!>(*disc)] disc.expected]
+      (slap actual [%limb %disc])
+    ::
+    %+  weld
+      $(expected start.expected, actual (slap actual [%limb %start]))
+    $(expected end.expected, actual (slap actual [%limb %end]))
+  ::
+      %dude
+    =/  error-result=tank  (error.expected)
+    %+  expect-eq
+      [-:!>(*tank) error-result]
+    (slap actual `hoon`[%kttr [%like ~[%error] ~]])
+  ::
+      %hood
+    %+  expect-eq
+      [-:!>(*rail) source-path.expected]
+    (slap actual [%limb %source-path])
+  ::
+      %join
+    %+  weld
+      %+  expect-eq
+        [[%face %disc -:!>(*disc)] disc.expected]
+      (slap actual [%limb %disc])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %mark [%atom %tas ~]] mark.expected]
+      (slap actual [%limb %mark])
+    ::
+    %+  weld
+      $(expected first.expected, actual (slap actual [%limb %first]))
+    $(expected second.expected, actual (slap actual [%limb %second]))
+  ::
+      %list
+    =.  actual  (slap actual [%limb %schematics])
+    ::
+    =/  schematics  schematics.expected
+    ::
+    =|  res=tang
+    |-  ^+  res
+    ?~  schematics
+      ::  make sure there aren't any extra :choices in :actual
+      ::
+      =.  actual  (assert-null actual)
+      ::  no more choices; produce any errors we got
+      ::
+      res
+    ::  :expected isn't empty yet; make sure :actual isn't either
+    ::
+    =.  actual  (assert-not-null actual)
+    ::  recurse on the first sub-schematic
+    ::
+    =.  res
+      %+  weld  res
+      ^$(expected i.schematics, actual (slap actual [%limb %i]))
+    ::  recurse on the rest of the sub-schematics
+    ::
+    $(schematics t.schematics, actual (slap actual [%limb %t]))
+  ::
+      %mash
+    %+  weld
+      %+  expect-eq
+        [[%face %disc -:!>(*disc)] disc.expected]
+      (slap actual [%limb %disc])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %mark [%atom %tas ~]] mark.expected]
+      (slap actual [%limb %mark])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %disc-first -:!>(*disc)] disc.expected]
+      (slap actual [%wing ~[%disc %first]])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %mark-first -:!>(*disc)] disc.expected]
+      (slap actual [%wing ~[%mark %first]])
+    ::
+    %+  weld
+      %_  $
+        expected  schematic.first.expected
+        actual    (slap actual [%wing ~[%schematic %first]])
+      ==
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %disc-second -:!>(*disc)] disc.expected]
+      (slap actual [%wing ~[%disc %second]])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %mark-second -:!>(*disc)] disc.expected]
+      (slap actual [%wing ~[%mark %second]])
+    ::
+    %_  $
+      expected  schematic.second.expected
+      actual    (slap actual [%wing ~[%schematic %second]])
+    ==
+  ::
+      %mute
+    %+  weld
+      $(expected subject.expected, actual (slap actual [%limb %subject]))
+    ::
+    =/  mutations  mutations.expected
+    =.  actual     (slap actual [%limb %mutations])
+    ::
+    =|  index=@ud
+    =|  res=tang
+    |-  ^+  res
+    ?~  mutations
+      ::  make sure there aren't any extra :choices in :actual
+      ::
+      =.  actual  (assert-null actual)
+      ::  no more choices; produce any errors we got
+      ::
+      res
+    ::  :expected isn't empty yet; make sure :actual isn't either
+    ::
+    =.  actual  (assert-not-null actual)
+    ::  recurse on the first sub-schematic
+    ::
+    =.  res
+      %+  weld
+        res
+      %+  weld
+        %+  expect-eq
+          [[%face (cat 3 'wing-' (scot %tas index)) -:!>(*wing)] p.i.mutations]
+        (slap actual [%wing ~[%p %mutations]])
+      ::
+      ^$(expected q.i.mutations, actual (slap actual [%wing ~[%q %mutations]]))
+    ::  recurse on the rest of the sub-schematics
+    ::
+    $(mutations t.mutations, actual (slap actual [%limb %t]))
+  ::
+      %pact
+    %+  weld
+      %+  expect-eq
+        [[%face %disc -:!>(*disc)] disc.expected]
+      (slap actual [%limb %disc])
+    ::
+    %+  weld
+      $(expected start.expected, actual (slap actual [%limb %start]))
+    $(expected diff.expected, actual (slap actual [%limb %diff]))
+  ::
+      %path
+    %-  expect-eq
+    ::
+    :_  %+  slap  actual
+        [%cnls [%limb %disc] [%limb %prefix] [%limb %raw-path]]
+    ::
+    ^-  vase
+    :_  [disc prefix raw-path]:expected
+    ^-  type
+    :+  %cell
+      [%face %disc -:!>(*disc)]
+    :+  %cell
+      [%face %prefix [%atom %tas ~]]
+    [%face %raw-path [%atom %tas ~]]
+  ::
+      %plan
+    %+  weld
+      %+  expect-eq
+        [[%face %path-to-render -:!>(*rail)] path-to-render.expected]
+      (slap actual [%limb %path-to-render])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %query-string -:!>(*coin)] query-string.expected]
+      (slap actual [%limb %query-string])
+    ::
+    %+  expect-eq
+      [[%face %scaffold -:!>(*scaffold)] scaffold.expected]
+    (slap actual [%limb %scaffold])
+  ::
+      %reef
+    %+  expect-eq
+      [[%face %disc -:!>(*disc)] disc.expected]
+    (slap actual [%limb %disc])
+  ::
+      %ride
+    %+  weld
+      %+  expect-eq
+        [[%face %formula -:!>(*hoon)] formula.expected]
+      (slap actual [%limb %formula])
+    ::
+    $(expected subject.expected, actual (slap actual [%limb %subject]))
+  ::
+      %same
+    $(expected schematic.expected, actual (slap actual [%limb %schematic]))
+  ::
+      %scry
+    %+  expect-eq
+      [[%face %resource -:!>(*resource)] resource.expected]
+    (slap actual [%limb %resource])
+  ::
+      %slim
+    %+  weld
+      %+  expect-eq
+        !>(`?`%.y)
+      ^-  vase
+      :-  -:!>(*?)
+      ^-  ?
+      =<  -
+      %+  ~(nets wa *worm)
+        subject-type.expected
+      q:(slap actual [%limb %subject-type])
+    ::
+    %+  expect-eq
+      [[%face %formula -:!>(*hoon)] formula.expected]
+    (slap actual [%limb %formula])
+  ::
+      %slit
+    %+  weld
+      %+  expect-eq
+        gate.expected
+      ((hard vase) q:(slap actual [%limb %gate]))
+    ::
+    %+  expect-eq
+      sample.expected
+    ((hard vase) q:(slap actual [%limb %sample]))
+  ::
+      ?(%vale %volt)
+    %+  weld
+      %+  expect-eq
+        [[%face %disc -:!>(*disc)] disc.expected]
+      (slap actual [%limb %disc])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %mark -:!>(*term)] mark.expected]
+      (slap actual [%limb %mark])
+    ::
+    %+  expect-eq
+      [[%face %input -:!>(**)] input.expected]
+    (slap actual [%limb %input])
+  ::
+      %walk
+    %+  weld
+      %+  expect-eq
+        [[%face %disc -:!>(*disc)] disc.expected]
+      (slap actual [%limb %disc])
+    ::
+    %+  weld
+      %+  expect-eq
+        [[%face %source -:!>(*term)] source.expected]
+      (slap actual [%limb %source])
+    ::
+    %+  expect-eq
+      [[%face %source -:!>(*term)] target.expected]
+    (slap actual [%limb %target])
+  ==
+::  +specialize-by-tag: specialize a $% vase's type to a particular :tag
+::
+::    Vase equivalent of:
+::
+::    ```
+::    ?>  ?=(<tag> -.value)  value
+::    ```
+::
+++  specialize-by-tag
+  |=  [tag=@tas =vase]
+  ^+  vase
+  ::
+  %+  slap  vase
+  ^-  hoon
+  :+  %wtbn
+    [%wtts [%leaf %tas tag] [%& 2]~]
+  [%wing [%& 1]~]
+::  +assert-null: specialize a vase to have a null type, crashing if invalid
+::
+::    Vase equivalent of:
+::
+::    ```
+::    ?>  ?=(~ value)  value
+::    ```
+::
+++  assert-null
+  |=  =vase
+  ^+  vase
+  ::
+  %+  slap  vase
+  ^-  hoon
+  :+  %wtbn
+    [%wtts [%base %null] [%& 1]~]
+  [%wing [%& 1]~]
+::  +assert-not-null: specialize a vase to non-null type, crashing if invalid
+::
+::    Vase equivalent of:
+::
+::    ```
+::    ?<  ?=(~ value)  value
+::    ```
+::
+++  assert-not-null
+  |=  =vase
+  ^+  vase
+  ::
+  %+  slap  vase
+  ^-  hoon
+  :+  %wtld
+    [%wtts [%base %null] [%& 1]~]
+  [%wing [%& 1]~]
+--

--- a/lib/test/ford.hoon
+++ b/lib/test/ford.hoon
@@ -2,6 +2,12 @@
 =,  ford
 =,  tester:tester
 |%
+::  +expect-schematic: assert a +schematic:ford is what we expect
+::
+::    Since Ford requests contain types, we can't do simple
+::    equality checking. This function handles all the different
+::    kinds of +schematic:ford, dealing with types as necessary.
+::
 ++  expect-schematic
   |=  [expected=schematic actual=vase]
   ^-  tang

--- a/tests/sys/vane/clay.hoon
+++ b/tests/sys/vane/clay.hoon
@@ -84,7 +84,7 @@
             (expect-eq !>(%.n) !>(live.note))
           ::
           %-  expect-schematic:test-ford
-          :_  [-:!>(*schematic:ford) schematic.note]
+          :_  !>(schematic.note)
           ^-  schematic:ford
           :+  %pin  ~1111.1.1
           :-  %list

--- a/tests/sys/vane/clay.hoon
+++ b/tests/sys/vane/clay.hoon
@@ -1,4 +1,4 @@
-/+  tester
+/+  tester, test-ford
 ::
 /=  clay-raw  /:  /===/sys/vane/clay  /!noun/
 ::
@@ -83,67 +83,19 @@
           %+  weld
             (expect-eq !>(%.n) !>(live.note))
           ::
-          ?.  ?=(%pin -.schematic.note)
-            [%leaf "bad move, not a %pin: {<move>}"]~
+          %-  expect-schematic:test-ford
+          :_  [-:!>(*schematic:ford) schematic.note]
+          ^-  schematic:ford
+          :+  %pin  ~1111.1.1
+          :-  %list
+          :~  :-  [%$ %path -:!>(*path) /file1/noun]
+              :^  %cast  [~nul %home]  %noun
+              [%$ %noun %noun 'file1']
           ::
-          %+  weld
-            (expect-eq !>(~1111.1.1) !>(date.schematic.note))
-          ::
-          =/  list-schematic=schematic:ford  schematic.schematic.note
-          ::
-          ?.  ?=(%list -.list-schematic)
-            [%leaf "bad move, not a %list: {<move>}"]~
-          ::
-          ?.  ?=([* * ~] schematics.list-schematic)
-            [%leaf "bad move, wrong number of sub-schematics: {<move>}"]~
-          ::
-          =/  s1=schematic:ford  i.schematics.list-schematic
-          =/  s2=schematic:ford  i.t.schematics.list-schematic
-          ::  test :s1
-          ::
-          ?.  ?=([^ *] s1)
-            [%leaf "bad move, s1 not cell: {<move>}"]~
-          ::
-          =/  path1=schematic:ford  -.s1
-          ?.  ?=([%$ %path *] path1)
-            [%leaf "bad move, path1 not %path: {<move>}"]~
-          ::
-          =/  vase1=vase  q.literal.path1
-          ::
-          %+  weld
-            (expect-eq !>([-:!>(*path) /file1/noun]) !>(vase1))
-          ::
-          =/  cast1=schematic:ford  +.s1
-          ::
-          ?.  ?=([%cast [%~nul %home] %noun *] cast1)
-            [%leaf "bad move, wrong cast1: {<move>}"]~
-          ::
-          =/  lit1=schematic:ford  input.cast1
-          ::
-          %+  weld
-            (expect-eq !>([%$ %noun %noun 'file1']) !>(lit1))
-          ::  test :s2
-          ::
-          ?.  ?=([^ *] s2)
-            [%leaf "bad move, s2 not cell: {<move>}"]~
-          ::
-          =/  path2=schematic:ford  -.s2
-          ?.  ?=([%$ %path *] path2)
-            [%leaf "bad move, path2 not %path: {<move>}"]~
-          ::
-          =/  vase2=vase  q.literal.path2
-          ::
-          %+  weld
-            (expect-eq !>([-:!>(*path) /file2/noun]) !>(vase2))
-          ::
-          =/  cast2=schematic:ford  +.s2
-          ::
-          ?.  ?=([%cast [%~nul %home] %noun *] cast2)
-            [%leaf "bad move, wrong cast2: {<move>}"]~
-          ::
-          =/  lit2=schematic:ford  input.cast2
-          ::
-          (expect-eq !>([%$ %noun %noun 'file2']) !>(lit2))
+              :-  [%$ %path -:!>(*path) /file2/noun]
+              :^  %cast  [~nul %home]  %noun
+              [%$ %noun %noun 'file2']
+          ==
     ==  ==
   ::
   ;:  welp


### PR DESCRIPTION
Wrote an `+expect-schematic` function in /lib/test/ford/hoon and used it to simplify the Clay tests.