### PR TITLE
Constitution + jael updates

### DIFF
--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -706,6 +706,13 @@
       %-  curd  =<  abet
       (~(pubs ~(feed su our.tac urb sub etn) hen) who.tac)
     ::
+    ::  seen after breach
+    ::    [%meet our=ship who=ship]
+    ::
+        %meet
+      %+  cure  our.tac
+      [[%meet who.tac]~ urb]
+    ::
     ::  watch private keys
     ::    {$vein $~}
     ::
@@ -866,6 +873,7 @@
         +>
       ?-  -.i.hab
         %ethe  (file can.i.hab)
+        %meet  (meet +.i.hab)
         %rite  (paid +.i.hab)
       ==
     ==
@@ -1054,8 +1062,15 @@
     ::
     ?.  (~(exists up mor.del) %jewel)  +>
     vein:feel
-  ::
-  ++  file
+  ::                                                    ::  ++meet:su
+  ++  meet                                              ::  seen after breach
+    |=  who=ship
+    ^+  +>
+    =+  ~|  [%met-unknown-ship who]
+        (~(got by kyz.puk) who)
+    (pubs:feel [[who -(live &)] ~ ~])
+  ::                                                    ::  ++file:su
+  ++  file                                              ::  process event logs
     ::TODO  whenever we add subscriptions for data,
     ::      outsource the updating of relevant state
     ::      to a ++feel arm.

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1077,6 +1077,8 @@
     |=  [new=? evs=logs]
     ^+  +>
     =?  +>  new
+      ::TODO  should we be mutating state here,
+      ::      or better to move this into ++vent:feel?
       +>(dns.eth *dnses, hul.eth ~, kyz.puk ~)
     =?  +>  |(new !=(0 ~(wyt by evs)))
       %-  vent:feel
@@ -1152,6 +1154,7 @@
       ::
       ::  sanity checks, should never fail if we operate correctly
       ::
+      ~|  %diff-order-insanity
       ?>  ?+  -.dif  &
             %spawned      ?>  ?=(^ kid.hul)
                           !(~(has in spawned.u.kid.hul) who.dif)
@@ -1512,9 +1515,11 @@
   ::
   ::  +|  filter-results
   ::
-  ::  +wake: kick polling
+  ::  +wake: kick polling, unless we changed source
   ::
-  ++  wake  poll-filter
+  ++  wake
+    ?.  ?=(%| -.source)  .
+    poll-filter
   ::
   ::  +sigh: parse rpc response and process it
   ::

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1123,11 +1123,6 @@
       ^-  [hel=hull kez=(unit (pair life pass))]
       =+  hul=(fall (~(get by hul.eth) who) *hull)
       ::
-      ::  if new, first dif must be %full
-      ::  XX review, requirement seems obsolete
-      ::
-      :: ?>  |((~(has by hul.eth) who) ?=(%full -.dif))
-      ::
       ::  sanity checks, should never fail if we operate correctly
       ::
       ?>  ?+  -.dif  &

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -61,7 +61,7 @@
         ==                                              ::
       $=  puk                                           ::  public keys (pubs)
         $:  yen=(jug ship duct)                         ::  trackers
-            kyz=(map ship (map life pass))              ::  public key versions
+            kyz=(map ship public)                       ::  public key state
         ==                                              ::
       $=  eth                                           ::  ethereum (vent)
         ::TODO  the subscribers here never hear dns or hul...
@@ -900,11 +900,10 @@
     ++  pubs
       |=  who=ship
       %_  ..feed
-        moz      =/  zen  (~(get by kyz.puk) who)
-                 ?~  zen  moz
-                 =/  lyf  (roll ~(tap in ~(key by u.zen)) max)
-                 ?:  =(0 lyf)  moz
-                 [[hen %give %pubs lyf u.zen] moz]
+        moz      =/  pub  (~(get by kyz.puk) who)
+                 ?~  pub  moz
+                 ?:  =(0 life.u.pub)  moz
+                 [[hen %give %pubs u.pub] moz]
         yen.puk  (~(put ju yen.puk) who hen)
       ==
     ::                                                  ::  ++vein:feed:su
@@ -933,33 +932,25 @@
     |%
     ::                                                  ::  ++pubs:feel:su
     ++  pubs                                            ::  kick public keys
-      |=  kez=(map ship (map life pass))
-      =/  kes  ~(tap by kez)
+      ::  puz: new public key states
+      |=  puz=(map ship public)
+      =/  pus  ~(tap by puz)
       ::
       ::  process change for each ship separately
       ::
       |-  ^+  ..feel
-      ?~  kes  ..feel
-      =;  fel  $(kes t.kes, ..feel fel)
-      =*  who  p.i.kes
-      =*  kyn  q.i.kes
-      =/  lyf  (roll ~(tap in ~(key by kyn)) max)
-      ::
-      ::  build new public key store
-      ::
-      =+  %+  ~(put by kyz.puk)  who
-          =-  (~(uni by -) kyn)
-          (fall (~(get by kyz.puk) who) ~)
+      ?~  pus  ..feel
+      =;  fel  $(pus t.pus, ..feel fel)
+      =*  who  p.i.pus
+      =*  pub  q.i.pus
       ::
       ::  update public key store and notify subscribers
-      ::  of the change
+      ::  of the new state
       ::
-      ::  XX we're sending a map here, but it only contains the update
-      ::  send full key history? or use [%pubs =life =pass]
-      ::
-      %+  exec(kyz.puk -)
+      ~&  [%sending-pubs-about who]
+      %+  exec(kyz.puk (~(put by kyz.puk) who pub))
         (~(get ju yen.puk) who)
-      [%give %pubs lyf kyn]
+      [%give %pubs pub]
     ::                                                  ::  ++vein:feel:su
     ++  vein                                            ::  kick private keys
       ^+  ..feel
@@ -1077,22 +1068,39 @@
       ?:(new &+evs |+evs)
     ::
     =+  vez=(order-events:ez ~(tap by evs))
-    =|  kyz=(map ship (map life pass))
+    =|  kyz=(map ship public)
     |^  ?~  vez  (pubs:feel kyz)
         =^  kyn  ..file  (file-event i.vez)
         $(vez t.vez, kyz kyn)
     ::
+    ++  get-public
+      |=  who=ship
+      ^-  public
+      %+  fall  (~(get by kyz) who)
+      ::NOTE  we can only do this because ++pubs:feel
+      ::      sends out entire new state, rather than
+      ::      just the processed changes.
+      %+  fall  (~(get by kyz.puk) who)
+      %*(. *public live |)
+    ::
     ++  file-keys
       |=  [who=ship =life =pass]
       ^+  kyz
-      =/  zen  (fall (~(get by kyz) who) ~)
-      =/  pub  (~(get by zen) life)
-      ?~  pub
-        %+  ~(put by kyz)
-          who
-        (~(put by zen) life pass)
-      ~|  [%key-mismatch who life]
-      ?>(=(u.pub pass) kyz)
+      =/  pub  (get-public who)
+      =/  puk  (~(get by pubs.pub) life)
+      ?^  puk
+        ::  key known, nothing changes
+        ~|  [%key-mismatch who life]
+        ?>(=(u.puk pass) kyz)
+      %+  ~(put by kyz)  who
+      :+  live.pub
+        (max life life.pub)
+      (~(put by pubs.pub) life pass)
+    ::
+    ++  file-discontinuity
+      |=  who=ship
+      =+  (get-public who)
+      (~(put by kyz) who -(live |))
     ::
     ++  file-event
       |=  [wer=event-id dif=diff-constitution]
@@ -1117,10 +1125,14 @@
       |=  [who=ship dif=diff-hull]
       ^+  [kyz ..file]
       =-  ::TODO  =; with just the type
-        :-  ?~  kez  kyz
-            (file-keys who u.kez)
+        :-  ?:  ?=(%& -.new)
+              (file-keys who p.new)
+            ?:  p.new  kyz
+            (file-discontinuity who)
         ..file(hul.eth (~(put by hul.eth) who hel))
-      ^-  [hel=hull kez=(unit (pair life pass))]
+      ::  hel: updated hull
+      ::  new: new keypair or "kept continuity?" (yes is no-op)
+      ^-  [hel=hull new=(each (pair life pass) ?)]
       =+  hul=(fall (~(get by hul.eth) who) *hull)
       ::
       ::  sanity checks, should never fail if we operate correctly
@@ -1134,14 +1146,16 @@
                           =(new.dif +(continuity-number.u.net.hul))
           ==
       ::
-      ::  apply hull changes, catch key changes
+      ::  apply hull changes, catch continuity and key changes
       ::
       :-  (apply-hull-diff hul dif)
-      ?+  -.dif  ~
-        %keys   `[life pass]:dif
-        %full   ?~  net.new.dif  ~
-                ::TODO  do we want/need to do a diff-check
-                `[life pass]:u.net.new.dif
+      =*  nop  |+&  ::  no-op
+      ?+  -.dif  nop
+        %continuity   |+|
+        %keys         &+[life pass]:dif
+        %full         ?~  net.new.dif  nop
+                      ::TODO  do we want/need to do a diff-check
+                      &+[life pass]:u.net.new.dif
       ==
     ::
     ++  file-dns

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1982,6 +1982,7 @@
       logs                                              ::  | new events
     ++  change                                          ::  urbit change
       $%  [%ethe can=chain]                             ::  on-chain change
+          [%meet who=ship]                              ::  meet in new era
           $:  %rite                                     ::  rights change
               rex/ship                                  ::  issuer
               pal/ship                                  ::  issued to
@@ -2032,6 +2033,7 @@
           ::TODO  %next for generating/putting new private key
           [%nuke ~]                                     ::  cancel tracker from
           [%pubs our=ship who=ship]                     ::  view public keys
+          [%meet our=ship who=ship]                     ::  met after breach
           [%vein our=ship]                              ::  view signing keys
           [%vent our=ship]                              ::  view ethereum events
           [%vest our=ship]                              ::  view public balance

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -398,6 +398,16 @@
         0xcfe3.69b7.197e.7f0c.f067.93ae.2472.a9b1.
           3583.fecb.ed2f.78df.a14d.1f10.796b.847c
       ::
+      ::  ChangedManager(address,address)
+      ++  changed-manager
+        0x73cd.9f21.dac5.ada0.0bce.c622.ae57.b362.
+          3d62.867a.0104.48a4.fa99.19b1.af37.8de7
+      ::
+      ::  ChangedDelegate(address,address)
+      ++  changed-delegate
+        0x3aca.0f3b.26ca.e754.a743.7b18.4417.8ce6.
+          07f2.1ca0.cbed.955e.0621.96d3.3c91.de6c
+      ::
       ::  ChangedDns(string,string,string)
       ++  changed-dns
         0xfafd.04ad.e1da.ae2e.1fdb.0fc1.cc6a.899f.
@@ -6573,7 +6583,6 @@
         `[who %escape `wer]
       ::
       ?:  =(event.log escape-canceled)
-        ::TODO verify this is safe, topics are 2 uints
         =/  who=@  (decode-topics topics.log ~[%uint])
         `[who %escape ~]
       ::
@@ -6608,9 +6617,18 @@
             (decode-topics topics.log ~[%uint %address])
         `[who %transfer-proxy tox]
       ::
-      ::NOTE  0x8be0...57e0 is Owneable's OwnershipTransferred(address,address).
-      ::      changed-dns is handled separately since it doesn't affect hulls.
-      ~&  [%unimplemented-event event.log]
+      ~?  ?!
+          ?|  =(event.log changed-manager)
+            ::
+              =(event.log changed-delegate)
+            ::
+              ::  contract owner changed
+              .=  event.log
+              ::  OwnershipTransferred(address,address)
+              0x8be0.079c.5316.5914.1344.cd1f.d0a4.f284.
+                1949.7f97.22a3.daaf.e3b4.186f.6b64.57e0
+          ==
+        [%unimplemented-event event.log]
       ~
     ::
     ++  apply-hull-diff

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1989,7 +1989,7 @@
       ==  ==                                            ::
     ++  gift                                            ::  out result <-$
       $%  [%mack p=(unit tang)]                         ::  message n/ack
-          [%pubs =life pubs=(map life pass)]            ::  public keys
+          [%pubs public]                                ::  public keys
           {$vest p/tally}                               ::  balance update
           [%vein =life vein=(map life ring)]            ::  private keys
           {$vine p/(list change)}                       ::  all raw changes
@@ -2002,6 +2002,11 @@
           [%e %hiss p=(unit user) q=mark r=cage]        ::  outbound user req
           [%a %want p=sock q=path r=*]                  ::  send message
           [%j %vent-result p=chain]                     ::  tmp workaround
+      ==                                                ::
+    ++  public                                          ::  public key state
+      $:  live=?                                        ::  seen in current era
+          life=life                                     ::  current key number
+          pubs=(map life pass)                          ::  pubkeys by number
       ==                                                ::
     ++  remote                                          ::  remote notification
       %+  each  safe                                    ::  &/addition


### PR DESCRIPTION
This PR contains two sets of changes.

First, it updates the zuse-constitution and jael logic to work more cleanly with the current version of the contracts. Aside from a few tweaks, I did a quick look-over of the existing logic, and it all still seems to match the contracts.

Secondly, it makes jael track continuity... sort of. When a ship indicates a continuity breach on-chain (or we've just never met it before), its `live` aka continuity flag will get set to `|`. It is then up to @joemfb's modified ames to send a `%meet` task to jael when we finally manage to connect with that ship again, setting the flag to `&`.  
Changes to this flag get sent as part of the existing `%pubs` subscription, which has been updated to always send full public key state for a ship (now `[live=? life=life pubs=(map life pass)]`) rather than just the changes.

...That continuity flag is stored as part of jael's `state-relative`, even though it really is absolute state (ie can't be deduced from other parts of the state). It would be more correct to store a list of `[ship life]`s we've "met" alongside the Ethereum event logs, but that also feels a bit janky.  
For now, I feel like this slight architectural mismatch isn't a big deal. This particular piece of state might need more work in the near future, I'd rather wait for the dust to settle before refactoring this.

I have lightly tested this and expect it to be correct based on that. No stress-testing was done though, but the logic here isn't too fragile.