### PR TITLE
Run tests in alphabetical order.

### DIFF
--- a/lib/test/runner.hoon
+++ b/lib/test/runner.hoon
@@ -16,6 +16,9 @@
   |=  paths-to-tests=(map path (list test-arm))
   ^-  (list test)
   ::
+  %-  sort  :_  |=([a=test b=test] !(aor path.a path.b))
+  ::
+  ^-  (list test)
   %-  zing
   %+  turn  ~(tap by paths-to-tests)
   |=  [=path test-arms=(list test-arm)]


### PR DESCRIPTION
This runs and displays tests in alphabetical order instead of in whatever ordering there was in the map.