### PR TITLE
Fix %reef handling more. Now uses the right part of the arvo core

### DIFF
--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -4675,6 +4675,9 @@
       =/  zuse-build=^build
         :*  date.build
             %ride  zuse-hoon
+            ::  hoon for `..is` to grab the :pit out of the arvo core
+            ::
+            %ride  [%cnts ~[[%& 1] %is] ~]
             %ride  arvo-hoon
             %ride  hoon-hoon
             [%$ %noun !>(~)]

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -3535,7 +3535,7 @@
     (expect-ford-empty ford-gate ~nul)
   ==
 ::
-++  disabled-slow-test-reef
+++  disabled-test-reef-slow
   ::
   =/  hoon-parsed=hoon
     (rain /~nul/base/~1234.5.6/sys/hoon/hoon hoon-scry)
@@ -3554,7 +3554,9 @@
   ~&  %hoon-compiled
   =/  arvo-compiled=vase  (slap hoon-compiled arvo-parsed)
   ~&  %arvo-compiled
-  =/  zuse-compiled=vase  (slap arvo-compiled zuse-parsed)
+  =/  pit-compiled=vase   (slap arvo-compiled [%cnts ~[[%& 1] %is] ~])
+  ~&  %pit-compiled
+  =/  zuse-compiled=vase  (slap pit-compiled zuse-parsed)
   ~&  %zuse-compiled
   ::
   =/  scry-results=(map [term beam] cage)


### PR DESCRIPTION
Now when Ford builds the standard library, it compiles Zuse against the `..is` core from Arvo. This is how Arvo itself builds Zuse. Up until now, we had been compiling Zuse against the whole Arvo core, which took longer to cause errors than I would have expected, but it did eventually cause some. This patch should fix those.

I left the `+disabled-test-reef-slow` unit test disabled for CI because it lives up to its name, but I verified it does pass.

@joemfb you probably want to see this too, since you found the bug with us.