### PR TITLE
Enqueue second Clay write during an Arvo event

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -187,7 +187,7 @@
 ::      location).
 ::  --  `hez` is the unix duct that %ergo's should be sent to.
 ::  --  `cez` is a collection of named permission groups.
-::  --  `cue` is a queue of request to perform in later events.
+::  --  `cue` is a queue of requests to perform in later events.
 ::  --  `tip` is the date of the last write; if now, enqueue incoming requests.
 ::
 ++  raft                                                ::  filesystem

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -187,6 +187,8 @@
 ::      location).
 ::  --  `hez` is the unix duct that %ergo's should be sent to.
 ::  --  `cez` is a collection of named permission groups.
+::  --  `cue` is a queue of request to perform in later events.
+::  --  `tip` is the date of the last write; if now, enqueue incoming requests.
 ::
 ++  raft                                                ::  filesystem
   $:  fat/(map ship room)                               ::  domestic

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -195,6 +195,8 @@
       mon/(map term beam)                               ::  mount points
       hez/(unit duct)                                   ::  sync duct
       cez/(map @ta crew)                                ::  permission groups
+      cue/(qeu [duct task:able])                        ::  queued requests
+      tip/@da                                           ::  last write date
   ==                                                    ::
 ::
 ::  Object store.
@@ -3681,6 +3683,17 @@
     [mos ..^$]
   ::
       $info
+    ::  second write at :now gets enqueued with a timer to be run in next event
+    ::
+    ?:  =(now tip.ruf)
+      =.  cue.ruf  (~(put to cue.ruf) [hen req])
+      =/  =move  [hen %pass /queued-request %b %wait now]
+      ::
+      [~[move] ..^$]
+    ::  set the last date to now so we'll know to enqueue a second write
+    ::
+    =.  tip.ruf  now
+    ::
     ?:  =(%$ des.req)
       [~ ..^$]
     =^  mos  ruf
@@ -3903,7 +3916,7 @@
       =+  ruf.old
       :*  (~(run by fat) rom)
           (~(run by hoy) run)
-          ran  mon  hez  ~
+          ran  mon  hez  ~  ~  *@da
       ==
     ::
     ++  wov
@@ -4112,7 +4125,15 @@
   ::
       $note  [[hen %give +.q.hin]~ ..^$]
       $wake
-    ~|  %why-wakey  !!
+    =^  queued  cue.ruf  ~(get to cue.ruf) 
+    ::
+    =/  queued-duct=duct       -.queued
+    =/  queued-task=task:able  +.queued
+    ::
+    ~|  [%mismatched-ducts %queued queued-duct %timer hen]
+    ?>  =(hen queued-duct)
+    ::
+    (call hen [-:!>(*task:able) queued-task])
     ::  =+  dal=(turn ~(tap by fat.ruf) |=([a=@p b=room] a))
     ::  =|  mos=(list move)
     ::  |-  ^-  [p=(list move) q=_..^^$]

--- a/tests/sys/vane/clay.hoon
+++ b/tests/sys/vane/clay.hoon
@@ -65,7 +65,7 @@
         ::
           ^-  tang
           ::
-          =/  move=move:clay-gate  i.t.t.moves
+          =/  move=move:clay-gate                        i.t.t.moves
           =/  =duct                                      p.move
           =/  card=(wind note:clay-gate gift:able:clay)  q.move
           ::
@@ -109,7 +109,7 @@
   =^  results2  clay-gate
     %-  clay-take-with-comparator  :*
       clay-gate
-      now=~2222.2.2
+      now=~1111.1.1
       scry=*sley
       ^=  take-args
         :*  wire=/castifying/~nul/home/~1111.1.1
@@ -160,7 +160,7 @@
   =^  results3  clay-gate
     %-  clay-take  :*
       clay-gate
-      now=~3333.3.3
+      now=~1111.1.1
       scry=*sley
       ^=  take-args
         :*  wire=/mutating/~nul/home/~1111.1.1
@@ -175,7 +175,7 @@
   =^  results4  clay-gate
     %-  clay-take  :*
       clay-gate
-      now=~4444.4.4
+      now=~1111.1.1
       scry=*sley
       ^=  take-args
         :*  wire=/diffing/~nul/home/~1111.1.1
@@ -190,7 +190,7 @@
   =^  results5  clay-gate
     %-  clay-take-with-comparator  :*
       clay-gate
-      now=~5555.5.5
+      now=~1111.1.1
       scry=*sley
       ^=  take-args
         :*  wire=/inserting/~nul/home/~1111.1.1
@@ -261,7 +261,7 @@
   =^  results6  clay-gate
     %-  clay-take  :*
       clay-gate
-      now=~6666.6.6
+      now=~1111.1.1
       scry=*sley
       ^=  take-args
         :*  wire=/patching/~nul/home
@@ -287,8 +287,7 @@
                     [%success %volt %noun %noun 'file1']
         ==  ==  ==
       ^=  expected-moves
-        :~  :*  duct=~[/init]  %give  %note  '+'  %rose
-                ["/" "/" ~]
+        :~  :*  duct=~[/init]  %give  %note  '+'  %rose  ["/" "/" ~]
                 :~  [%leaf "~nul"]
                     [%leaf "home"]
                     [%leaf "1"]
@@ -296,14 +295,146 @@
                     [%leaf "noun"]
             ==  ==
         ::
-            :*  duct=~[/init]  %give  %note  '+'  %rose
-                ["/" "/" ~]
+            :*  duct=~[/init]  %give  %note  '+'  %rose  ["/" "/" ~]
                 :~  [%leaf "~nul"]
                     [%leaf "home"]
                     [%leaf "1"]
                     [%leaf "file2"]
                     [%leaf "noun"]
     ==  ==  ==  ==
+  ::  make a second write request during the same arvo event
+  ::
+  ::    This should produce a Behn timer at `now` to run the write
+  ::    request.
+  ::
+  =^  results7  clay-gate
+    %-  clay-call-with-comparator  :*
+      clay-gate
+      now=~1111.1.1
+      scry=*sley
+      ^=  call-args
+        :+  duct=~[/info2]  type=-:!>(*task:able:clay)
+        ^-  task:able:clay
+        :^  %info  ~nul  %home
+        ^-  nori:clay
+        :-  %&
+        ^-  soba:clay
+        :~  [/file3/noun `miso:clay`[%ins [%noun %noun 'file3']]]
+            [/file4/noun `miso:clay`[%ins [%noun %noun 'file4']]]
+        ==
+      ^=  comparator
+        |=  moves=(list move:clay-gate)
+        ^-  tang
+        ::
+        ?.  ?=([* ~] moves)
+          [%leaf "wrong number of moves: {<moves>}"]~
+        ::
+        =/  move=move:clay-gate                        i.moves
+        =/  =duct                                      p.move
+        =/  card=(wind note:clay-gate gift:able:clay)  q.move
+        ::
+        %+  weld
+          (expect-eq !>(~[/info2]) !>(duct))
+        ::
+        ?.  ?=(%pass -.card)
+          [%leaf "bad move, not a %pass: {<move>}"]~
+        ::
+        =/  =wire  p.card
+        ::
+        %+  weld
+          (expect-eq !>(/queued-request) !>(wire))
+        ::
+        =/  note=note:clay-gate  q.card
+        ::
+        ?.  ?=([%b %wait *] note)
+          [%leaf "bad move, not a %wait: {<move>}"]~
+        ::
+        (expect-eq !>(~1111.1.1) !>(p.note))
+    ==
+  ::
+  =^  results8  clay-gate
+    %-  clay-take-with-comparator  :*
+      clay-gate
+      now=~2222.2.2
+      scry=*sley
+      ^=  take-args
+        :*  wire=/queued-request
+            duct=~[/info2] 
+            -:!>(*sign:clay-gate)
+            ^-  sign:clay-gate
+            [%b %wake ~]
+        ==
+      ^=  comparator
+        |=  moves=(list move:clay-gate)
+        ^-  tang
+        ::
+        ?.  ?=([* * * ~] moves)
+          [%leaf "wrong number of moves: {<(lent moves)>}"]~
+        ::
+        ^-  tang
+        ;:  weld
+          %+  expect-eq
+            !>  ^-  move:clay-gate
+                :-  duct=~[/info2]
+                ^-  (wind note:clay-gate gift:able:clay)
+                :+  %pass  /castifying/~nul/home/~2222.2.2
+                ^-  note:clay-gate
+                :-  %f
+                [%build ~nul live=%.n [%pin ~2222.2.2 [%list ~]]]
+            !>  i.moves
+        ::
+          %+  expect-eq
+            !>  ^-  move:clay-gate
+                :-  duct=~[/info2]
+                ^-  (wind note:clay-gate gift:able:clay)
+                :+  %pass  /diffing/~nul/home/~2222.2.2
+                ^-  note:clay-gate
+                :-  %f
+                [%build ~nul live=%.n [%pin ~2222.2.2 [%list ~]]]
+            !>  i.t.moves
+        ::
+          ^-  tang
+          ::
+          =/  move=move:clay-gate                        i.t.t.moves
+          =/  =duct                                      p.move
+          =/  card=(wind note:clay-gate gift:able:clay)  q.move
+          ::
+          %+  weld
+            (expect-eq !>(~[/info2]) !>(duct))
+          ::
+          ?.  ?=(%pass -.card)
+            [%leaf "bad move, not a %pass: {<move>}"]~
+          ::
+          =/  =wire  p.card
+          ::
+          %+  weld
+            (expect-eq !>(/inserting/~nul/home/~2222.2.2) !>(wire))
+          ::
+          =/  note=note:clay-gate  q.card
+          ::
+          ?.  ?=([%f %build *] note)
+            [%leaf "bad move, not a %build: {<move>}"]~
+          ::
+          %+  weld
+            (expect-eq !>(~nul) !>(our.note))
+          ::
+          %+  weld
+            (expect-eq !>(%.n) !>(live.note))
+          ::
+          %-  expect-schematic:test-ford
+          :_  schematic.note
+          ^-  schematic:ford
+          :+  %pin  ~2222.2.2
+          :-  %list
+          :~  :-  [%$ %path -:!>(*path) /file3/noun]
+              :^  %cast  [~nul %home]  %noun
+              [%$ %noun %noun 'file3']
+          ::
+              :-  [%$ %path -:!>(*path) /file4/noun]
+              :^  %cast  [~nul %home]  %noun
+              [%$ %noun %noun 'file4']
+          ==
+    ==  ==
   ::
   ;:  welp
     results0
@@ -313,6 +444,7 @@
     results4
     results5
     results6
+    results7
   ==
 ::  |utilities: helper functions for testing
 ::


### PR DESCRIPTION
All but the first write request during an Arvo event gets enqueued, to be run in a later event triggered by a Behn timer. There's a test on this behavior, which passes.

This doesn't entirely fix referential transparency for date-base read requests, but it should at least make it less likely for referential transparency to be violated. Fixing this problem in its entirety is actually a bit tricky, and we will need to think it through in more detail. This is just a quick patch.

The failing case is that someone does a read request at the current date, then does a write request in the same Arvo event, then performs the same read request a second time, which now has a different answer.

I still think it's worth adding this to see if we can unblock the collections integration, even if it doesn't get us all the way to correctness. We should not use this solution indefinitely, though.