### PR TITLE
Fix +grad case in +make-join

### DIFF
--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -560,6 +560,7 @@
 ++  build-to-tape
   |=  =build
   ^-  tape
+  ~+
   ::
   =/  enclose  |=(tape "[{+<}]")
   =/  date=@da  date.build
@@ -1734,9 +1735,6 @@
     ~/  %add-subs-to-client
     |=  [new-client=build new-subs=(list build) =build-relation]
     ^+  builds.state
-    ::  the client must not add itself as a sub-build
-    ::
-    ?<  (lien new-subs |=(b=build =(new-client b)))
     ::
     %+  ~(jab by builds.state)  new-client
     |=  =build-status
@@ -2124,9 +2122,6 @@
     ++  track-sub-builds
       |=  [client=build sub-builds=(list build)]
       ^+  state
-      ::  the client must not add itself as a sub-build
-      ::
-      ?<  (lien sub-builds |=(b=build =(client b)))
       ::  mark :sub-builds as :subs in :build's +build-status
       ::
       =^  build-status  builds.state
@@ -5362,7 +5357,9 @@
       |=  kid=^build
       ^-  [(unit build-result) _out]
       ::
-      ?<  =(kid build)
+      ?:  =(kid build)
+        ~|  [%depend-on-self (build-to-tape kid)]
+        !!
       ::
       =.  sub-builds.out  [kid sub-builds.out]
       ::  +access-build-record will mutate :results.state

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -1734,6 +1734,9 @@
     ~/  %add-subs-to-client
     |=  [new-client=build new-subs=(list build) =build-relation]
     ^+  builds.state
+    ::  the client must not add itself as a sub-build
+    ::
+    ?<  (lien new-subs |=(b=build =(new-client b)))
     ::
     %+  ~(jab by builds.state)  new-client
     |=  =build-status
@@ -2121,6 +2124,9 @@
     ++  track-sub-builds
       |=  [client=build sub-builds=(list build)]
       ^+  state
+      ::  the client must not add itself as a sub-build
+      ::
+      ?<  (lien sub-builds |=(b=build =(client b)))
       ::  mark :sub-builds as :subs in :build's +build-status
       ::
       =^  build-status  builds.state
@@ -3229,10 +3235,15 @@
         =/  grad-mark=(unit term)  ((sand %tas) q.grad-vase)
         ?~  grad-mark
           %-  return-error  :_  ~  :-  %leaf
-          "ford: %pact failed: %{<mark>} mark invalid +grad"
+          "ford: %join failed: %{<mark>} mark invalid +grad"
+        ::  todo: doesn't catch full cycles of +grad arms, only simple cases
+        ::
+        ?:  =(u.grad-mark mark)
+          %-  return-error  :_  ~  :-  %leaf
+          "ford: %join failed: %{<mark>} mark +grad arm refers to self"
         ::
         =/  join-build=^build
-          [date.build [%join disc mark [%$ first-cage] [%$ second-cage]]]
+          [date.build [%join disc u.grad-mark [%$ first-cage] [%$ second-cage]]]
         ::
         =^  join-result  out  (depend-on join-build)
         ?~  join-result
@@ -5350,6 +5361,8 @@
     ++  depend-on
       |=  kid=^build
       ^-  [(unit build-result) _out]
+      ::
+      ?<  =(kid build)
       ::
       =.  sub-builds.out  [kid sub-builds.out]
       ::  +access-build-record will mutate :results.state

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -5603,6 +5603,78 @@
     (expect-ford-empty ford-gate ~nul)
   ==
 ::
+++  test-join-grad  ^-  tang
+  ::
+  =/  hoon-src-type=type  [%atom %$ ~]
+  ::
+  =/  scry-results=(map [term beam] (unit cage))
+    %-  my  :~
+      :-  [%cx [[~nul %home %da ~1234.5.6] /hoon/txt/mar]]
+      :^  ~  %hoon  hoon-src-type
+      txt-scry
+    ::
+      :-  [%cx [[~nul %home %da ~1234.5.6] /hoon/txt-diff/mar]]
+      :^  ~  %hoon  hoon-src-type
+      diff-scry
+    ::
+      :-  [%cx [[~nul %home %da ~1234.5.6] /hoon/diff/txt/mar]]
+      ~
+    ::
+      :-  [%cx [[~nul %home %da ~1234.5.6] /hoon/hoon/mar]]
+      :^  ~  %hoon  hoon-src-type
+      '''
+      |_  foo=@t
+      ++  grab
+        |%
+        ++  noun  @t
+        ++  txt  of-wain:format
+        --
+      ++  grow
+        |%
+        ++  txt  (to-wain:format foo)
+        --
+      ++  grad  %txt
+      --
+      '''
+    ==
+  ::
+  =^  results1  ford-gate
+    %-  ford-call-with-comparator  :*
+      ford-gate
+      now=~1234.5.6
+      scry=(scry-with-results-and-failures scry-results)
+      ::
+      ^=  call-args
+        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+            :^  %join  [~nul %home]  %hoon
+            ::  replace %a with %c on the first line
+            ::
+            :-  [%$ %txt-diff !>(~[[%| ~[%a] ~[%c]] [%& 1]])]
+            ::  replace %b with %d on the second line
+            ::
+            [%$ %txt-diff !>(~[[%& 1] [%| ~[%b] ~[%d]]])]
+        ==
+      ::
+      ^=  comparator
+        |=  moves=(list move:ford-gate)
+        ::
+        ?>  =(1 (lent moves))
+        ?>  ?=(^ moves)
+        ?>  ?=([* %give %made @da %complete *] i.moves)
+        =/  result  result.p.card.i.moves
+        ?>  ?=([%success %join *] build-result.result)
+        ::
+        =/  =cage  cage.build-result.result
+        ::
+        =/  result=(urge:clay cord)  ~[[%| ~[%a] ~[%c]] [%| ~[%b] ~[%d]]]
+        (expect-cage %txt-diff !>(result) cage)
+    ==
+  ::
+  ;:  weld
+    results1
+    (expect-ford-empty ford-gate ~nul)
+  ==
+::
 ++  test-list  ^-  tang
   ::
   =/  ud-type=type  [%atom %ud ~]


### PR DESCRIPTION
This fixes a bug in +make-join where following the +grad arm will cause a build to add itself as a dependency. This adds a test to ensure this doesn't regress.

This also adds several assertion that ensure that a client is not in the list of its sub builds, which were useful in tracking down this bug.

review: @belisarius222 
cc: @ixv 