### PR TITLE
Add @q, phonetic data representation

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -5293,6 +5293,7 @@
 ++  dem  (bass 10 (most gon dit))                       ::  decimal to atom
 ++  dit  (cook |=(a/@ (sub a '0')) (shim '0' '9'))      ::  decimal digit
 ++  dog  ;~(plug dot gay)                               ::  .  number separator
+++  dof  ;~(plug hep gay)                               ::  - @q separator
 ++  doh  ;~(plug ;~(plug hep hep) gay)                  ::  --  phon separator
 ++  dun  (cold ~ ;~(plug hep hep))                      ::  -- (stop) to ~
 ++  duz  (cold ~ ;~(plug tis tis))                      ::  == (stet) to ~
@@ -5480,6 +5481,11 @@
              haf:ab                                     ::  star
              tiq:ab                                     ::  galaxy
            ==
+  ++  feq  %+  cook  |=(a=(list @) (rep 4 (flop a)))
+           ;~  plug
+             ;~(pose hif:ab tiq:ab)
+             (star ;~(pfix dof hif:ab))
+           ==
   ++  fim  (sear den:fa (bass 58 (plus fem:ab)))
   ++  hex  (ape (bass 0x1.0000 ;~(plug qex:ab (star ;~(pfix dog qix:ab)))))
   ++  lip  =+  tod=(ape ted:ab)
@@ -5597,6 +5603,20 @@
                 ?:(=((mod imp 4) 0) ?:(=(imp 0) "" "--") "-")
                 rep
              ==
+          ==
+        ::
+            $q
+          =*  val  q.p.lot
+          :+  '.'  '~'
+          =-  =.(rep (weld - rep) rep)
+          %-  tail
+          %+  roll  ?:(=(0 val) ~[0] (rip 3 val))
+          |=  [q=@ s=? r=tape]
+          :-  !s
+          ;:  weld
+            (trip (?:(s tod:po tos:po) q))
+            ?:(&(s !=(r "")) "-" ~)
+            r
           ==
         ::
             $r
@@ -5896,6 +5916,7 @@
       (stag %if lip:ag)
       royl
       (stag %f ;~(pose (cold & (just 'y')) (cold | (just 'n'))))
+      (stag %q ;~(pfix sig feq:ag))
     ==
   --
 ::

--- a/tests/sys/hoon/auras.hoon
+++ b/tests/sys/hoon/auras.hoon
@@ -1,0 +1,42 @@
+/+  *test
+|%
+++  test-parse-q
+  ;:  weld
+    %+  expect-eq
+      !>  .~zod
+      !>  `@q`0x0
+    ::
+    %+  expect-eq
+      !>  .~marbud
+      !>  `@q`0x102
+    ::
+    %+  expect-eq
+      !>  .~nec-marbud
+      !>  `@q`0x1.0102
+    ::
+    %+  expect-eq
+      !>  .~marnec-marnec-marnec-marnec-marbud
+      !>  `@q`0x101.0101.0101.0101.0102
+    ::
+  ==
+::
+++  test-render-q
+  ;:  weld
+    %+  expect-eq
+      !>  '.~zod'
+      !>  (scot %q 0x0)
+    ::
+    %+  expect-eq
+      !>  '.~marbud'
+      !>  (scot %q 0x102)
+    ::
+    %+  expect-eq
+      !>  '.~nec-marbud'
+      !>  (scot %q 0x1.0102)
+    ::
+    %+  expect-eq
+      !>  '.~marnec-marnec-marnec-marnec-marbud'
+      !>  (scot %q 0x101.0101.0101.0101.0102)
+    ::
+  ==
+--


### PR DESCRIPTION
It's `@p`, except never scrambles, doesn't care about even number of bytes, and doesn't use `--` in large values.  
This is needed for tickets, and useful for anything else that may want to use the `@p` look-and-feel to display data.

Syntax for literals is `.~`. A `.~` by itself is invalid, you need at least one syllable. They follow byte ordering as in the `@ux` case, so:

```hoon
@ux       @q
0x1       .~nec
0x201     .~binnec
0x3.0201  .~wes-binnec
```

Note that leading zeroes are valid, but won't change the value. `.~dozzod-dozzod` is equivalent to `.~zod`.

I have included some tests! Pretty sure this is how you test auras: just using them.