### PR TITLE
fix clay cache for non-%mime entries; also add equality check as optimization

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1168,14 +1168,30 @@
         =/  mis=miso  q.i.p.lem
         ?>  ?=(%mut -.mis)
         =/  cag=cage  p.mis
-        =/  mim=mime  ((hard mime) q.q.cag)
-        ::  if we have the %mime value cached, there's no change to apply
+        ::  if :mis has the %mime mark and it's the same as cached, no-op
         ::
-        =?    mut.nuz
-            !=(`mim (~(get by mim.dom) pax))
-          [i.p.lem mut.nuz]
+        ?:  ?.  =(%mime p.cag)
+              %.n
+            ?~  cached=(~(get by mim.dom) pax)
+              %.n
+            =(((hard mime) q.q.cag) u.cached)
+          ::
+          $(p.lem t.p.lem)
+        ::  if the :mis mark is the target mark and the value is the same, no-op
         ::
-        $(p.lem t.p.lem)
+        ?:  =/  target-mark=mark  =+(spur=(flop pax) ?~(spur !! i.spur))
+            ?.  =(target-mark p.cag)
+              %.n
+            ::
+            =/  stored            (need (need (read-x:ze let.dom pax)))
+            =/  stored-cage=cage  ?>(?=(%& -.stored) p.stored)
+            ::
+            =(q.q.stored-cage q.q.cag)
+          ::
+          $(p.lem t.p.lem)
+        ::  the value differs from what's stored, so register mutation
+        ::
+        $(p.lem t.p.lem, mut.nuz [i.p.lem mut.nuz])
       ==
     ::  sort each section alphabetically for determinism
     ::


### PR DESCRIPTION
My previous PR (https://github.com/urbit/arvo/pull/839) could crash on some inputs that weren't of mark `%mime`. This PR fixes that, and it adds an optimization: if Clay receives a new version of a file (a `%mut` `+miso`), first check noun equality of its contents against the current contents for that path; if they're the same noun, don't produce a Ford build for that path.