### PR TITLE
reinstated ++poke-lens-command with changes

### DIFF
--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -1814,6 +1814,10 @@
   |=  act/sole-action  ~|  poke+act  %.  act
   (wrap he-type):arm
 ::
+++  poke-lens-command
+  |=  com/command:^^^^lens  ~|  poke-lens+com  %.  com
+  (wrap he-lens):arm
+::
 ++  poke-json
   |=  jon/json
   ^-  {(list move) _+>.$}


### PR DESCRIPTION
Added ++poke-lens-command back into dojo.hoon with a similar fix to the addition of ++he-lens