### PR TITLE
Remove forced ssl upgrade for localhost http requests

### DIFF
--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -6288,9 +6288,7 @@
       ;~(plug auri (punt ;~(pfix hax (cook crip (star pque)))))
     ::                                                  ::  ++auri:de-purl:html
     ++  auri                                            ::  2396 URL
-      %+  cook
-        |=  a/purl
-        ?.(?=(hoke r.p.a) a a(p.p &))
+      %+  cook  |~(a/purl a)
       ;~  plug
         ;~(plug htts thor)
         ;~(plug ;~(pose apat (easy *pork)) yque)

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -6288,7 +6288,6 @@
       ;~(plug auri (punt ;~(pfix hax (cook crip (star pque)))))
     ::                                                  ::  ++auri:de-purl:html
     ++  auri                                            ::  2396 URL
-      %+  cook  |~(a/purl a)
       ;~  plug
         ;~(plug htts thor)
         ;~(plug ;~(pose apat (easy *pork)) yque)


### PR DESCRIPTION
I've been playing around trying to glue urbit and IPFS together. For my first iteration, I tried to `+curl` my local IPFS API from the Dojo. Because `go-ipfs` [doesn't implement HTTPS](https://github.com/ipfs/faq/issues/136#issuecomment-227264141), I made sure to do a `+curl "http://localhost:5001..."`, but I was still getting an ssl related error:
```
> +curl "http://localhost:5001/api/v0/get?arg=QmagqTLSZvdqjWp2hVFokDyThekNAACsUG8r2XGhBWPQh6"
< http://localhost:5001/api/v0/get?arg=QmagqTLSZvdqjWp2hVFokDyThekNAACsUG8r2XGhBWPQh6
http: fail (170, 504): ssl handshake failure
HTTP 504
```

Talking to @Fang- at the last meetup, he reassured me this should not be happening, and specifying "http" should do a regular non-ssl request. I dug in a bit and found the issue: in the definition for `++  auri` there is a conditional to check if this is a localhost request (using `++  hoke`), and if so, it forces it to use SSL.

This PR removes this forced upgrade, so i can specify either an http or https request to localhost.

There might be a reason for this check, but I couldn't find one. I did some git spelunking and found that this was added in commit 2c3c4c8b1db6f8617ae5376c54297560114bd599 , so maybe @cgyarvin knows if this is still needed or not.

Also, I don't fully grok the implications of creating this "iron gate" here; I cargo-culted from a similar-looking `++  aurf` definition above and it worked :)