### PR TITLE
Make Ethereum snapshots work with children

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1365,13 +1365,18 @@
       ~&  [%hear-pubs tea sih]
       =/  our=ship  (slav %p i.t.tea)
       =/  her=ship  (slav %p i.t.t.t.tea)
-      ?:  =(0 life.sih)
-        ~&  %ames-hear-empty-pubs
-        [~ +>.$]
-      =/  ded=deed
-        [life.sih (~(got by pubs.sih) life.sih) oath=~]
       =/  gus  (need (~(us go ton.fox) our))
       =/  diz  (myx:gus her)
+      ?:  =(0 life.sih)
+          ::  this should clear lew.wod.dur.diz because it means
+          ::  we know longer trust that their public key came to
+          ::  us honestly (becuse of a %jael snapshot restore).
+          ::  in practice, that crashes in ++cluy:las:as:go, so
+          ::  we ignore for now.
+          ~&  [%ames-hear-empty-pub her]
+          [~ +>.$]
+      =/  ded=deed
+        [life.sih (~(got by pubs.sih) life.sih) oath=~]
       =.  lew.wod.dur.diz  `ded
       =.  ton.fox  (~(su go ton.fox) (nux:gus diz))
       [~ +>.$]

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -2091,7 +2091,21 @@
   ::                                                    ::  ++restore-snap:et
   ++  restore-snap                                      ::  restore snapshot
     |=  snap=snapshot
+    ::  update pub subscribers
+    ::
+    =.  +>.$
+      =/  subs=(list (pair ship (set duct)))
+        ~(tap by yen.puk.sub)
+      |-  ^+  +>.^$
+      ?~  subs  +>.^$
+      =/  pub  (fall (~(get by kyz.snap) p.i.subs) %*(. *public live |))
+      =.  +>.^$  (exec q.i.subs [%give %pubs pub])
+      $(subs t.subs)
+    ::  update vent subscribers
+    ::
+    =.  +>.$  (vent-pass yen.eth snap+snap)
     ::  keep the following in sync with ++extract-snap:file:su
+    ::
     %=  +>.$
         eve.urb       eve.snap
         etn           etn.snap(source source.etn)
@@ -2099,7 +2113,29 @@
         +.eth.sub     eth.snap
         sap           sap(last-block 0)
     ==
-  ::
+  ::                                                    ::  ++exec:et
+  ++  exec                                              ::  mass gift
+    |=  {yen/(set duct) cad/card}
+    =/  noy  ~(tap in yen)
+    |-  ^+  ..exec
+    ?~  noy  ..exec
+    $(noy t.noy, moves [[i.noy cad] moves])
+  ::                                                    ::  ++vent-pass:et
+  ++  vent-pass                                         ::  "give" vent
+    |=  [yen=(set duct) res=vent-result]
+    =+  yez=~(tap in yen)
+    |-  ^+  ..vent-pass
+    ?~  yez  ..vent-pass
+    =*  d  i.yez
+    ?>  ?=([[%a @ @ *] *] d)
+    =+  our=(slav %p i.t.i.d)
+    =+  who=(slav %p i.t.t.i.d)
+    %+  exec  [d ~ ~]
+    :+  %pass
+      /(scot %p our)/vent-result
+    ^-  note:able
+    [%a %want [our who] /j/(scot %p our)/vent-result %vent-result res]
+  ::                                                    ::  ++feed:su
   --
 --
 ::                                                      ::::

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -95,7 +95,7 @@
   $%  [%hail p=remote]                                  ::  reset rights
       [%nuke ~]                                         ::  cancel trackers
       [%vent ~]                                         ::  view ethereum events
-      [%vent-result p=chain]                            ::  tmp workaround
+      [%vent-result p=vent-result]                      ::  tmp workaround
   ==                                                    ::
 ++  card                                                ::  i/o action
   (wind note:able gift)                                 ::
@@ -724,7 +724,7 @@
       ::
       =.  +>.$
         ?~  snap.tac  +>.$
-        (restore-snap u.snap.tac)
+        (restore-snap hen our u.snap.tac)
       ::
       =.  moz
         %+  weld  moz
@@ -984,7 +984,8 @@
   ++  cure                                              ::  absolute edits
     |=  {hen/duct our/ship hab/(list change) urb/state-absolute}
     ^+  +>
-    (curd(urb urb) abet:(~(apex su hen our urb sub etn sap) hab))
+    =.  ^urb  urb
+    (curd abet:(~(apex su hen our urb sub etn sap) hab))
   ::                                                    ::  ++cute:of
   ++  cute                                              ::  ethereum changes
     |=  $:  hen=duct
@@ -997,7 +998,12 @@
             sap=state-snapshots
         ==
     ^+  +>
-    %-  cure(urb urb, sub sub, etn etn, sap sap, moz (weld (flop mos) moz))
+    =:  ^urb  urb
+        ^sub  sub
+        ^etn  etn
+        ^sap  sap
+    ==
+    %-  cure(moz (weld (flop mos) moz))
     [hen our abet:(link:(burb our) ven)]
   ::                                                    ::  ++wind:of
   ++  wind                                              ::  rewind to snap
@@ -1024,7 +1030,7 @@
         [snap.snap +>.^$]
       $
     ~&  [%wind block latest-block.etn.snap ~(wyt by hul.eth.snap)]
-    =.  +>.$  (restore-snap snap)
+    =.  +>.$  (restore-snap hen our snap)
     %=    +>.$
         moz
       =-  [[hen %pass /wind/look %j %look our -] moz]
@@ -1035,15 +1041,9 @@
     ==
   ::                                                    ::  ++restore-snap:of
   ++  restore-snap                                      ::  restore snapshot
-    |=  snap=snapshot
-    ::  keep the following in sync with ++extract-snap:file:su
-    %=  +>.$
-        eve.urb       eve.snap
-        etn           etn.snap(source source.etn)
-        kyz.puk.sub   kyz.snap
-        +.eth.sub     eth.snap
-        sap           sap(last-block 0)
-    ==
+    |=  [hen=duct our=@p snap=snapshot]
+    %^  cute  hen  our  =<  abet
+    (~(restore-snap et our now.sys urb.lex sub.lex etn.lex sap.lex) snap)
   --
 ::                                                      ::  ++su
 ::::                    ## relative^heavy               ::  subjective engine
@@ -1084,7 +1084,7 @@
     ::TODO  we really want to just send the %give, but ames is being a pain.
     :: =>  (exec yen.eth [%give %vent |+evs])
     =>  ?~  evs  .
-        (vent-pass yen.eth |+evs)
+        (vent-pass yen.eth chain+|+evs)
     [(flop moz) sub etn sap]
   ::                                                    ::  ++apex:su
   ++  apex                                              ::  apply changes
@@ -1109,7 +1109,7 @@
     $(noy t.noy, moz [[i.noy cad] moz])
   ::
   ++  vent-pass
-    |=  [yen=(set duct) res=chain]
+    |=  [yen=(set duct) res=vent-result]
     =+  yez=~(tap in yen)
     |-  ^+  ..vent-pass
     ?~  yez  ..vent-pass
@@ -1153,7 +1153,7 @@
       ==
     ::
     ++  vent
-      %.  [[hen ~ ~] &+eve]
+      %.  [[hen ~ ~] chain+&+eve]  ::  XX  send snap
       %_  vent-pass
       :: %_  ..feed  ::TODO  see ++abet
         :: moz      [[hen %give %vent &+eve] moz]
@@ -1231,11 +1231,11 @@
       ==
     ::
     ++  vent
-      |=  can=chain
+      |=  ver=vent-result
       ^+  ..feel
       ::TODO  see ++abet
       :: (exec yen.eth [%give %vent can])
-      (vent-pass yen.eth can)
+      (vent-pass yen.eth ver)
     --
   ::                                                    ::  ++form:su
   ++  form                                              ::  generate reports
@@ -1348,6 +1348,7 @@
       +>(dns.eth *dnses, hul.eth ~, kyz.puk ~)
     =?  +>  |(new !=(0 ~(wyt by evs)))
       %-  vent:feel
+      :-  %chain
       ?:(new &+evs |+evs)
     ::
     =+  vez=(order-events:ez ~(tap by evs))
@@ -1860,17 +1861,21 @@
   ::  +hear-vent: process incoming events
   ::
   ++  hear-vent
-    |=  can=chain
+    |=  =vent-result
     ^+  +>
-    ?-  -.can
-      %&   (assume p.can)
-      ::
-        %|
-      =+  evs=~(tap by p.can)
-      |-
-      ?~  evs  +>.^$
-      =.  +>.^$  (accept i.evs)
-      $(evs t.evs)
+    ?-  -.vent-result
+        %snap  (restore-snap snap.vent-result)
+        %chain
+      ?-  -.can.vent-result
+        %&   (assume p.can.vent-result)
+        ::
+          %|
+        =+  evs=~(tap by p.can.vent-result)
+        |-
+        ?~  evs  +>.^$
+        =.  +>.^$  (accept i.evs)
+        $(evs t.evs)
+      ==
     ==
   ::
   ::  +assume: clear state and process events
@@ -1878,7 +1883,7 @@
   ++  assume
     |=  evs=logs
     ^+  +>
-    %.  |+evs
+    %.  chain+|+evs
     %_  hear-vent
       heard         ~
       latest-block  0
@@ -2076,6 +2081,17 @@
     =+  dif=(event-log-to-hull-diff log)
     ?~  dif  +>.$
     (put-change cuz %hull u.dif)
+  ::                                                    ::  ++restore-snap:et
+  ++  restore-snap                                      ::  restore snapshot
+    |=  snap=snapshot
+    ::  keep the following in sync with ++extract-snap:file:su
+    %=  +>.$
+        eve.urb       eve.snap
+        etn           etn.snap(source source.etn)
+        kyz.puk.sub   kyz.snap
+        +.eth.sub     eth.snap
+        sap           sap(last-block 0)
+    ==
   ::
   --
 --

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1394,9 +1394,8 @@
         [kyz ..file]
       ::
       ::  sanity check, should never fail if we operate correctly
-      ::  XX is this true in the presence of reorgs?
       ::
-      ::  ?>  (gte block.wer latest-block)
+      ?>  (gte block.wer latest-block)
       =:  evs           (~(put by evs) wer dif)
           heard         (~(put in heard) wer)
           latest-block  (max latest-block block.wer)
@@ -1481,8 +1480,11 @@
           %+  sub.add
             (div block.wer interval.sap)
           (div last-block.sap interval.sap)
-        ~&  :*  %snap  count=count.sap  max-count=max-count.sap 
-                last-block=last-block.sap  interval=interval.sap
+        ~&  :*  %snap
+                count=count.sap
+                max-count=max-count.sap
+                last-block=last-block.sap
+                interval=interval.sap
                 lent=(lent ~(tap to snaps.sap))
             ==
         %=  sap
@@ -1491,7 +1493,7 @@
           last-block  block.wer
         ==
       =?  sap  (gth count.sap max-count.sap)
-        ~&  :*  %dump  count=count.sap  max-count=max-count.sap 
+        ~&  :*  %dump  count=count.sap  max-count=max-count.sap
                 lent=(lent ~(tap to snaps.sap))
             ==
         %=  sap
@@ -2005,7 +2007,6 @@
     ?:  ?=(%error -.rep)
       ~&  [%catch-up-step-error--retrying message.rep]
       (catch-up from-block)
-    ::  XX file
     =.  +>.$  (take-events rep)
     (catch-up next-block)
   ::

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1153,7 +1153,14 @@
       ==
     ::
     ++  vent
-      %.  [[hen ~ ~] chain+&+eve]  ::  XX  send snap
+      =/  last-snap
+        |-  ^-  snapshot
+        =^  snap=[@ud snap=snapshot]  snaps.sap
+          ~(get to snaps.sap)
+        ?:  =(~ snaps.sap)
+          snap.snap
+        $
+      %.  [[hen ~ ~] snap+last-snap]
       %_  vent-pass
       :: %_  ..feed  ::TODO  see ++abet
         :: moz      [[hen %give %vent &+eve] moz]

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -2012,6 +2012,11 @@
         (map ship safe)                                 ::  liabilities
       (map ship safe)                                   ::  assets
     ::                                                  ::
+    ++  vent-result                                     ::  %vent result
+      $%  [%snap snap=snapshot:jael]                    ::  restore snapshot
+          [%chain can=chain]                            ::  get new events
+      ==                                                ::
+    ::                                                  ::
     ++  chain                                           ::  batch of changes
       %+  each  logs                                    ::  & all events
       logs                                              ::  | new events
@@ -2031,7 +2036,7 @@
           {$vest p/tally}                               ::  balance update
           [%vein =life vein=(map life ring)]            ::  private keys
           {$vine p/(list change)}                       ::  all raw changes
-          [%vent p=chain]                               ::  ethereum changes
+          [%vent p=vent-result]                         ::  ethereum changes
       ==                                                ::
     ::                                                  ::
     ++  note                                            ::  out request $->
@@ -2047,7 +2052,7 @@
       $%  [%want p=sock q=path r=*]                     ::  send message
       ==  ==                                            ::
           $:  %j                                        ::
-      $%  [%vent-result p=chain]                        ::  tmp workaround
+      $%  [%vent-result p=vent-result]                  ::  tmp workaround
           [%look our=ship src=(each ship purl:eyre)]    ::
       ==  ==                                            ::
           $:  @tas                                      ::
@@ -2069,7 +2074,7 @@
     ++  sign                                            ::  in result $<-
       $%  {$b $wake ~}                                  ::  wakeup
           [%e %sigh p=cage]                             ::  marked http response
-          [%j %vent p=chain]                            ::  ethereum changes
+          [%j %vent p=vent-result]                      ::  ethereum changes
           [%a %woot p=ship q=coop]                      ::  message result
       ==                                                ::
     ++  tally                                           ::  balance update


### PR DESCRIPTION
OT: How's the frequency/size of PR's?  Should I be bunching these changes into larger PR's?

Couple of things:

- Use snapshots to initialize children rather than just sending them the event log and having them rederive the state.
- Properly update subscribers when a snapshot happens, as described in the following email snippet:

> When we restore a snapshot, it should be fine to just spam out a `%pubs` update for each ship to every subscriber, right?  In practice, it looks like the subscribers are ames for each our neighbors (?), so this will be linear in the number of neighbors, which is fine.  Subscribers just need to make sure they the the update as complete -- i.e. it may remove keys that you thought were real.
>
> For vents, I figure we just use the snapshot mechanism itself.  When a snapshot is applied, all vent subscribers should get that snapshot.  Thus, for example, when ~zod restores a snapshot, the flow is:
>
> - ~zod jael spams a pub to ames (1 per neighbor)
> - ~zod passes the snapshot to ~marzod
> - ~marzod spams a pub to ames (1 per neighbor)
> - ~marzod passes the snapshot to its children