### PR TITLE
fix eyre path parsing for security drivers

### DIFF
--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -743,7 +743,9 @@
       %-  emule  |.  ^+  ..apex
       =*  sec  p.kyz    ::  ?                           ::  https bit
       =*  heq  r.kyz    ::  httq                        ::  request content
-      =+  ryp=`quri`(rash q.heq zest:de-purl)
+      =/  ryp=quri
+        =+  (rush q.heq zest:de-purl)
+        ?^(- u.- ~|(eyre-parse-url-failed+q.heq !!))
       =+  maf=(eat-headers r.heq)
       =+  ^=  pul  ^-  purl
           ?-  -.ryp

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -6398,7 +6398,7 @@
       ;~(pose pcar net wut)
     ::                                                  ::  ++pquo:de-purl:html
     ++  pquo                                            ::  normal query char
-      ;~(pose pure pesc pold net wut)
+      ;~(pose pure pesc pold net wut col)
     ::                                                  ::  ++pure:de-purl:html
     ++  pure                                            ::  2396 unreserved
       ;~(pose aln hep dot cab sig)


### PR DESCRIPTION
Sometime this summer (fall?), %eyre stopped successfully parsing oauth2 redirect urls from google.

An example with the printf added in this pr:

[ %eyre-parse-url-failed
  \/'/~/ac/googleapis.com/_state/in?state=_&code=4/ZZZZZZZZFyuRFw3mZZZZZZZZZ8Z\/
    ZZZZZZZZCym_B9DFiOlwPTMvZZZZZZZZpzLLqk1MvcBiNQZZZZZZZZIwFg3o&scope=openid%
    20email%20https://mail.google.com%20https://www.googleapis.com/auth/plus.m
    e%20https://www.googleapis.com/auth/userinfo.email%20https://www.googleapi
    s.com/auth/ndev.clouddns.readwrite%20https://www.googleapis.com/auth/cloud
    -platform.read-only'
  \/                                                                          \/
]

The culprit is the colon(s) in the scope parameter. There seems to be some disagreement about whether it needs to be escaped in url query-parameters. Regardless, we need to be able to parse these urls ...