### PR TITLE
refactors %eyre %born task, prunes pending requests

### DIFF
--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -678,9 +678,45 @@
     =.  our  ?~(hov our u.hov)  ::  XX
     =.  p.top  our              ::  XX necessary?
     ?-    -.kyz
+        ::  new unix process - learn of first boot or a restart.
+        ::
         $born
-      ::  XX capture IPs too
-      ::  XX continue to support turf in %born? (currently unused)
+      ::  save outgoing duct
+      ::
+      =.  ged  hen
+      ::  give %form to start servers
+      ::
+      =.  mow  :_(mow [hen [%give %form fig]])
+      ::  kill active incoming requests
+      ::
+      =.  +>.$
+        =/  fok=(list duct)  ~(tap in ~(key by lyv))
+        |-  ^+   +>.^$
+        ?~  fok  +>.^$
+        %=  $
+          fok    t.fok
+          +>.^$  ^$(hen i.fok, kyz [%thud ~])
+        ==
+      ::  kill active outgoing requests
+      ::
+      =.  +>.$
+        =/  fok=(list duct)  ~(tap in ~(key by kes))
+        |-  ^+   +>.^$
+        ?~  fok  +>.^$
+        %=  $
+          fok    t.fok
+          +>.^$  ^$(hen i.fok, kyz [%them ~])
+        ==
+      ::  if galaxy, request %ames domain from %jael
+      ::
+      ::    %jael response handled in $turf branch of +axon.
+      ::
+      =?  mow  ?=(%czar (clan:title our))  :_(mow [hen %pass / %j %turf ~])
+      ::  learn externally known domain names
+      ::
+      ::    If any are new, request certificate. XX currently unused. remove?
+      ::    XX %born card also includes locally-known IPs. use for DNS?
+      ::
       ::
       =/  mod/(set turf)
         %-  ~(gas in *(set turf))
@@ -692,12 +728,7 @@
       =?  mow  ?=(^ dif)
         =/  cmd  [%acme %poke `cage`[%acme-order !>(dom)]]
         :_(mow [hen %pass /acme/order %g %deal [our our] cmd])
-      =?  mow  ?=(%czar (clan:title our))
-        :_(mow [hen %pass / %j %turf ~])
-      %=  +>.$
-        ged  hen                                        ::  register external
-        mow  :_(mow [hen [%give %form fig]])
-      ==
+      +>.$
     ::
         $live
       +>.$(clr.por p.kyz, sek.por q.kyz)


### PR DESCRIPTION
I've been seeing the %eyre `%pump-blocked` error from urbit/urbit#784 on the testnet. I believe it's caused by open requests persisting across restarts.