### PR TITLE
Invalid Hoon literals in sail syntax

### DIFF
--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -551,7 +551,7 @@
       ;head:title:"Redirecting..."
       ;body
         ;p: Redirecting to ;{a/"{url}" "{url}"}
-        ;script: setTimeout(function()\{document.location = {(en-json (tape:enjs url))}}, 3000)
+        ;script:'setTimeout(function()\{document.location = {(en-json (tape:enjs url))}}, 3000)'
       ==
     ==
   ::

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -551,7 +551,7 @@
       ;head:title:"Redirecting..."
       ;body
         ;p: Redirecting to ;{a/"{url}" "{url}"}
-        ;script:'setTimeout(function()\{document.location = {(en-json (tape:enjs url))}}, 3000)'
+        ;script:"setTimeout(function()\{document.location = {(en-json (tape:enjs url))}}, 3000)"
       ==
     ==
   ::

--- a/web/landscape/profile/settings.hoon
+++ b/web/landscape/profile/settings.hoon
@@ -10,24 +10,24 @@
     ;div.row.mt-4
       ;div.flex-col-2;
       ;div.flex-col-x
-        ;a.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-devices]")[0].classList.add("hide"); document.querySelectorAll("[urb-qr]")[0].classList.remove("hide");})()')): Connect device
-        ;h2.mt-6: Devices
+        ;a.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-devices]")[0].classList.add("hide"); document.querySelectorAll("[urb-qr]")[0].classList.remove("hide");})()')):'Connect device'
+        ;h2.mt-6:'Devices'
         ;h3.text-mono.mt-4: 108.208.53.121
-        ;div: Current session
+        ;div:'Current session'
         ;h3.text-mono.mt-4: 67.188.43.52
-        ;div: Chrome on OS X 10.12.6
+        ;div:'Chrome on OS X 10.12.6'
         ;div
-          ;span.mr-3: Last login:
+          ;span.mr-3:'Last login:'
           ;span.text-mono: 2018.4.21
         ==
         ;h3.text-mono.mt-4: 43.222.12.64
         ;div: iOS 14.11
         ;div
-          ;span.mr-3: Last login:
+          ;span.mr-3:'Last login:'
           ;span.text-mono: 2018.3.12
         ==
         ;div.mt-6
-          ;a.h3.vanilla.text-red(href "javascript:void(0)"): Log Out ↓
+          ;a.h3.vanilla.text-red(href "javascript:void(0)"):'Log Out ↓'
         ==
       ==
     ==
@@ -40,8 +40,8 @@
           =urb-component  "QRCodeComponent"
           =urb-ship       "{(scow %p p.bem.gas)}"
           =urb-code       "{cod}";
-        ;h2.mt-8.mt-0.text-500.profile-qr-desc: Scan this code to connect your device
-        ;a.mt-4.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-qr]")[0].classList.add("hide"); document.querySelectorAll("[urb-devices]")[0].classList.remove("hide");})()')): Done
+        ;h2.mt-8.mt-0.text-500.profile-qr-desc:'Scan this code to connect your device'
+        ;a.mt-4.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-qr]")[0].classList.add("hide"); document.querySelectorAll("[urb-devices]")[0].classList.remove("hide");})()')):'Done'
       ==
     ==
   ==

--- a/web/landscape/profile/settings.hoon
+++ b/web/landscape/profile/settings.hoon
@@ -11,23 +11,23 @@
       ;div.flex-col-2;
       ;div.flex-col-x
         ;a.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-devices]")[0].classList.add("hide"); document.querySelectorAll("[urb-qr]")[0].classList.remove("hide");})()')):'Connect device'
-        ;h2.mt-6:'Devices'
+        ;h2.mt-6:"Devices"
         ;h3.text-mono.mt-4: 108.208.53.121
-        ;div:'Current session'
+        ;div:"Current session"
         ;h3.text-mono.mt-4: 67.188.43.52
-        ;div:'Chrome on OS X 10.12.6'
+        ;div:"Chrome on OS X 10.12.6"
         ;div
-          ;span.mr-3:'Last login:'
+          ;span.mr-3:"Last login:"
           ;span.text-mono: 2018.4.21
         ==
         ;h3.text-mono.mt-4: 43.222.12.64
         ;div: iOS 14.11
         ;div
-          ;span.mr-3:'Last login:'
+          ;span.mr-3:"Last login:"
           ;span.text-mono: 2018.3.12
         ==
         ;div.mt-6
-          ;a.h3.vanilla.text-red(href "javascript:void(0)"):'Log Out ↓'
+          ;a.h3.vanilla.text-red(href "javascript:void(0)"):"Log Out ↓"
         ==
       ==
     ==
@@ -40,8 +40,8 @@
           =urb-component  "QRCodeComponent"
           =urb-ship       "{(scow %p p.bem.gas)}"
           =urb-code       "{cod}";
-        ;h2.mt-8.mt-0.text-500.profile-qr-desc:'Scan this code to connect your device'
-        ;a.mt-4.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-qr]")[0].classList.add("hide"); document.querySelectorAll("[urb-devices]")[0].classList.remove("hide");})()')):'Done'
+        ;h2.mt-8.mt-0.text-500.profile-qr-desc:"Scan this code to connect your device"
+        ;a.mt-4.vanilla.btn.btn-primary(href (trip 'javascript:(function(){document.querySelectorAll("[urb-qr]")[0].classList.add("hide"); document.querySelectorAll("[urb-devices]")[0].classList.remove("hide");})()')):"Done"
       ==
     ==
   ==


### PR DESCRIPTION
Having unleashed working parts of the new parser onto entire arvo tree, the 
tokenizer uncovered a following problem:
In sail syntax it is permissible to have unquoted string literals. 
This is very bad for future code introspection purposes, and I would like to put this up for discussion, 
i.e. IMHO we in the future compiler sail syntax should only permit proper literals without 
non-standard quirks