### PR TITLE
Update /lib/keygen to match latest spec

### DIFF
--- a/lib/keygen.hoon
+++ b/lib/keygen.hoon
@@ -28,6 +28,14 @@
   %+  to-seed:bip39  nom
   (trip (fall pass ''))
 ::
+++  derive-network-seed
+  |=  [mngs=@ rev=@ud]
+  ^-  @ux
+  =+  (seed:ds 64^mngs (weld "network" (a-co:co rev)))
+  ?:  =(0 rev)  -
+  ::  hash again to prevent length extension attacks
+  (sha-256l:sha 32 -)
+::
 ++  full-wallet-from-ticket
   ::  who:    username
   ::  ticket: password
@@ -62,7 +70,7 @@
     %+  to-seed:bip39
       seed:management
     (trip (fall pass ''))
-  =+  sed=(seed:ds 64^mad (weld "network" (a-co:co rev)))
+  =+  sed=(derive-network-seed mad rev)
   [rev sed (urbit:ds sed)]
 ::
 ++  ds                                                  ::  derive from raw seed

--- a/tests/lib/keygen.hoon
+++ b/tests/lib/keygen.hoon
@@ -156,7 +156,7 @@
     !>  =-  -(network *uode)
         %-  full-wallet-from-ticket
         :+  ~nec  ::  1
-          4^0x1.0102  ::TODO  .~doznec-marbud
+          4^.~doznec-marbud
         [0 ~]
 ::
 ++  test-generate-wallet-1
@@ -246,7 +246,7 @@
         =-  -(voting *node)
         %-  full-wallet-from-ticket
         :+  ~matbyr  ::  65.012
-          8^0x102.af04.0506.0798  ::TODO  .~marbud-tidsev-litsut-hidfep
+          8^.~marbud-tidsev-litsut-hidfep
         [0 ~]
 ::
 ++  test-generate-wallet-2
@@ -326,13 +326,10 @@
         %-  full-wallet-from-ticket
         :+  ~zod
           :-  48
-          0xc5a.b5ba.ea8e.e798.21d3.fc9f.8876.6da1.
-           95bd.d4a6.3375.32fe.8f7f.d92f.d5f4.446a.
-           f9bf.0006.a211.823b.fbc9.a701.01e6.6f1f
-          ::TODO  .~wacfus-dabpex-danted-mosfep-pasrud-lavmer-
-          ::        nodtex-taslus-pactyp-milpub-pildeg-fornev-
-          ::        ralmed-dinfeb-fopbyr-sanbet-sovmyl-dozsut-
-          ::        mogsyx-mapwyc-sorrup-ricnec-marnys-lignex
+          .~wacfus-dabpex-danted-mosfep-pasrud-lavmer-
+            nodtex-taslus-pactyp-milpub-pildeg-fornev-
+            ralmed-dinfeb-fopbyr-sanbet-sovmyl-dozsut-
+            mogsyx-mapwyc-sorrup-ricnec-marnys-lignex
         [6 `'froot loops']
 ::
 ++  test-derive-network-seed-rev-0

--- a/tests/lib/keygen.hoon
+++ b/tests/lib/keygen.hoon
@@ -334,4 +334,15 @@
           ::        ralmed-dinfeb-fopbyr-sanbet-sovmyl-dozsut-
           ::        mogsyx-mapwyc-sorrup-ricnec-marnys-lignex
         [6 `'froot loops']
+::
+++  test-derive-network-seed-rev-0
+  %+  expect-eq
+    !>  (seed:ds 64^0x5eed "network0")
+    !>  (derive-network-seed 0x5eed 0)
+::
+++  test-derive-network-seed-rev-up
+  %+  expect-eq
+    !>  |
+    !>  .=  (seed:ds 64^0x5eed "network1")
+        (derive-network-seed 0x5eed 1)
 --


### PR DESCRIPTION
For details on these changes, see urbit/fora-posts#9.

The tests here mimic what's done in keygen-js, but the "doesn't equal" case looks a little bit silly because `/lib/test` doesn't offer a non-equivalence check yet.

Also taking this chance to update the tests to use actual `@q` notation, now that that's in.