### PR TITLE
Additional caching in the arvo kernel

### DIFF
--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -132,7 +132,7 @@
   ::
   ++  wink                                              ::  deploy
     |=  {now/@da eny/@ ski/slyd}
-    =+  rig=(slym q.sew +<)                             ::  activate vane
+    =^  rig  p.sew  (~(slym wa p.sew) q.sew +<)         ::  activate vane
     ~%  %wink  +>+>  ~
     |%
     ++  doze
@@ -159,12 +159,14 @@
       |=  {gat/vase hil/mill}
       ^-  (unit (pair vase worm))
       =^  sam  p.sew  (~(slot wa p.sew) 6 gat)
-      =+  ^=  hig
+      =^  hig  p.sew
         ?-  -.hil
           %&  (~(nest wa p.sew) p.sam p.p.hil)
           %|  (~(nets wa p.sew) p.sam p.p.hil)
         ==
-      ?.(-.hig ~ `[(slym gat +>.hil) +.hig])
+      ?.  hig
+        ~
+      `(~(slym wa p.sew) gat +>.hil)
     ::
     ++  slur-a  ~/(%slur-a |=({gat/vase hil/mill} =+(%a (slur gat hil))))
     ++  slur-b  ~/(%slur-b |=({gat/vase hil/mill} =+(%b (slur gat hil))))

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -13901,7 +13901,7 @@
 ++  wa  !:                                              ::  cached compile
   |_  worm
   ++  nell  |=(ref/type (nest [%cell %noun %noun] ref)) ::  nest in cell
-  ++  nest                                              ::  nest:ut
+  ++  nest                                              ::  nest:ut, cached
     |=  {sut/type ref/type}
     ^-  {? worm}
     ?:  (~(has in nes) [sut ref])  [& +>+<]
@@ -13991,6 +13991,11 @@
     ^-  {vase worm}
     =^  gun  +>+<  (mint p.vax [%$ axe])
     [[p.gun .*(q.vax [0 axe])] +>+<.$]
+  ::
+  ++  slym                                              ::  ++slym, cached
+    |=  {gat/vase sam/*}
+    ^-  [vase worm]
+    (slap gat(+<.q sam) [%limb %$])
   ::
   ++  sped                                              ::  specialize vase
     |=  vax/vase


### PR DESCRIPTION
The +slym on each vane activation and each invocation of +slur should cache the type calculation.

(Over the shoulder coded with Ted.)