### PR TITLE
dual boot with cc-release

### DIFF
--- a/.travis/get-or-build-pill.sh
+++ b/.travis/get-or-build-pill.sh
@@ -33,7 +33,7 @@ mkdir prev
     |autoload |
     |mount %
   .
-  [ $? = 0 ] && cp -r ../sys prev/zod/home/
+  [ $? = 0 ] && cp -r ../sys prev/zod/home/ && cp ../gen/solid.hoon prev/zod/home/gen/
 } || {
   : Pilling: Parent-pill pier not available, trying preceding pill commit
   HASH2=$(git -C .. log -2 $HASH --format=%H -- sys/ | tail -1)

--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-49b2824783cfeeb8517ba58e06718cb6c55cccdf.tgz
+https://ci-piers.urbit.org/zod-5729d9946a857826ff4b0b6872c59bdb1c7ab22d.tgz

--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-5729d9946a857826ff4b0b6872c59bdb1c7ab22d.tgz
+https://ci-piers.urbit.org/zod-8411424685019d1728002d71c109560b9fd13f2a.tgz

--- a/gen/brass.hoon
+++ b/gen/brass.hoon
@@ -270,19 +270,31 @@
     ::
     =/  pax  (en-beam:format bec tyl)
     =/  lon  .^(arch %cy pax)
+    ::  XX this serialization should use marks
+    ::
     =?  hav  ?=(^ fil.lon)  
-        ?.  ?=({$hoon *} tyl)
+        ?.  ?=  ?($css $hoon $js $json $md $txt $udon $umd)
+            -.tyl
           ::
-          ::  install only hoon files for now
+          ::  install only files with whitelisted marks
           ::
+          ~&  ignoring+pax
           hav
         ::
         ::  cot: file as plain-text octet-stream
         ::
         =;  cot  [[(flop `path`tyl) `[/text/plain cot]] hav]
         ^-  octs
-        ?-    tyl  
-            {$hoon *}
+        ?-    tyl
+            {$json *}
+          =/  dat  .^(json %cx pax)
+          (as-octt:mimes:html (en-json:html dat))
+        ::
+            {$txt *}
+          =/  dat  .^(wain %cx pax)
+          (as-octs:mimes:html (of-wain:format dat))
+        ::
+            *
           =/  dat  .^(@t %cx pax)
           [(met 3 dat) dat]
         ==

--- a/gen/ivory.hoon
+++ b/gen/ivory.hoon
@@ -39,21 +39,21 @@
 =+  whole-formula=q:(~(mint ut %noun) %noun whole-hoon)
 ~&  %ivory-compiled
 ::
-::  tang: standard library (%zuse) installation event
+::  zuse-ovo: standard library installation event
 ::
-=/  tang
+=/  zuse-ovo=ovum
   =/  pax  (weld sys /zuse)
   =/  txt  .^(@ %cx (weld pax /hoon))
-  `ovum`[/vane/zuse [%veer %$ pax txt]]
+  [/vane/zuse [%veer %$ pax txt]]
 ::
-::  installed: kernel with tang installed
+::  installed: Arvo gate (formal instance) with %zuse installed
 ::
-~&  %tang-installing
+~&  %zuse-installing
 =/  installed
-  .*(0 [%7 whole-formula [%9 2 %10 [6 %1 now tang] %0 1]])
-~&  %tang-installed
+  .*(0 [%7 whole-formula [%9 2 %10 [6 %1 now zuse-ovo] %0 1]])
+~&  %zuse-installed
 ::
-::  produce both whole-formula (for jet registration)
-::  and a kernel with the standard library already installed
+::  produce a formula that evaluates :whole-formula (for jet registration),
+::  then ignores that result and produces :installed
 ::
 [%7 whole-formula %1 installed]

--- a/gen/ivory.hoon
+++ b/gen/ivory.hoon
@@ -39,4 +39,21 @@
 =+  whole-formula=q:(~(mint ut %noun) %noun whole-hoon)
 ~&  %ivory-compiled
 ::
-whole-formula
+::  tang: standard library (%zuse) installation event
+::
+=/  tang
+  =/  pax  (weld sys /zuse)
+  =/  txt  .^(@ %cx (weld pax /hoon))
+  `ovum`[/vane/zuse [%veer %$ pax txt]]
+::
+::  installed: kernel with tang installed
+::
+~&  %tang-installing
+=/  installed
+  .*(0 [%7 whole-formula [%9 2 %10 [6 %1 now tang] %0 1]])
+~&  %tang-installed
+::
+::  produce both whole-formula (for jet registration)
+::  and a kernel with the standard library already installed
+::
+[%7 whole-formula %1 installed]

--- a/gen/solid.hoon
+++ b/gen/solid.hoon
@@ -12,7 +12,7 @@
 :-  %say
 |=  $:  [now=@da eny=@uvJ bec=beak]
         arg=$@(~ [top=path ~])
-        dub/_|
+        dub=_|
     ==
 :-  %noun
 ::  sys: root path to boot system, `/~me/[desk]/now/sys`
@@ -27,9 +27,6 @@
 =/  compiler-src  .^(@t %cx (weld compiler-path /hoon))
 =/  arvo-src      .^(@t %cx (weld arvo-path /hoon))
 =/  arvo-formula
-  =;  res
-    ?:(?=(%& -.res) p.res (mean (flop p.res)))
-  %-  mule  |.
   ~&  %solid-loaded
   =/  compiler-hoon  (rain compiler-path compiler-src)
   ?.  dub
@@ -79,7 +76,7 @@
       =/  txt  .^(@ %cx (weld pax /hoon))
       [[%vane den] [%veer abr pax txt]]
     --
-::  arvo with vanes installed
+::  installed: Arvo gate (formal interface) with %zuse and vanes installed
 ::
 =/  installed
   =<  q
@@ -88,7 +85,9 @@
     .*(0 arvo-formula)
   |=  [ovo=ovum ken=*]
   [~ .*(ken [%9 2 %10 [6 %1 now ovo] %0 1])]
-::  produce both the arvo-formula (for jet registration)
-::  and a kernel with the vanes already installed
+::
+::  produce a pair of :arvo-formula (for jet registration) and
+::  the Arvo core (structural interface), which is the context
+::  of the formal Arvo interface gate :installed
 ::
 [arvo-formula .*(installed [%0 7])]

--- a/gen/solid.hoon
+++ b/gen/solid.hoon
@@ -10,59 +10,85 @@
 ::::
   !:
 :-  %say
-|=  $:  {now/@da eny/@uvJ bec/beak}
-        {arg/$@(~ {top/path ~}) dub/_|}
+|=  $:  [now=@da eny=@uvJ bec=beak]
+        arg=$@(~ [top=path ~])
+        dub/_|
     ==
-?~  arg  $(arg ~[top=`path`/(scot %p p.bec)/[q.bec]/(scot %da now)/sys])
-::
 :-  %noun
-=+  pax=`path`(weld top.arg `path`[%hoon ~])
-=+  arp=`path`(weld top.arg `path`[%arvo ~])
+::  sys: root path to boot system, `/~me/[desk]/now/sys`
+::
+=/  sys=path
+  ?^  arg  top.arg
+  /(scot %p p.bec)/[q.bec]/(scot %da now)/sys
+::
+=/  compiler-path  (weld sys /hoon)
+=/  arvo-path      (weld sys /arvo)
 ~&  %solid-start
-=+  txt=.^(@t %cx (weld pax `path`[%hoon ~]))
-=+  rax=.^(@t %cx (weld arp `path`[%hoon ~]))
-=+  ^=  ken
-    =-  ?:(?=(%& -.res) p.res (mean (flop p.res)))
-    ^=  res  %-  mule  |.
-    ~&  %solid-loaded
-    =+  gen=(rain pax txt)
+=/  compiler-src  .^(@t %cx (weld compiler-path /hoon))
+=/  arvo-src      .^(@t %cx (weld arvo-path /hoon))
+=/  arvo-formula
+  =;  res
+    ?:(?=(%& -.res) p.res (mean (flop p.res)))
+  %-  mule  |.
+  ~&  %solid-loaded
+  =/  compiler-hoon  (rain compiler-path compiler-src)
+  ?.  dub
+    ::  compile arvo against hoon, with our current compiler
+    ::
+    =/  whole-hoon=hoon
+      [%tsbn compiler-hoon [%tsbn [%$ 7] (rain arvo-path arvo-src)]]
     ~&  %solid-parsed
-    =+  one=(~(mint ut %noun) %noun gen)
-    ~&  %solid-compiled
-    ?.  dub
-      =+  two=(~(mint ut p.one) %noun (rain arp rax))
-      ~&  %solid-arvo
-      [7 q.one q.two]
-    =+  zax=(cat 3 '=>  ' (cat 3 txt (cat 3 '  ' rax))) 
-    ~&  %solid-double-loading
-    =+  all=.*(0 q.one)
-    ~&  %solid-double-loaded
+    =/  whole-formula  q:(~(mint ut %noun) %noun whole-hoon)
+    ~&  %solid-arvo
+    whole-formula
+  ::  compile arvo against hoon, with a freshly compiled hoon (via +ride)
+  ::
+  ~&  %solid-parsed
+  =/  compiler-formula  q:(~(mint ut %noun) %noun compiler-hoon)
+  ~&  %solid-compiled
+  =/  whole-src
+    (rap 3 ['=>  ' compiler-src '=>  +7  ' arvo-src ~])
+  ~&  %solid-double-loaded
+  =/  whole-formula
     =<  +
-    .*(all [9 2 [0 2] [1 %noun zax] [0 7]])
+    .*  0
+    :+  %7
+      compiler-formula
+    [%9 2 %10 [6 %1 %noun whole-src] [%0 1]]
+  ~&  %solid-double-compiled
+  whole-formula
 ::
-~&  [%solid-kernel `@ux`(mug ken)]
-:-  ken
-=+  all=.*(0 ken)
-=+  ^=  vay  ^-  (list {p/@tas q/path})
-    :~  [%$ /zuse]
-        [%f /vane/ford]
-        [%b /vane/behn]
-        [%d /vane/dill]
-        [%a /vane/ames]
-        [%c /vane/clay]
-        [%g /vane/gall]
-        [%e /vane/eyre]
-        [%j /vane/jael]
-    ==
-|-  ^+  all
-?~  vay  all
-=+  pax=(weld top.arg q.i.vay)
-=+  txt=.^(@ %cx (weld pax `path`[%hoon ~]))
-=+  sam=[now `ovum`[[%gold ~] [%veer p.i.vay pax txt]]]
-~&  [%solid-veer i.vay]
-::  +poke at +10
+~&  [%solid-kernel `@ux`(mug arvo-formula)]
+::  module-ova: vane load operations.
 ::
-=+  gat=.*(all .*(all [0 10]))
-=+  nex=+:.*([-.gat [sam +>.gat]] -.gat)
-$(vay t.vay, all nex)
-
+=/  module-ova=(list ovum)
+    |^  :~  (vent %$ /zuse)
+            (vent %a /vane/ames)
+            (vent %b /vane/behn)
+            (vent %c /vane/clay)
+            (vent %d /vane/dill)
+            (vent %e /vane/eyre)
+            (vent %f /vane/ford)
+            (vent %g /vane/gall)
+            (vent %j /vane/jael)
+        ==
+    ++  vent
+      |=  [abr=term den=path]
+      ^-  ovum
+      =/  pax  (weld sys den)
+      =/  txt  .^(@ %cx (weld pax /hoon))
+      [[%vane den] [%veer abr pax txt]]
+    --
+::  arvo with vanes installed
+::
+=/  installed
+  =<  q
+  %^    spin
+      module-ova
+    .*(0 arvo-formula)
+  |=  [ovo=ovum ken=*]
+  [~ .*(ken [%9 2 %10 [6 %1 now ovo] %0 1])]
+::  produce both the arvo-formula (for jet registration)
+::  and a kernel with the vanes already installed
+::
+[arvo-formula .*(installed [%0 7])]

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -1,7 +1,11 @@
 ::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ::::::  ::::::    Postface                              ::::::
 ::::::  ::::::::::::::::::::::::::::::::::::::::::::::::::::::
-=>  +7
+~>  %slog.[0 leaf+"arvo-boot"]
+=<  |=  {now/@da ovo/*}
+    ^-  *
+    ~>  %slog.[0 leaf+"arvo-event"]
+    .(+> +:(poke now ovo))
 ~>  %slog.[0 leaf+"%arvo-assembly"]
 =-  ~>  %slog.[0 leaf+"%arvo-assembled"]
     -
@@ -559,14 +563,19 @@
   ~&  [%vega-start-hoon hap]
   =+  src=((hard @t) (need (peek now cx+pax)))
   =+  arv=((hard @t) (need (peek now cx+wax)))
-  =+  gen=(rain hap src)
+  ::  construct  =>(hoon =>(+7 arvo))
+  ::
+  =/  gen=hoon
+    :+  %tsbn  (rain hap src)
+    :+  %tsld  (rain zup arv)
+    [%$ 7]
   ~&  %vega-parsed
-  =+  one=(~(mint ut %noun) %noun gen)
+  =/  fol  q:(~(mint ut %noun) %noun gen)
   ~&  %vega-compiled
-  ~&  [%vega-arvo zup]
-  =+  two=(~(mint ut p.one) %noun (rain zup arv))
-  ~&  %vega-minted
-  .*(0 [7 q.one q.two])
+  ::  evaluate :fol to produce the Arvo gate,
+  ::  then produce the Arvo core at +7
+  ::
+  .*(0 [%7 fol %0 7])
 ::
 ++  vega                                                ::  reboot kernel
   |=  {now/@da ova/(list ovum) hap/path zup/path}

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -558,11 +558,11 @@
   ^-  *
   =-  ?:(?=(%& -.res) p.res ((slog p.res) ~))
   ^=  res  %-  mule  |.
-  =+  pax=(weld hap `path`[%hoon ~])
-  =+  wax=(weld zup `path`[%hoon ~])
+  =/  pax  (weld hap /hoon)
+  =/  wax  (weld zup /hoon)
   ~&  [%vega-start-hoon hap]
-  =+  src=((hard @t) (need (peek now cx+pax)))
-  =+  arv=((hard @t) (need (peek now cx+wax)))
+  =/  src  ((hard @t) (need (peek now cx+pax)))
+  =/  arv  ((hard @t) (need (peek now cx+wax)))
   ::  construct  =>(hoon =>(+7 arvo))
   ::
   =/  gen=hoon
@@ -582,22 +582,27 @@
   ^-  (unit {p/(list ovum) q/*})
   =-  ?:(?=(%| -.res) ((slog p.res) ~) `p.res)
   ^=  res  %-  mule  |.
-  =+  ken=(veke now hap zup)
+  =/  ken  (veke now hap zup)
   ~&  [%vega-kernel `@ux`(mug ken)] 
-  =+  ^=  nex
-      ::  +peek at +47
-      ::
-      =+  gat=.*(ken .*(ken [0 47]))
-      (need ((hard (unit @)) .*([-.gat [[now ~] +>.gat]] -.gat)))
+  =/  nex
+    ::  call +peek at +47
+    ::
+    %-  need
+    %-  (hard (unit @))
+    .*(ken [%9 2 %10 [6 %1 now ~] [%9 47 %0 1]])
   ~&  [%vega-compiled hoon-version nex]
   ?>  (lte nex hoon-version)
+  ::  entropy, pending effects, vanes
+  ::
+  =/  sam  [eny ova q.niz]
   ::  +load at +46 or +come at +22
   ::
-  =+  gat=.*(ken .*(ken [0 ?:(=(nex hoon-version) 46 22)]))
-  =+  sam=[eny ova q.niz]
-  =+  raw=.*([-.gat [sam +>.gat]] -.gat)
-  =+  yep=((list ovum) -.raw)
-  [[[~ %vega hap] yep] +.raw]
+  =/  axe  ?:(=(nex hoon-version) 46 22)
+  =/  out
+    .*(ken [%9 2 %10 [6 %1 sam] [%9 axe %0 1]])
+  ::  add a reset notification to the pending effects
+  ::
+  [[[~ %vega hap] ((list ovum) -.out)] +.out]
 ::
 ++  veer                                                ::  install vane/tang
   |=  {now/@da fav/curd}

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -117,6 +117,10 @@
   ?~  u.bop  [~ ~]
   [~ ~ +.q.u.u.bop]
 ::
+++  symp                                                ::  symbol or empty
+  |=  a=*  ^-  @tas
+  ?.(&(?=(@ a) ((sane %tas) a)) %$ a)
+::
 ++  vent                                                ::  vane core
   |=  {lal/@tas vil/vile bud/vase sew/(pair worm vase)}
   ~%  %vent  +>+  ~
@@ -224,7 +228,7 @@
             ==
         ^=  har  ^-  (each (pair arvo worm) term)
         =^  caq  p.sew  (~(spot wa p.sew) 3 wec)
-        ?+    q.caq   [%| (cat 3 %funk (@tas q.caq))]
+        ?+    q.caq   [%| (cat 3 %funk (symp q.caq))]
         ::
             {$pass p/* q/@tas r/{p/@tas q/*}}
           %-  (bond |.([%| p.r.q.caq]))
@@ -321,7 +325,7 @@
             (slix (slid [%& [%atom %tas `org] org] hil))
           ==
       ?~  pru
-        ~&  [%swim-lost lal (@tas +>-.hil)]
+        ~&  [%swim-lost lal (symp +>-.hil)]
         [[~ p.sew] q.sew]
       =^  pro  p.sew  (need pru)
       =^  moz  p.sew  (~(slap wa p.sew) pro [%limb %p])
@@ -429,23 +433,21 @@
         $pass
       ~?  &(!lac !=(%$ p.gum))
         :^  %pass  [p.gum p.q.r.gum]
-          [(@tas +>-.q.q.r.gum) p.r.gum]
+          [(symp +>-.q.q.r.gum) p.r.gum]
         q.gum
       [p.q.r.gum ~ [[p.gum p.r.gum] q.gum] q.q.r.gum]
     ::
         $give
-      ?.  ?&  ?=(^ q.gum)
-              ?=(^ i.q.gum)
-          ==
+      ?.  &(?=(^ q.gum) ?=(^ i.q.gum))
         ~|  [%jack-bad-duct q.gum]
-        ~|  [%jack-bad-card p.gum (@tas +>-.p.r.gum)]
+        ~|  [%jack-bad-card p.gum (symp +>-.p.r.gum)]
         !!
       ~?  &(!lac |(!=(%blit +>-.p.r.gum) !=(%d p.gum)))
-        [%give p.gum (@tas +>-.p.r.gum) `duct`q.gum]
+        [%give p.gum (symp +>-.p.r.gum) `duct`q.gum]
       [i.i.q.gum [~ t.i.q.gum] t.q.gum p.r.gum]
     ::
         $slip
-      ~?  !lac  [%slip p.gum (@tas +>-.q.p.r.gum) q.gum]
+      ~?  !lac  [%slip p.gum (symp +>-.q.p.r.gum) q.gum]
       [p.p.r.gum ~ q.gum q.p.r.gum]
     ==
   ::

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -434,10 +434,11 @@
       [p.q.r.gum ~ [[p.gum p.r.gum] q.gum] q.q.r.gum]
     ::
         $give
-      ?>  ?=(^ q.gum)
-      ?.  ?=(^ i.q.gum)
-        ~&  [%jack-bad-duct q.gum]
-        ~&  [%jack-bad-card +>-.p.r.gum]
+      ?.  ?&  ?=(^ q.gum)
+              ?=(^ i.q.gum)
+          ==
+        ~|  [%jack-bad-duct q.gum]
+        ~|  [%jack-bad-card p.gum (@tas +>-.p.r.gum)]
         !!
       ~?  &(!lac |(!=(%blit +>-.p.r.gum) !=(%d p.gum)))
         [%give p.gum (@tas +>-.p.r.gum) `duct`q.gum]

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1300,6 +1300,8 @@
     ::
         %ouzo
       ::  ~&  [%send now p.bon `@p`(mug (shaf %flap q.bon))]
+      ~|  [%ames-bad-duct duct=gad.fox lane=p.bon]
+      ?>  ?=(^ gad.fox)
       :_  fox
       [[gad.fox [%give %send p.bon q.bon]] ~]
     ::

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -185,7 +185,10 @@
       =.  tym  (raze tym)
       =/  nex=(unit @da)  ?~(p.tym ~ (some p:~(get up p.tym)))
       :_  tym
-      ?:(=(old nex) ~ [gad %give %doze nex]~)
+      ?:  =(old nex)  ~
+      ~|  [%behn-bad-duct duct=gad doze=nex]
+      ?>  ?=(^ gad)
+      [gad %give %doze nex]~
     ::
         $wait
       =/  old=(unit @da)  ?~(p.tym ~ (some p:~(get up p.tym)))
@@ -193,7 +196,10 @@
       =.  tym  (raze tym)
       =/  nex=(unit @da)  ?~(p.tym ~ (some p:~(get up p.tym)))
       :_  tym
-      ?:(=(old nex) ~ [gad %give %doze nex]~)
+      ?:  =(old nex)  ~
+      ~|  [%behn-bad-duct duct=gad doze=nex]
+      ?>  ?=(^ gad)
+      [gad %give %doze nex]~
     ::
         $wake
       |-  ^+  [*(list move) tym]
@@ -203,6 +209,8 @@
         ~&  %weird-wake  [~ tym]
       =/  nex  ~(get up p.tym)
       ?:  (lte now p.nex)
+        ~|  [%behn-bad-duct duct=gad doze=nex]
+        ?>  ?=(^ gad)
         [[gad %give %doze `p.nex]~ tym]
       =^  mof  tym  $(p.tym ~(pop up p.tym))
       [[`move`[q.nex %give %wake ~] mof] tym]

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3766,6 +3766,9 @@
       (~(has in who.r) |+nom.req)
     --
   ::
+      $crud
+    [[[hen %slip %d %flog req] ~] ..^$]
+  ::
       $drop
     =^  mos  ruf
       =+  den=((de now hen ruf) [. .]:our.req des.req)

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -4692,6 +4692,7 @@
             ::
             %ride  [%cnts ~[[%& 1] %is] ~]
             %ride  arvo-hoon
+            %ride  [%$ 7]
             %ride  hoon-hoon
             [%$ %noun !>(~)]
         ==

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1273,6 +1273,7 @@
         $crew  `%c
         $crow  `%c
         $deal  `%g
+        $dirk  `%c
         $drop  `%c
         $flog  `%d
         $info  `%c

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -745,6 +745,7 @@
           {$cred our/ship nom/@ta cew/crew}             ::  set permission group
           {$crew our/ship}                              ::  permission groups
           {$crow our/ship nom/@ta}                      ::  group usage
+          {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$drop our/@p des/desk}                       ::  cancel pending merge
           {$info our/@p des/desk dit/nori}              ::  internal edit
           {$init our/@p}                                ::  report install

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -3535,7 +3535,7 @@
     (expect-ford-empty ford-gate ~nul)
   ==
 ::
-++  disabled-test-reef-slow
+++  test-reef-slow
   ::
   =/  hoon-parsed=hoon
     (rain /~nul/base/~1234.5.6/sys/hoon/hoon hoon-scry)
@@ -3552,7 +3552,7 @@
   =/  pit=vase  !>(~)
   =/  hoon-compiled=vase  (slap pit hoon-parsed)
   ~&  %hoon-compiled
-  =/  arvo-compiled=vase  (slap hoon-compiled arvo-parsed)
+  =/  arvo-compiled=vase  (slap (slot 7 hoon-compiled) arvo-parsed)
   ~&  %arvo-compiled
   =/  pit-compiled=vase   (slap arvo-compiled [%cnts ~[[%& 1] %is] ~])
   ~&  %pit-compiled


### PR DESCRIPTION
The PR restores the formal Arvo interface gate (equivalent to `+poke`, and expected by cc-release), and updates `+solid` and `|reset` to with/around that interface. It also improves error handling in arvo and some vanes (fixing issues that come up when booting cc-release). And it adds `%zuse` to the `+ivory` pill, and all of (current) userspace to the `+brass` pill.

I have a branch of vere that merges `cc-release` and `release-candidate`, and can boot fake galaxies off of it. I think that's as far as we can get in a dual-boot scenario, without significantly complicating vane initialization or the boot sequence. I have some more cleanup and work to do on that merged branch, than I'll push it. Since the changes in this PR are necessary and compatible, I'm opening it early to avoid potential regressions or future conflicts.