### PR TITLE
Don't run nest checks on every +call.

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1227,20 +1227,15 @@
     |%                                                  ::  vane interface
     ++  call                                            ::  handle request
       |=  $:  hen=duct
-              hic=(hypo (hobo task:able))
-          ==
-      =>  %=    .                                       ::  XX temporary
-              q.hic
-            ^-  task:able
-            ?:  ?=(%soft -.q.hic)
-              ((hard task:able) p.q.hic)
-            ?:  (~(nest ut -:!>(*task:able)) | p.hic)  q.hic
-            ~&  [%ames-call-flub (@tas `*`-.q.hic)]
-            ((hard task:able) q.hic)
+              type=*
+              wrapped-task=(hobo task:able)
           ==
       ^-  [(list move) _..^$]
-      =^  duy  ..knob
-        (knob hen q.hic)
+      =/  task=task:able
+        ?.  ?=(%soft -.wrapped-task)
+          wrapped-task
+        ((hard task:able) p.wrapped-task)
+      =^  duy  ..knob  (knob hen task)
       [duy ..^$]
     ::
     ++  load

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -152,20 +152,15 @@
 ^?
 |%                                                      ::  poke+peek pattern
 ++  call                                                ::  handle request
-  |=  $:  hen/duct
-          hic/(hypo (hobo task:able))
+  |=  $:  hen=duct
+          type=*
+          wrapped-task=(hobo task:able)
       ==
-  =>  %=    .                                           ::  XX temporary
-          q.hic
-        ^-  task:able
-        ?:  ?=($soft -.q.hic)
-          ::  ~&  [%behn-call-soft (,@tas `*`-.p.q.hic)]
-          ((hard task:able) p.q.hic)
-        ?:  (~(nest ut -:!>(*task:able)) | p.hic)  q.hic
-        ~&  [%behn-call-flub (@tas `*`-.q.hic)]
-        ((hard task:able) q.hic)
-      ==
-  =*  req  q.hic
+  ::
+  =/  req=task:able
+    ?.  ?=(%soft -.wrapped-task)
+      wrapped-task
+    ((hard task:able) p.wrapped-task)
   |-  ^-  [(list move) _..^^$]
   ::
   ?:  ?=(%born -.req)

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -492,39 +492,34 @@
     --
 |%                                                      ::  poke+peek pattern
 ++  call                                                ::  handle request
-  |=  $:  hen/duct
-          hic/(hypo (hobo task:able))
+  |=  $:  hen=duct
+          type=*
+          wrapped-task=(hobo task:able)
       ==
   ^+  [*(list move) ..^$]
-  =>  %=    .                                           ::  XX temporary
-          q.hic
-        ^-  task:able
-        ?:  ?=($soft -.q.hic)
-          ::  ~&  [%dill-call-soft (@tas `*`-.p.q.hic)]
-          ((hard task:able) p.q.hic)
-        ?:  (~(nest ut -:!>(*task:able)) | p.hic)  q.hic
-        ~&  [%dill-call-flub (@tas `*`-.q.hic)]
-        ((hard task:able) q.hic)
-      ==
+  =/  task=task:able
+    ?.  ?=(%soft -.wrapped-task)
+      wrapped-task
+    ((hard task:able) p.wrapped-task)
   ::  the boot event passes thru %dill for initial duct distribution
   ::
-  ?:  ?=(%boot -.q.hic)
-    ?>  ?=(?(%dawn %fake) -.p.q.hic)
+  ?:  ?=(%boot -.task)
+    ?>  ?=(?(%dawn %fake) -.p.task)
     ?>  =(~ hey.all)
     =.  hey.all  `hen
-    =/  boot  ((soft note-jael) p.q.hic)
+    =/  boot  ((soft note-jael) p.task)
     ?~  boot
       ~|  invalid-boot-event+hen  !!
     :_(..^$ [hen %pass / %j u.boot]~)
   ::  we are subsequently initialized. single-home
   ::
-  ?:  ?=(%init -.q.hic)
+  ?:  ?=(%init -.task)
     ?>  =(~ dug.all)
     ?>  =(~ ore.all)
-    =.  ore.all  `p.q.hic
+    =.  ore.all  `p.task
     ::  configure new terminal, setup :hood and %clay
     ::
-    =*  our  p.q.hic
+    =*  our  p.task
     =*  duc  (need hey.all)
     =/  app  %hood
     =/  see  (tuba "<awaiting {(trip app)}, this may take a few minutes>")
@@ -534,17 +529,17 @@
     [moz ..^$]
   ::  %flog tasks are unwrapped and sent back to us on our default duct
   ::
-  ?:  ?=(%flog -.q.hic)
+  ?:  ?=(%flog -.task)
     ?~  hey.all
       [~ ..^$]
     ::  this lets lib/helm send %heft a la |mass
     ::
     =/  not=note-dill
-      ?:(?=([%crud %hax-heft ~] p.q.hic) [%heft ~] p.q.hic)
+      ?:(?=([%crud %hax-heft ~] p.task) [%heft ~] p.task)
     [[u.hey.all %slip %d not]~ ..^$]
   ::  a %sunk notification from %jail comes in on an unfamiliar duct
   ::
-  ?:  ?=(%sunk -.q.hic)
+  ?:  ?=(%sunk -.task)
     [~ ..^$]
   ::
   =/  nus  (ax hen)
@@ -552,11 +547,11 @@
     ::  we got this on an unknown duct or
     ::  before %boot or %init (or one of those crashed)
     ::
-    ~&  [%dill-call-no-flow hen -.q.hic]
-    =/  tan  ?:(?=(%crud -.q.hic) q.q.hic ~)
+    ~&  [%dill-call-no-flow hen -.task]
+    =/  tan  ?:(?=(%crud -.task) q.task ~)
     [((slog (flop tan)) ~) ..^$]
   ::
-  =^  moz  all  abet:(call:u.nus q.hic)
+  =^  moz  all  abet:(call:u.nus task)
   [moz ..^$]
 ::
 ++  load                                                ::  trivial

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -2245,20 +2245,18 @@
 ^?                                                      ::  opaque core
 |%                                                      ::
 ++  call                                                ::  handle request
-  |=  $:  hen/duct
-          hic/(hypo (hobo task:able))
+  |=  $:  hen=duct
+          type=*
+          wrapped-task=(hobo task:able)
       ==
-  =>  %=    .                                           ::  XX temporary
-          q.hic
-        ^-  task:able
-        ?:  ?=($soft -.q.hic)
-          ((hard task:able) p.q.hic)
-        ?:  (~(nest ut -:!>(*task:able)) | p.hic)  q.hic
-        ~&  [%eyre-call-flub (@tas `*`-.q.hic)]
-        ((hard task:able) q.hic)
-      ==
+  ::
+  =/  task=task:able
+    ?.  ?=(%soft -.wrapped-task)
+      wrapped-task
+    ((hard task:able) p.wrapped-task)
+  ::
   ^+  [*(list move) ..^$]
-  ?:  ?=($wegh -.q.hic)
+  ?:  ?=($wegh -.task)
     :_  ..^$  :_  ~
     :^  hen  %give  %mass
     :-  %eyre
@@ -2275,7 +2273,7 @@
   ^+  [p=*(list move) q=..^$]
   =.  gub  ?.(=(`@`0 gub) gub (cat 3 (rsh 3 1 (scot %p (end 6 1 eny))) '-'))
   =^  mos  bol
-    abet:(apex:~(adit ye [hen [now eny our sky] ~] bol) q.hic)
+    abet:(apex:~(adit ye [hen [now eny our sky] ~] bol) task)
   [mos ..^$]
 ::
 ++  load                                                ::  take previous state


### PR DESCRIPTION
This removes an "XX temporary" from 2014 in most of the vane `+call` functions. Ford does not do anything like this, and other vanes shouldn't be calling the compiler to validate their input.

(This doesn't touch Clay because there's additional debugging in that one which I've seen trigger in the wild.)