### PR TITLE
handles %crud in %behn

### DIFF
--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -14,8 +14,7 @@
           ==                                            ::
 +*  broq  [a b]                                         ::  brodal skew qeu
           (list (sqeu a b))                             ::
-+$  move  {p/duct q/(wind note gift:able)}              ::  local move
-+$  note  ~                                             ::  out request $->
++$  move  {p/duct q/(wind note:able gift:able)}         ::  local move
 +$  sign  ~                                             ::  in result $<-
 +$  clok  (broq @da duct)                               ::  stored timers
 +$  coke  $~  [%0 ~ ~ ~]                                ::  all state
@@ -162,6 +161,9 @@
       wrapped-task
     ((hard task:able) p.wrapped-task)
   |-  ^-  [(list move) _..^^$]
+  ::
+  ?:  ?=(%crud -.req)
+    [[[hen %slip %d %flog req] ~] ..^^$]
   ::
   ?:  ?=(%born -.req)
     =.  gad  hen

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -700,6 +700,10 @@
     ::                                                  ::::
   ++  able  ^?
     |%
+    ++  note                                            ::  out request $->
+      $%  $:  $d                                        ::  to %dill
+      $%  {$flog p/flog:dill}                           ::
+      ==  ==  ==                                        ::
     ++  gift                                            ::  out result <-$
       $%  {$doze p/(unit @da)}                          ::  next alarm
           {$mass p/mass}                                ::  memory usage
@@ -707,6 +711,7 @@
       ==                                                ::
     ++  task                                            ::  in request ->$
       $%  {$born ~}                                     ::  new unix process
+          {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$rest p/@da}                                 ::  cancel alarm
           {$wait p/@da}                                 ::  set alarm
           {$wake ~}                                    ::  timer activate


### PR DESCRIPTION
As discussed in #906, every vane that accepts tasks from unix must be able to handle a `%curd` task. `%behn` was the last that did not. (And this is not an abstract change -- it came up as an issue when I was merging cc-release)