### PR TITLE
Do fast special cases for +slaw instead of always calling +slay.

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -5951,16 +5951,16 @@
       ?.(&(?=({~ $$ @ @} con) =(p.p.u.con mod)) ~ [~ q.p.u.con])
   ::
       %p
-    (rust (trip txt) ;~(pfix sig fed:ag))
+    (rush txt ;~(pfix sig fed:ag))
   ::
       %ud
-    (rust (trip txt) dem:ag)
+    (rush txt dem:ag)
   ::
       %ux
-    (rust (trip txt) ;~(pfix (jest '0x') hex:ag))
+    (rush txt ;~(pfix (jest '0x') hex:ag))
   ::
       %tas
-    (rust (trip txt) sym)
+    (rush txt sym)
   ==
 ::
 ++  slay

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -5944,8 +5944,24 @@
   ~/  %slaw
   |=  {mod/@tas txt/@ta}
   ^-  (unit @)
-  =+  con=(slay txt)
-  ?.(&(?=({~ $$ @ @} con) =(p.p.u.con mod)) ~ [~ q.p.u.con])
+  ?+    mod
+      ::  slow fallback case to the full slay
+      ::
+      =+  con=(slay txt)
+      ?.(&(?=({~ $$ @ @} con) =(p.p.u.con mod)) ~ [~ q.p.u.con])
+  ::
+      %p
+    (rust (trip txt) ;~(pfix sig fed:ag))
+  ::
+      %ud
+    (rust (trip txt) dem:ag)
+  ::
+      %ux
+    (rust (trip txt) ;~(pfix (jest '0x') hex:ag))
+  ::
+      %tas
+    (rust (trip txt) sym)
+  ==
 ::
 ++  slay
   |=  txt/@ta  ^-  (unit coin)


### PR DESCRIPTION
+slay is a giant, recursive, slow parser combinator. +slaw is called
on every beam handling, on Gall +take, etc. In actual usage, we can
special case based on the passed in type and use a much smaller
parser.