### PR TITLE
Also add %uv handling to +slaw

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -5959,6 +5959,9 @@
       %ux
     (rush txt ;~(pfix (jest '0x') hex:ag))
   ::
+      %uv
+    (rush txt ;~(pfix (jest '0v') viz:ag))
+  ::
       %tas
     (rush txt sym)
   ==


### PR DESCRIPTION
Also fast path %uv so that vere can directly call +slaw instead of +slay. The HTTP wires use `0v` values as identities and vere currently calls `+nock:so` raw to handle this. We can fast path this though.