### PR TITLE
Trim ethereum snapshot in Jael

### DIFF
--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -701,7 +701,7 @@
         =/  cub  (nol:nu:crub:crypto key.seed.tac)
         %+  ~(put by kyz.puk.sub)
           our
-        [& lyf.seed.tac (my [lyf.seed.tac pub:ex:cub] ~)]
+        [lyf.seed.tac (my [lyf.seed.tac pub:ex:cub] ~)]
       ::  our initial private key, as a +tree of +rite
       ::
       =/  rit  (sy [%jewel (my [lyf.seed.tac key.seed.tac] ~)] ~)
@@ -767,7 +767,7 @@
       ::  our initial public key
       ::
       =.  kyz.puk.sub
-        (~(put by kyz.puk.sub) our [& 1 (my [1 pub:ex:cub] ~)])
+        (~(put by kyz.puk.sub) our [1 (my [1 pub:ex:cub] ~)])
       ::  our private key, as a +tree of +rite
       ::
       ::    Private key updates are disallowed for fake ships,

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -82,7 +82,6 @@
   ==                                                    ::
 ++  state-absolute                                      ::  absolute urbit
   $:  pry/(map ship (map ship safe))                    ::  promises
-      eve=logs                                          ::  on-chain events
   ==                                                    ::
 ++  state-snapshots                                     ::  rewind points
   $:  interval=_100                                     ::  block interval
@@ -711,7 +710,7 @@
       ::
       =/  kyz
         %-  ~(run by czar.tac)
-        |=([=life =pass] `public`[live=| life (my [life pass] ~)])
+        |=([=life =pass] `public`[life (my [life pass] ~)])
       =.  +>.$
         %-  curd  =<  abet
         (pubs:~(feel su hen our urb sub etn sap) kyz)
@@ -1109,8 +1108,7 @@
   ::
   ++  extract-snap                                    ::  extract rewind point
     ^-  snapshot
-    :*  eve.urb
-        kyz.puk.sub
+    :*  kyz.puk.sub
         +.eth.sub
         etn(source *(each ship node-src))
     ==
@@ -1149,7 +1147,7 @@
       %.  [[hen ~ ~] snap+last-snap]
       %_  vent-pass
       :: %_  ..feed  ::TODO  see ++abet
-        :: moz      [[hen %give %vent &+eve] moz]
+        :: moz      [[hen %give %vent] moz]
         yen.eth  (~(put in yen.eth) hen)
       ==
     ::                                                  ::  ++fake:feed:su
@@ -1159,7 +1157,7 @@
       ++  pubs
         |=  who=ship
         =/  cub  (pit:nu:crub:crypto 512 who)
-        =/  pub  [live=| life=1 (my [1 pub:ex:cub] ~)]
+        =/  pub  [life=1 (my [1 pub:ex:cub] ~)]
         =.  moz  [[hen %give %pubs pub] moz]
         (pubs:feel (my [who pub] ~))
       --
@@ -1186,7 +1184,7 @@
       ::  update public key store and notify subscribers
       ::  of the new state
       ::
-      :: ~&  [%sending-pubs-about who life.pub live.pub]
+      :: ~&  [%sending-pubs-about who life.pub]
       %+  exec(kyz.puk (~(put by kyz.puk) who pub))
         (~(get ju yen.puk) who)
       [%give %pubs pub]
@@ -1313,21 +1311,21 @@
             =(who (^sein:title our))
         ==
       ?~  old
-        [live=& life (my [life pass] ~)]
+        [life (my [life pass] ~)]
       =/  fyl  life.u.old
       =/  sap  (~(got by pubs.u.old) fyl)
       ~|  [%met-mismatch who life=[old=fyl new=life] pass=[old=sap new=pass]]
       ?>  ?:  =(fyl life)
             =(sap pass)
           =(+(fyl) life)
-      [live=& life (~(put by pubs.u.old) life pass)]
+      [life (~(put by pubs.u.old) life pass)]
     ?.  ?=(^ old)
       ~|  [%met-unknown-ship who]  !!
     =/  fyl  life.u.old
     =/  sap  (~(got by pubs.u.old) fyl)
     ~|  [%met-mismatch who life=[old=fyl new=life] pass=[old=sap new=pass]]
     ?>  &(=(fyl life) =(sap pass))
-    [live=& life pubs.u.old]
+    [life pubs.u.old]
   ::                                                    ::  ++file:su
   ++  file                                              ::  process event logs
     ::TODO  whenever we add subscriptions for data,
@@ -1358,7 +1356,7 @@
       ::      sends out entire new state, rather than
       ::      just the processed changes.
       %+  fall  (~(get by kyz.puk) who)
-      %*(. *public live |)
+      *public
     ::
     ++  file-keys
       |=  [who=ship =life =pass]
@@ -1370,15 +1368,14 @@
         ~|  [%key-mismatch who life `@ux`u.puk `@ux`pass (get-public ~zod)]
         ?>(=(u.puk pass) kyz)
       %+  ~(put by kyz)  who
-      :+  live.pub
-        (max life life.pub)
+      :-  (max life life.pub)
       (~(put by pubs.pub) life pass)
     ::
     ++  file-discontinuity
       |=  who=ship
       ^+  kyz
       =+  (get-public who)
-      (~(put by kyz) who -(live |))
+      (~(put by kyz) who -)
     ::
     ++  file-event
       |=  [wer=event-id dif=diff-constitution]
@@ -1525,8 +1522,6 @@
     |=  ven=chain
     %_  +>
       hab   [[%ethe ven] hab]
-      eve   ?:  ?=(%& -.ven)  p.ven
-            (~(uni by eve) p.ven)
     ==
   ::                                                    ::  ++lawn:ur
   ++  lawn                                              ::  debts, rex to pal
@@ -2128,7 +2123,7 @@
         ~(tap by yen.puk.sub)
       |-  ^+  +>.^$
       ?~  subs  +>.^$
-      =/  pub  (fall (~(get by kyz.snap) p.i.subs) %*(. *public live |))
+      =/  pub  (fall (~(get by kyz.snap) p.i.subs) *public)
       =.  +>.^$  (exec q.i.subs [%give %pubs pub])
       $(subs t.subs)
     ::  update vent subscribers
@@ -2137,7 +2132,6 @@
     ::  keep the following in sync with ++extract-snap:file:su
     ::
     %=    +>.$
-        eve.urb       eve.snap
         etn           etn.snap(source source.etn)
         kyz.puk.sub   kyz.snap
         +.eth.sub     eth.snap

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1109,8 +1109,9 @@
   ++  extract-snap                                    ::  extract rewind point
     ^-  snapshot
     :*  kyz.puk.sub
-        +.eth.sub
-        etn(source *(each ship node-src))
+        [dns hul]:eth.sub
+        heard.etn
+        latest-block.etn
     ==
   ::                                                    ::  ++feed:su
   ++  feed                                              ::  subscribe to view
@@ -2099,7 +2100,7 @@
       ==
     =^  snap=snapshot  +>.$
       ?:  |(=(~ old-qeu) (lth block block-number:(need ~(top to old-qeu))))
-        [%*(. *snapshot latest-block.etn launch:contracts) +>.$]
+        [%*(. *snapshot latest-block launch:contracts) +>.$]
       |-  ^-  [snapshot _+>.^$]
       =^  snap=[block-number=@ud snap=snapshot]  old-qeu
         ~(get to old-qeu)
@@ -2110,7 +2111,7 @@
       ?:  |(=(~ old-qeu) (lth block block-number:(need ~(top to old-qeu))))
         [snap.snap +>.^$]
       $
-    ~&  [%restoring-block block latest-block.etn.snap ~(wyt by hul.eth.snap)]
+    ~&  [%restoring-block block latest-block.snap ~(wyt by hul.eth.snap)]
     (restore-snap snap &)
   ::                                                    ::  ++restore-snap:et
   ++  restore-snap                                      ::  restore snapshot
@@ -2132,10 +2133,11 @@
     ::  keep the following in sync with ++extract-snap:file:su
     ::
     %=    +>.$
-        etn           etn.snap(source source.etn)
-        kyz.puk.sub   kyz.snap
-        +.eth.sub     eth.snap
-        sap           sap(last-block 0)
+        heard.etn         heard.snap
+        latest-block.etn  latest-block.snap
+        kyz.puk.sub       kyz.snap
+        +.eth.sub         eth.snap
+        sap               sap(last-block 0)
         moves
       ?.  look  moves
       =-  [[hen %pass /wind/look %j %look our -] moves]

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -2185,13 +2185,20 @@
           $:  dns=dnses                                 ::  on-chain dns state
               hul=(map ship hull)                       ::  on-chain ship state
         ==                                              ::
-        etn=state-eth-node                              ::  eth connection state
-    ==                                                  ::
+        eth-bookmark
+    ==
+  ::  +eth-bookmark: cursor into the ethereum chain
+  ::
+  ++  eth-bookmark
+    $:  heard=(set event-id:ethe)
+        latest-block=@ud
+    ==
+  ::  +state-eth-node: state of a connection to an ethereum node
+  ::
   ++  state-eth-node                                    ::  node config + meta
     $:  source=(each ship node-src)                     ::  learning from
-        heard=(set event-id:ethe)                       ::  processed events
-        latest-block=@ud                                ::  last heard block
         foreign-block=@ud                               ::  node's latest block
+        eth-bookmark
     ==                                                  ::
   ::                                                    ::
   ::::                  ++pki:jael                      ::  (1h2) certificates
@@ -8318,7 +8325,7 @@
     ++  bloq
       |=  snap=snapshot:jael
       ^-  @ud
-      latest-block.etn.snap
+      latest-block.snap
     ::  +czar:snap:dawn: extract galaxy table
     ::
     ++  czar

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -2116,8 +2116,7 @@
           [%sunk p=ship q=life]                         ::  report death
       ==  ==  ==                                        ::
     ++  public                                          ::  public key state
-      $:  live=?                                        ::  seen in current era
-          life=life                                     ::  current key number
+      $:  life=life                                     ::  current key number
           pubs=(map life pass)                          ::  pubkeys by number
       ==                                                ::
     ++  remote                                          ::  remote notification
@@ -2176,8 +2175,7 @@
     ==                                                  ::
   ++  snapshot                                          ::  rewind point
     =,  constitution:ethe                               ::
-    $:  eve=logs:able                                   ::  eth absolute state
-        kyz=(map ship public:able)                      ::  public key state
+    $:  kyz=(map ship public:able)                      ::  public key state
         $=  eth                                         ::
           $:  dns=dnses                                 ::  on-chain dns state
               hul=(map ship hull)                       ::  on-chain ship state

--- a/tests/sys/zuse/dawn.hoon
+++ b/tests/sys/zuse/dawn.hoon
@@ -31,17 +31,21 @@
 ::  snapshot
 ::
 ++  snap
-  ^-  snapshot:jael
-  :*  *logs:able:jael
-      ~
-      :*  ['urbit.org' 'urbit.org' '']
-          %-  malt
-          :*  ~zod^hul
-              ~marzod^hul
-              (turn (gulf 1 255) |=(gal=@ gal^hul))
-          ==
-      ==
-      %*(. *state-eth-node:jael latest-block 4.230.000)
+  =|  =snapshot:jael
+  %_    snapshot
+      kyz  ~
+  ::
+      dns.eth
+    ['urbit.org' 'urbit.org' '']
+  ::
+      hul.eth
+    %-  malt
+    :*  ~zod^hul
+        ~marzod^hul
+        (turn (gulf 1 255) |=(gal=@ gal^hul))
+    ==
+  ::
+      latest-block  4.230.000
   ==
 ::
 ++  test-give-bloq


### PR DESCRIPTION
**NOTE: requires more testing before merge; waiting on booting a ship on the testnet for manual testing and snapshot generation**

Removes some fields from the ethereum snapshot:
- Ethereum event logs
- the state of Urbit's connection to the Ethereum node

Also removes the `live` bit from the `+public` datatype, since it wasn't used and probably belongs as Ames state.

This changes the snapshot format, but we don't need to change Vere or perform any staging. We should be able to export a snapshot from a ship running this code, then boot off that.