### PR TITLE
Add ~| to arvo to try to debug intermittent crash.

### DIFF
--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -175,7 +175,9 @@
   ::
   ++  wink                                              ::  deploy
     |=  {now/@da eny/@ ski/slyd}
-    =^  rig  worm.vane  (~(slym wa worm.vane) vase.vane +<)  ::  activate vane
+    =^  rig  worm.vane
+      ~|  [%failed-vane-activation-for lal]
+      (~(slym wa worm.vane) vase.vane +<)  ::  activate vane
     ~%  %wink  +>+>  ~
     |%
     ++  slid
@@ -196,14 +198,18 @@
     ++  slur                                            ::  call gate on
       |=  {gat/vase hil/mill}
       ^-  (unit (pair vase worm))
-      =^  sam  worm.vane  (~(slot wa worm.vane) 6 gat)
+      =^  sam  worm.vane
+        ~|  [%failed-slot-in lal]
+        (~(slot wa worm.vane) 6 gat)
       =^  hig  worm.vane
+        ~|  [%failed-nest-in lal]
         ?-  -.hil
           %&  (~(nest wa worm.vane) p.sam p.p.hil)
           %|  (~(nets wa worm.vane) p.sam p.p.hil)
         ==
       ?.  hig
         ~
+      ~|  [%failed-slym-in lal]
       `(~(slym wa worm.vane) gat +>.hil)
     ::
     ++  slur-a  ~/(%slur-a |=({gat/vase hil/mill} =+(%a (slur gat hil))))
@@ -347,6 +353,7 @@
               hil/mill
           ==
       ^-  [(list move) _vane]
+      ~|  [%failed-swim lal org pux]
       ::  ~&  [%swim-wyt `@ud`~(wyt in worm.vane)]
       =+  ^=  pru
           ?~  pux
@@ -377,6 +384,7 @@
   |=  {lal/@tas vil/vile bud/vase pax/path txt/@ta}     ::
   =-  ?:(?=(%| -.res) ((slog p.res) ~) (some p.res))
   ^=  res  %-  mule  |.
+  ~|  [%failed-vint lal]
   =+  gen=(rain pax txt)
   ~&  [%vane-parsed `@p`(mug gen)]
   =+  pro=(vent lal vil bud [(slym (slap bud gen) bud) *worm])
@@ -406,6 +414,7 @@
     |-  ^-  (unit (unit (cask)))
     ?~  vanes  ~
     ?.  =(lal label.i.vanes)  $(vanes t.vanes)
+    ~|  [%failed-scry ron bed]
     %-  scry:(wink:(vent lal vil bud vane.i.vanes) now (shax now) ..^$)
     [fur ren bed]
   ::
@@ -446,6 +455,7 @@
     |=  {org/@tas lal/@tas pux/(unit wire) hen/duct hil/mill =vane}
     ^-  [p=(list move) q=_vane]
     =+  ven=(vent lal vil bud vane)
+    ~|  [%failed-take lal]
     =+  win=(wink:ven now (shax now) beck)
     (swim:win org pux hen hil)
   ::
@@ -496,6 +506,7 @@
   ++  kick                                              ::  new main loop
     |=  {lac/? mor/(list muse)}
     =|  ova/(list ovum)
+    ~|  [%failed-kick lac]
     |-  ^-  {p/(list ovum) q=(list [label=@tas =vane])}
     ?~  mor  [(flop ova) vanes]
     =^  nyx  vanes  (jack lac i.mor)
@@ -675,6 +686,7 @@
       ~&  [%vane `@tas`lal.fav pax.fav `@p`(mug txt.fav)]
     :_  t.vanes
     :-  label.i.vanes
+    ~|  [%failed-vane-activation now lal.fav]
     vane:(ruck:(vent lal.fav vil bud [vase.vane.i.vanes *worm]) pax.fav txt.fav)
   ==
 ::

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -477,6 +477,7 @@
   ++  jack                                              ::  dispatch card
     |=  {lac/? gum/muse}
     ^-  {{p/(list ovum) q/(list muse)} _vanes}
+    ~|  %failed-jack
     ::  =.  lac  |(lac ?=(?(%g %f) p.gum))
     ::  =.  lac  &(lac !?=($b p.gum))
     %+  fire
@@ -506,7 +507,6 @@
   ++  kick                                              ::  new main loop
     |=  {lac/? mor/(list muse)}
     =|  ova/(list ovum)
-    ~|  [%failed-kick lac]
     |-  ^-  {p/(list ovum) q=(list [label=@tas =vane])}
     ?~  mor  [(flop ova) vanes]
     =^  nyx  vanes  (jack lac i.mor)


### PR DESCRIPTION
There is some weird failure in the +wa cache code that happens when hoon.hoon gets changed. I can't repro this on demand, so I want to add a bunch of ~| to debug.