### PR TITLE
Don't do two passes in the unjetted +sort

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -787,10 +787,11 @@
   =>  .(a ^.(homo a))
   |-  ^+  a
   ?~  a  ~
+  =+  s=(skid t.a |:(c=i.a (b c i.a)))
   %+  weld
-    $(a (skim t.a |:(c=i.a (b c i.a))))
+    $(a p.s)
   ^+  t.a
-  [i.a $(a (skim t.a |:(c=i.a !(b c i.a))))]
+  [i.a $(a q.s)]
 ::
 ++  spin                                                ::  stateful turn
   ::


### PR DESCRIPTION
While jetting +sort (urbit/urbit#1088), I made it do only a single
pass to separate the list around a pivot instead of using two. Do
this in the hoon code, too.