### PR TITLE
Fix turn types

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -821,10 +821,13 @@
 ++  swag                                                ::  slice
   |*  {{a/@ b/@} c/(list)}
   (scag +<-> (slag +<-< c))
+::  +turn: transform each value of list :a using the function :b
 ::
-++  turn                                                ::  transform
+++  turn
   ~/  %turn
-  |*  {a/(list) b/gate}
+  |*  [a=(list) b=gate]
+  =>  .(a (homo a))
+  ^-  (list _(b ?~(a !! i.a)))
   |-
   ?~  a  ~
   [i=(b i.a) t=$(a t.a)]

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -827,7 +827,7 @@
   ~/  %turn
   |*  [a=(list) b=gate]
   =>  .(a (homo a))
-  ^-  (list _(b ?~(a !! i.a)))
+  ^-  (list _?>(?=(^ a) (b i.a)))
   |-
   ?~  a  ~
   [i=(b i.a) t=$(a t.a)]


### PR DESCRIPTION
+turn now no longer has a TMI problem, nor does it lose its product type, even if passed a wet gate to transform the list.

The product type had to be calculated by type-inferring the product of running the input gate on an element of the list. Otherwise, a wet input gate will cause +turn to lose specificity in its output type, since the type of each element in the product list would be the result of inferring the input gate across its default sample.