### PR TITLE
+slum to call raw nock gate; some associated cleanup

### DIFF
--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-16a5f3e089bc6b4526b503a1ccfa58c2ca7b4602.tgz
+https://ci-piers.urbit.org/zod-59453d5d5b50acbab95adcb4486a0324b478e2bc.tgz

--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-59453d5d5b50acbab95adcb4486a0324b478e2bc.tgz
+https://ci-piers.urbit.org/zod-946204edd92019777a68e3a8034cbee74154fbda.tgz

--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-6a1f32bb1984fa9329c072de09ba67b212c8dbed.tgz
+https://ci-piers.urbit.org/zod-16a5f3e089bc6b4526b503a1ccfa58c2ca7b4602.tgz

--- a/gen/brass.hoon
+++ b/gen/brass.hoon
@@ -74,7 +74,7 @@
               state-gate
             %=  $
               main-sequence  +.main-sequence
-              state-gate     .*(state-gate(+< -.main-sequence) -.state-gate)
+              state-gate  .*(state-gate [%9 2 %10 [6 %1 -.main-sequence] %0 1])
             ==
 ::
 ::  boot-two: startup formula
@@ -119,7 +119,7 @@
         ::
         ~>  %slog.[0 leaf+"1-c (compiling compiler, wait a few minutes)"]
         =+  ^=  compiler-tool
-            .*(compiler-gate(+< [%noun compiler-source]) -.compiler-gate)
+            .*(compiler-gate [%9 2 %10 [6 %1 [%noun compiler-source]] %0 1])
         ::
         ::  switch to the second-generation compiler.  we want to be
         ::  able to generate matching reflection nouns even if the
@@ -137,13 +137,13 @@
         ::
         ~>  %slog.[0 leaf+"1-e"]
         =+  ^=  kernel-span
-            -:.*(compiler-gate(+< [-.compiler-tool '+>']) -.compiler-gate)
+            -:.*(compiler-gate [%9 2 %10 [6 %1 [-.compiler-tool '+>']] %0 1])
         ::
         ::  compile the arvo source against the kernel core.
         ::
         ~>  %slog.[0 leaf+"1-f"]
         =+  ^=  kernel-tool
-            .*(compiler-gate(+< [kernel-span arvo-source]) -.compiler-gate)
+            .*(compiler-gate [%9 2 %10 [6 %1 [kernel-span arvo-source]] %0 1])
         ::
         ::  create the arvo kernel, whose subject is the kernel core.
         ::

--- a/gen/metal.hoon
+++ b/gen/metal.hoon
@@ -73,7 +73,7 @@
               state-gate
             %=  $
               main-sequence  +.main-sequence
-              state-gate     .*(state-gate(+< -.main-sequence) -.state-gate)
+              state-gate  .*(state-gate [%9 2 %10 [6 %1 -.main-sequence] %0 1])
             ==
 ::
 ::  boot-two: startup formula
@@ -118,7 +118,7 @@
         ::
         ~>  %slog.[0 leaf+"1-c"]
         =+  ^=  compiler-tool
-            .*(compiler-gate(+< [%noun compiler-source]) -.compiler-gate)
+            .*(compiler-gate [%9 2 %10 [6 %1 [%noun compiler-source]] %0 1])
         ::
         ::  switch to the second-generation compiler.  we want to be
         ::  able to generate matching reflection nouns even if the
@@ -136,13 +136,13 @@
         ::
         ~>  %slog.[0 leaf+"1-e"]
         =+  ^=  kernel-span
-            -:.*(compiler-gate(+< [-.compiler-tool '+>']) -.compiler-gate)
+            -:.*(compiler-gate [%9 2 %10 [6 %1 [-.compiler-tool '+>']] %0 1])
         ::
         ::  compile the arvo source against the kernel core.
         ::
         ~>  %slog.[0 leaf+"1-f"]
         =+  ^=  kernel-tool
-            .*(compiler-gate(+< [kernel-span arvo-source]) -.compiler-gate)
+            .*(compiler-gate [%9 2 %10 [6 %1 [kernel-span arvo-source]] %0 1])
         ::
         ::  create the arvo kernel, whose subject is the kernel core.
         ::

--- a/gen/solid.hoon
+++ b/gen/solid.hoon
@@ -66,7 +66,7 @@
       (module-ova:pill sys)
     .*(0 arvo-formula)
   |=  [ovo=ovum ken=*]
-  [~ .*(ken [%9 2 %10 [6 %1 now ovo] %0 1])]
+  [~ (slum ken [now ovo])]
 ::
 ::  our boot-ova is a list containing one massive formula:
 ::

--- a/gen/solid.hoon
+++ b/gen/solid.hoon
@@ -66,7 +66,7 @@
       (module-ova:pill sys)
     .*(0 arvo-formula)
   |=  [ovo=ovum ken=*]
-  [~ (slum ken [now ovo])]
+  [~ .*(ken [%9 2 %10 [6 %1 now ovo] %0 1])]
 ::
 ::  our boot-ova is a list containing one massive formula:
 ::

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -789,21 +789,19 @@
   =>  ?:  =(nex hoon-version)
         [hot=`*`raw .]
       ~&  [%hoon-compile-upgrade nex]
-      =/  hot
-        .*(cop [%9 2 %10 [6 %1 [%noun hun]] %0 1])
+      =/  hot  (slum cop [%noun hun])
       .(cop .*(0 +.hot))
   ::  extract the hoon core from the outer gate (+ride)
   ::
   =/  hoc  .*(cop [%0 7])
   ::  compute the type of the hoon.hoon core
   ::
-  =/  hyp
-    -:.*(cop [%9 2 %10 [6 %1 [-.hot '+>']] %0 1])
+  =/  hyp  -:(slum cop [-.hot '+>'])
   ::  compile arvo
   ::
   =/  rav
     ~&  [%arvo-compile `@p`(mug hyp) `@p`(mug van)]
-    .*(cop [%9 2 %10 [6 %1 [hyp van]] %0 1])
+    (slum cop [hyp van])
   ::  activate arvo, and extract the arvo core from the outer gate
   ::
   =/  voc  .*(hoc [%7 +.rav %0 7])
@@ -813,10 +811,10 @@
     =/  arm  ?:(=(nex hoon-version) 'load' 'come')
     ::  compute the type of the arvo.hoon core
     ::
-    =/  vip  -:.*(cop [%9 2 %10 [6 %1 [-.rav '+>']] %0 1])
+    =/  vip  -:(slum cop [-.rav '+>'])
     ::  compute the formula for the upgrade gate
     ::
-    =/  fol  +:.*(cop [%9 2 %10 [6 %1 [vip arm]] %0 1])
+    =/  fol  +:(slum cop [vip arm])
     ::  produce the upgrade gate
     ::
     .*(voc fol)
@@ -832,8 +830,7 @@
     ==
   ::  call into the new kernel
   ::
-  =/  out
-    .*(gat [%9 2 %10 [6 %1 sam] %0 1])
+  =/  out  (slum gat sam)
   ::  tack a reset notification onto the product
   ::
   [[[/ %vega ~] ((list ovum) -.out)] +.out]

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6170,7 +6170,7 @@
   ^-  toon
   ?.  &(?=(^ gat) ?=(^ +.gat))
     [%2 ~]
-  (mock [[-.gat [sam +>.gat]] -.gat] gul)
+  (mock [gat(+< sam) %9 2 %0 1] gul)
 ::
 ++  mule                                                ::  typed virtual
   ~/  %mule
@@ -6186,12 +6186,19 @@
 ++  mute                                                ::  untyped virtual
   |=  taq/_=>(~ ^?(|.(**)))
   ^-  (each * (list tank))
-  =+  ton=(mock [taq 9 2 0 1] |=({* *} ~))
+  =+  ton=(mock [taq %9 2 %0 1] |=({* *} ~))
   ?-  -.ton
     $0  [%& p.ton]
     $1  [%| (turn p.ton |=(a/* (smyt (path a))))]
     $2  [%| p.ton]
   ==
+::  +slum: slam a gate on a sample using raw nock, untyped
+::
+++  slum
+  ~/  %slum
+  |=  [gat=* sam=*]
+  ^-  *
+  .*(gat(+< sam) [%9 2 %0 1])
 ::
 ++  soft                                                ::  maybe remold
   |*  han/$-(* *)
@@ -11324,7 +11331,7 @@
         $type
       =+  tyr=|.((dial dole))
       =+  vol=tyr(sut lum)
-      =+  cis=((hard tank) .*(vol -:vol))
+      =+  cis=((hard tank) .*(vol [%9 2 %0 1]))
       :^  ~   %palm
         [~ ~ ~ ~]
       [[%leaf '#' 't' '/' ~] cis ~]
@@ -13997,11 +14004,11 @@
     ^-  {? worm}
     ?:  (~(has in nes) [sut ref])  [& +>+<]
     =+  gat=|=({a/type b/type} (~(nest ut a) | b))
-    ?.  (? .*(gat(+< [sut ref]) -.gat))
+    ?.  (? (slum gat [sut ref]))
       ~&  %nets-failed
       =+  tag=`*`skol
-      =+  foo=(tank .*(tag(+< ref) -.tag))
-      =+  bar=(tank .*(tag(+< sut) -.tag))
+      =+  foo=(tank (slum tag ref))
+      =+  bar=(tank (slum tag sut))
       ~&  %nets-need
       ~>  %slog.[0 bar]
       ~&  %nets-have

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6198,7 +6198,7 @@
   ~/  %slum
   |=  [gat=* sam=*]
   ^-  *
-  .*(gat(+< sam) [%9 2 %0 1])
+  .*(gat [%9 2 %10 [6 1 sam] %0 1])
 ::
 ++  soft                                                ::  maybe remold
   |*  han/$-(* *)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6198,7 +6198,7 @@
   ~/  %slum
   |=  [gat=* sam=*]
   ^-  *
-  .*(gat [%9 2 %10 [6 1 sam] %0 1])
+  .*(gat [%9 2 %10 [6 %1 sam] %0 1])
 ::
 ++  soft                                                ::  maybe remold
   |*  han/$-(* *)


### PR DESCRIPTION
Added a `+slum` gate to encapsulate calling a gate using Nock. Also removed cases where we were using `.*(gat -.gat)` where we should have been doing `.*(gat [%9 2 %0 1])` so we don't lose jetting.