### PR TITLE
Dont nuck in sloy

### DIFF
--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -103,25 +103,31 @@
 ::                section 3bE, Arvo core                ::
 ::
 ++  sloy
+  ::  +sloy: adapter from old style scrys to new style scrys
+  ::
+  ::    This does path parsing which shows up hot, but removing the last +slay
+  ::    here requires deeper interface changes.
+  ::
   !:
+  ~/  %sloy
   |=  sod/slyd
   ^-  slyt
   |=  {ref/* raw/*}
   =+  pux=((soft path) raw)
   ?~  pux  ~
   ?.  ?=({@ @ @ @ *} u.pux)  ~
-  =+  :*  hyr=(slay i.u.pux)
-          fal=(slay i.t.u.pux)
-          dyc=(slay i.t.t.u.pux)
+  =+  :*  hyr=(slaw %tas i.u.pux)
+          fal=(slaw %p i.t.u.pux)
+          dyc=(slaw %tas i.t.t.u.pux)
           ved=(slay i.t.t.t.u.pux)
           tyl=t.t.t.t.u.pux
       ==
-  ?.  ?=({$~ $$ $tas @} hyr)  ~
-  ?.  ?=({$~ $$ $p @} fal)  ~
-  ?.  ?=({$~ $$ $tas @} dyc)  ~
+  ?~  hyr  ~
+  ?~  fal  ~
+  ?~  dyc  ~
   ?.  ?=(^ ved)  ~
-  =+  ron=q.p.u.hyr
-  =+  bed=[[q.p.u.fal q.p.u.dyc (case p.u.ved)] (flop tyl)]
+  =/  ron=@tas  u.hyr
+  =+  bed=[[u.fal u.dyc (case p.u.ved)] (flop tyl)]
   =+  bop=(sod ref ~ ron bed)
   ?~  bop  ~
   ?~  u.bop  [~ ~]

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -5939,8 +5939,12 @@
 ::
 ::::  4m: formatting functions
   ::
-++  scot  |=(mol/dime ~(rent co %$ mol))
-++  scow  |=(mol/dime ~(rend co %$ mol))
+++  scot
+  ~/  %scot
+  |=(mol/dime ~(rent co %$ mol))
+++  scow
+  ~/  %scow
+  |=(mol/dime ~(rend co %$ mol))
 ++  slat  |=(mod/@tas |=(txt/@ta (slaw mod txt)))
 ++  slav  |=({mod/@tas txt/@ta} (need (slaw mod txt)))
 ++  slaw

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -514,10 +514,12 @@
   ::
   |%
   ++  am                                                ::    am
+    ~%  %ames-am  ..is  ~
     |_  [now=@da fox=fort ski=sley]                     ::  protocol engine
     ::  +deed: scry for our deed
     ::
     ++  deed
+      ~/  %deed
       |=  [our=ship now=@da lyf=life]
       ;;  ^deed
       %-  need  %-  need
@@ -528,6 +530,7 @@
     ::  +sein: scry for sponsor
     ::
     ++  sein
+      ~/  %sein
       |=  [our=ship now=@da who=ship]
       ;;  ship
       %-  need  %-  need
@@ -536,6 +539,7 @@
     ::  +saxo: scry for sponsorship chain
     ::
     ++  saxo
+      ~/  %saxo
       |=  [our=ship now=@da who=ship]
       ;;  (list ship)
       %-  need  %-  need
@@ -543,6 +547,7 @@
       [[151 %noun] %j (en-beam:format [our %saxo da+now] /(scot %p who))]
     ::
     ++  vein                                            ::    vein:am
+      ~/  %vein
       |=  [our=ship =life vein=(map life ring)]         ::  new private keys
       ^-  fort
       ::
@@ -582,6 +587,7 @@
       ==
     ::
     ++  gnaw                                            ::    gnaw:am
+      ~/  %gnaw
       |=  [kay=cape ryn=lane pac=rock]                  ::  process packet
       ^-  [p=(list boon) q=fort]
       ?.  =(protocol-version (end 0 3 pac))  [~ fox]
@@ -644,6 +650,7 @@
       [%pito (need nex)]~
     ::
     ++  rack                                            ::    rack:am
+      ~/  %rack
       |=  [soq=sock cha=path cop=coop]                  ::  e2e ack
       =+  oh=(ho:(um p.soq) q.soq)
       =^  gud  oh  (cook:oh cop cha ~)
@@ -651,6 +658,7 @@
       (cans:oh cha)
     ::
     ++  wake                                            ::    wake:am
+      ~/  %wake
       |=  hen=duct                                      ::  harvest packets
       ^-  [p=(list boon) q=fort]
       =.  tim.fox  ~
@@ -1224,8 +1232,10 @@
   |=  [our=ship now=@da eny=@uvJ ski=sley]              ::  current invocation
   ^?                                                    ::  opaque core
   =<
+    ~%  %ames-protocol  ..is  ~
     |%                                                  ::  vane interface
     ++  call                                            ::  handle request
+      ~/  %call
       |=  $:  hen=duct
               type=*
               wrapped-task=(hobo task:able)
@@ -1257,14 +1267,17 @@
     ::
     ++  stay  fox
     ++  take                                            ::  accept response
+      ~/  %take
       |=  [tea=wire hen=duct hin=(hypo sign:able)]
       ^-  [(list move) _..^$]
       =^  duy  ..knap
         (knap tea hen q.hin)
       [duy ..^$]
     --
+  ~%  %ames-impl  ..is  ~
   |%
   ++  clop
+    ~/  %clop
     |=  [now=@da hen=duct bon=boon]
     ^-  [(list move) fort]
     ?-    -.bon
@@ -1342,6 +1355,7 @@
     ==
   ::
   ++  knap
+    ~/  %knap
     |=  [tea=wire hen=duct sih=sign:able]
     ^-  [(list move) _+>]
     ?-  +<.sih
@@ -1417,6 +1431,7 @@
     ==
   ::
   ++  knob
+    ~/  %knob
     |=  [hen=duct kyz=task:able]
     ^-  [(list move) _+>]
     ?:  ?=(%crud -.kyz)
@@ -1513,6 +1528,7 @@
     $(p.fuy t.p.fuy, out (weld (flop toe) out))
   ::
   ++  temp
+    ~/  %temp
     |=  [our=ship his=ship tyl=path]
     ^-  (unit (unit cage))
     ?:  ?=([?(%show %tell) *] tyl)


### PR DESCRIPTION
+sloy is practically how we perform most scrying. It parses wires
using the full +slay when several of the elements. Replaces all
usages we can with +slaw.

The long term fix is to move to not parsing wires, but that won't
happen before current release-candidate is released.