### PR TITLE
use +slum in gen/solid

### DIFF
--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-7ed3a02a926c2f1d018d26826e4efa44a33c361e.tgz
+https://ci-piers.urbit.org/zod-5d1d390c917fa3e51760af40cf6eafb04ceae880.tgz

--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-946204edd92019777a68e3a8034cbee74154fbda.tgz
+https://ci-piers.urbit.org/zod-7ed3a02a926c2f1d018d26826e4efa44a33c361e.tgz

--- a/gen/solid.hoon
+++ b/gen/solid.hoon
@@ -66,7 +66,7 @@
       (module-ova:pill sys)
     .*(0 arvo-formula)
   |=  [ovo=ovum ken=*]
-  [~ .*(ken [%9 2 %10 [6 %1 now ovo] %0 1])]
+  [~ (slum ken [now ovo])]
 ::
 ::  our boot-ova is a list containing one massive formula:
 ::


### PR DESCRIPTION
Minor follow-up to https://github.com/urbit/arvo/pull/923 that uses the new +slum gate in the gen/solid generator.