### PR TITLE
Light version of +sloy

### DIFF
--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -132,6 +132,27 @@
   ?~  bop  ~
   ?~  u.bop  [~ ~]
   [~ ~ +.q.u.u.bop]
+::  +sloy-light: minimal parsing version of sloy
+::
+::    There are several places inside vanes where we manually call the scry
+::    function raw, instead of passing it into +mink. In those cases, we're
+::    paying the price to render the arguments as text, and then are
+::    immediately parsing the passed in data. We can avoid that.
+::
+::    TODO: The entire scrying system needs to be cleaned up in a more
+::    permanent way. This hack fixes up some print/parse costs, but doesn't
+::    recover the print/parse costs of the scry itself, which we could prevent
+::    if we didn't send (list @ta), but instead sent (list dime).
+::
+++  sloy-light
+  ~/  %sloy-light
+  |=  sod/slyd
+  |=  [ref=* ron=@tas fal=@p dyc=@tas ved=case tyl=path]
+  =+  bed=[[fal dyc ved] (flop tyl)]
+  =+  bop=(sod ref ~ ron bed)
+  ?~  bop  ~
+  ?~  u.bop  [~ ~]
+  [~ ~ +.q.u.u.bop]
 ::
 ++  symp                                                ::  symbol or empty
   |=  a=*  ^-  @tas

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -148,7 +148,9 @@
   ~/  %sloy-light
   |=  sod/slyd
   |=  [ref=* ron=@tas fal=@p dyc=@tas ved=case tyl=path]
-  =+  bed=[[fal dyc ved] (flop tyl)]
+  ::  we do not flop tyl because tyl wouldn't have been flopped by +en-beam
+  ::
+  =+  bed=[[fal dyc ved] tyl]
   =+  bop=(sod ref ~ ron bed)
   ?~  bop  ~
   ?~  u.bop  [~ ~]

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -523,10 +523,10 @@
       |=  [our=ship now=@da lyf=life]
       ;;  ^deed
       %-  need  %-  need
-      %-  (sloy ski)
+      %-  (sloy-light ski)
       =/  pur=spur
         /(scot %ud lyf)/(scot %p our)
-      [[151 %noun] %j (en-beam:format [our %deed da+now] pur)]
+      [[151 %noun] %j our %deed da+now pur]
     ::  +sein: scry for sponsor
     ::
     ++  sein
@@ -534,8 +534,8 @@
       |=  [our=ship now=@da who=ship]
       ;;  ship
       %-  need  %-  need
-      %-  (sloy ski)
-      [[151 %noun] %j (en-beam:format [our %sein da+now] /(scot %p who))]
+      %-  (sloy-light ski)
+      [[151 %noun] %j our %sein da+now /(scot %p who)]
     ::  +saxo: scry for sponsorship chain
     ::
     ++  saxo
@@ -543,8 +543,8 @@
       |=  [our=ship now=@da who=ship]
       ;;  (list ship)
       %-  need  %-  need
-      %-  (sloy ski)
-      [[151 %noun] %j (en-beam:format [our %saxo da+now] /(scot %p who))]
+      %-  (sloy-light ski)
+      [[151 %noun] %j our %saxo da+now /(scot %p who)]
     ::
     ++  vein                                            ::    vein:am
       ~/  %vein

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -292,8 +292,8 @@
         |=  who=ship
         ;;  ship
         %-  need  %-  need
-        %-  (sloy ski)
-        [[151 %noun] %j (en-beam:format [our %sein da+now] /(scot %p who))]
+        %-  (sloy-light ski)
+        [[151 %noun] %j our %sein da+now /(scot %p who)]
       ::
       ++  init                                          ::  initialize
         ~&  [%dill-init our ram]


### PR DESCRIPTION
Right now, in Ames and Dill, we are rendering to `@tas` all the path components in scry paths. This overhead is clearly visible in a runtime flame graph. Introduce a version of +sloy which takes its arguments instead of parsing its arguments out of a path.

The correct long term fix to fix this entire class of issue is #926, but this hack is enough to speed up each ames packet by a few milliseconds.