### PR TITLE
removes strange %ames self-gift when forwarding to self

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1298,7 +1298,10 @@
       :~  [s.bon %give %woot q.p.bon r.bon]
       ==
     ::
-        %mead  :_(fox [[hen [%give %hear p.bon q.bon]] ~])
+        %mead
+      =^  moz  +>.$  (knob hen [%hear p.bon q.bon])
+      [moz fox]
+    ::
         %milk
       ::  ~&  [%milk p.bon q.bon]
       ?>  ?=([@ @ *] q.q.bon)

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -492,8 +492,7 @@
       $%  {$west p/sack q/path r/*}                     ::
       ==  ==  ==                                        ::
     ++  gift                                            ::  out result <-$
-      $%  {$hear p/lane q/@}                            ::  receive packet
-          {$mack p/(unit tang)}                         ::  
+      $%  {$mack p/(unit tang)}                         ::  acknowledgement
           {$mass p/mass}                                ::  memory usage
           {$send p/lane q/@}                            ::  transmit packet
           {$turf p/(list turf)}                         ::  bind to domains


### PR DESCRIPTION
This pattern required a special-case in the event/effect processing. That pattern was synchronous, so handling it in the runtime offered no advantages -- instead we just recur here.