### PR TITLE
Remove some tiscom

### DIFF
--- a/app/ask.hoon
+++ b/app/ask.hoon
@@ -94,7 +94,7 @@
     (transmit set+~ pro+prompt ~)   :: XX handle multiple links?
   ::
       $det                              :: reject all input
-    =^  inv  som  (~(transceive ^sole som) +.act)
+    =^  inv  som  (~(transceive sole som) +.act)
     =.  sos  (~(put by sos) ost.bow som)
     ?~  wom
       =/  try  (rose (tufa buf.som) fed:ag)
@@ -125,7 +125,7 @@
 ++  transmit
   |=  {inv/sole-edit mor/(list sole-effect)}
   =/  som  (~(got by sos) ost.bow)
-  =^  det  som  (~(transmit ^sole som) inv)
+  =^  det  som  (~(transmit sole som) inv)
   =.  sos  (~(put by sos) ost.bow som)
   [[(effect mor+[det+det mor])]~ +>.$]
 ::

--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -1625,7 +1625,7 @@
     (he-diff %tan u.p.cit)
   ::
   ++  he-lens
-    |=  com/command:^^^^lens
+    |=  com/command:^^lens
     ^+  +>
     =+  ^-  source/dojo-source
         =|  num/@
@@ -1815,7 +1815,7 @@
   (wrap he-type):arm
 ::
 ++  poke-lens-command
-  |=  com/command:^^^^lens  ~|  poke-lens+com  %.  com
+  |=  com/command:^^lens  ~|  poke-lens+com  %.  com
   (wrap he-lens):arm
 ::
 ++  poke-json

--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -5,8 +5,6 @@
 /-  sole, lens                                          ::  console structures
 /+  sole                                                ::  console library
 =,  sole
-=,  space:userlib
-=,  format
 ::                                                      ::  ::
 ::::                                                    ::  ::::
   ::                                                    ::    ::
@@ -310,7 +308,7 @@
         ::
         =?  a  &(?=(^ a) =('' i.a))
           t.a
-        =+((de-beam a) ?^(- u [he-beak (flop a)]))
+        =+((de-beam:format a) ?^(- u [he-beak (flop a)]))
       =+  vez=(vang | dp-path)
       (sear plex:vez (stag %clsg poor:vez))
     ::
@@ -320,11 +318,11 @@
       auru:de-purl:html
     ::
     ++  dp-model   ;~(plug dp-server dp-config)         ::  ++dojo-model
-    ++  dp-path    (en-beam he-beam)                       ::  ++path
+    ++  dp-path    (en-beam:format he-beam)                       ::  ++path
     ++  dp-server  (stag 0 (most net sym))              ::  ++dojo-server
     ++  dp-hoon    tall:(vang | dp-path)                ::  ++hoon
     ++  dp-rood                                         ::  'dir' hoon
-      =>  (vang | (en-beam dir))
+      =>  (vang | (en-beam:format dir))
       ;~  pose
         rood
       ::
@@ -566,9 +564,9 @@
                       ?:  ?=({@ ~} pax)  ~[i.pax %home '0']
                       ?:  ?=({@ @ ~} pax)  ~[i.pax i.t.pax '0']
                       pax
-                  =.  dir  (need (de-beam pax))
+                  =.  dir  (need (de-beam:format pax))
                   =-  +>(..dy (he-diff %tan - ~))
-                  rose+[" " `~]^~[leaf+"=%" (smyt (en-beam he-beak s.dir))]
+                  rose+[" " `~]^~[leaf+"=%" (smyt (en-beam:format he-beak s.dir))]
         ==
       ::
           $help
@@ -589,7 +587,7 @@
           %info
           /file
           our.hid
-          (foal (en-beam p.p.mad) cay)
+          (foal:space:userlib (en-beam:format p.p.mad) cay)
         ==
       ::
           $flat
@@ -1701,7 +1699,7 @@
         ?-  -.sink.com
           $stdout       [%show %0]
           $output-file  $(sink.com [%command (cat 3 '@' pax.sink.com)])
-          $output-clay  [%file (need (de-beam pax.sink.com))]
+          $output-clay  [%file (need (de-beam:format pax.sink.com))]
           $url          [%http %post `~. url.sink.com]
           $to-api       !!
           $send-api     [%poke our.hid api.sink.com]

--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -1269,10 +1269,10 @@
     ++  dy-edit                                         ::  handle edit
       |=  cal/sole-change
       ^+  +>+>
-      =^  dat  say  (~(transceive ^sole say) cal)
+      =^  dat  say  (~(transceive sole say) cal)
       ?:  |(?=(^ per) ?=(^ pux) ?=(~ pro))
         ~&  %dy-edit-busy
-        =^  lic  say  (~(transmit ^sole say) dat)
+        =^  lic  say  (~(transmit sole say) dat)
         (dy-diff %mor [%det lic] [%bel ~] ~)
       (dy-slam(per `dat) /edit u.pro !>((tufa buf.say)))
     ::
@@ -1541,12 +1541,12 @@
   ++  he-errd                                           ::  reject update
     |=  {rev/(unit sole-edit) err/@u}  ^+  +>
     =+  red=(fall rev [%nop ~])       ::  required for error location sync
-    =^  lic  say  (~(transmit ^sole say) red)
+    =^  lic  say  (~(transmit sole say) red)
     (he-diff %mor [%det lic] [%err err] ~)
   ::
   ++  he-pone                                           ::  clear prompt
     ^+  .
-    =^  cal  say  (~(transmit ^sole say) [%set ~])
+    =^  cal  say  (~(transmit sole say) [%set ~])
     (he-diff %mor [%det cal] ~)
   ::
   ++  he-prow                                           ::  where we are
@@ -1719,7 +1719,7 @@
     ^+  +>
     ::  ~&  [%his-clock ler.cal]
     ::  ~&  [%our-clock ven.say]
-    =^  dat  say  (~(transceive ^sole say) cal)
+    =^  dat  say  (~(transceive sole say) cal)
     ?.  ?&  ?=($del -.dat)
             =(+(p.dat) (lent buf.say))
         ==
@@ -1753,7 +1753,7 @@
       ?~  p.doy
         (he-errd ~ (lent txt))
       =+  old=(weld ?~(buf "> " "  ") (tufa buf.say))
-      =^  cal  say  (~(transmit ^sole say) [%set ~])
+      =^  cal  say  (~(transmit sole say) [%set ~])
       =.  +>.$   (he-diff %mor txt+old nex+~ det+cal ~)
       ?-  -.u.p.doy
         %&  (he-plan(buf ~) p.u.p.doy)

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -22,7 +22,6 @@
 ::
 ::::
 =,  hall-sur
-=,  hall-lib
 =>  ::  #
     ::  #  %arch
     ::  #
@@ -2342,7 +2341,7 @@
   ;:  weld
     /circle/[nom]/(scot %p hos.cir)/[nom.cir]
     (sort wat gth)  ::  consistence
-    (range-to-path ran)
+    (range-to-path:hall-lib ran)
   ==
 ::
 ++  wire-to-peer
@@ -2395,7 +2394,7 @@
     :^    %circle
         i.t.wir
       [(slav %p i.t.t.wir) i.t.t.t.wir]
-    (path-to-range t.t.t.t.wir)
+    (path-to-range:hall-lib t.t.t.t.wir)
   ::
       {$repeat @ @ @ ~}
     :+  %repeat

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -117,7 +117,7 @@
 ::  #
 ::    functional cores and arms.
 ::
-~%  %hall-door  ..^^^is  ~
+~%  %hall-door  ..^is  ~
 |_  {bol/bowl:gall $1 state}
 ::
 ::  #  %transition

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -116,7 +116,7 @@
 ::  #
 ::    functional cores and arms.
 ::
-~%  %hall-door  ..^is  ~
+~%  %hall-door  ..is  ~
 |_  {bol/bowl:gall $1 state}
 ::
 ::  #  %transition
@@ -359,7 +359,7 @@
         (ta-action [%create nom des typ])
     %-  ta-deltas
     ::  if needed, subscribe to our parent's /burden.
-    =+  sen=(above [our now our]:bol)
+    =+  sen=(above:hall-lib [our now our]:bol)
     ?:  ?|  !=(%czar (clan:title sen))
             =(sen our.bol)
             =(%pawn (clan:title our.bol))
@@ -769,7 +769,7 @@
     ~/  %hall-ta-observe
     |=  who/ship
     ^+  +>
-    ?.  =(our.bol (above our.bol now.bol who))
+    ?.  =(our.bol (above:hall-lib our.bol now.bol who))
       ~&([%not-our-bearer who] +>)
     (ta-delta %observe who)
   ::
@@ -1144,7 +1144,7 @@
         ::  ignore if it won't result in change.
         ?.  ?|  &(?=($remove -.dif.rum) ?=(^ old))
                 ?=(~ old)
-                !=(u.old (change-config u.old dif.rum))
+                !=(u.old (change-config:hall-lib u.old dif.rum))
             ==
           +>.$
         ::  full changes to us need to get split up.
@@ -1164,7 +1164,7 @@
         ::  ignore if it won't result in change.
         ?.  ?|  &(?=($remove -.dif.rum) ?=(^ old))
                 ?=(~ old)
-                !=(u.old (change-status u.old dif.rum))
+                !=(u.old (change-status:hall-lib u.old dif.rum))
             ==
           +>.$
         (so-delta-our rum)
@@ -1250,7 +1250,7 @@
           ::  in audience, replace above with us.
           ::TODO  this really should be done by the sender.
           =.  aud.t
-            =+  dem=[(above [our now our]:bol) nom]
+            =+  dem=[(above:hall-lib [our now our]:bol) nom]
             ?.  (~(has in aud.t) dem)  aud.t
             =+  (~(del in aud.t) dem)
             (~(put in -) so-cir)
@@ -1258,7 +1258,7 @@
           ?:  &(?=(^ num) =(t (snag u.num grams)))  ~
           ::TODO  this really should have sent us the message
           ::      src as well but that's not an easy fix.
-          `[%story nom %gram [(above [our now our]:bol) nom] t]
+          `[%story nom %gram [(above:hall-lib [our now our]:bol) nom] t]
         ==
       ::  inherited flag
       %_(self deltas [[%story nom %inherited &] deltas])
@@ -1283,7 +1283,7 @@
           ?|  !(~(has by locals) who)
             ::
               =+  old=(~(got by locals) who)
-              =+  new=(change-status - dif)
+              =+  new=(change-status:hall-lib - dif)
               ?&  !=(old new)
                 ::
                   ?=  ~
@@ -1939,7 +1939,7 @@
     ~/  %hall-da-change-nick
     |=  {who/ship nic/nick}
     ^+  +>
-    +>(nicks (change-nicks nicks who nic))
+    +>(nicks (change-nicks:hall-lib nicks who nic))
   ::
   ::  #
   ::  #  %stories
@@ -2125,7 +2125,7 @@
         =.  +>
           %-  sa-emil
           (sa-config-effects shape dif.det)
-        +>(shape (change-config shape dif.det))
+        +>(shape (change-config:hall-lib shape dif.det))
       ::
           $status
         %_  +>
@@ -2133,7 +2133,7 @@
           ?:  ?=($remove -.dif.det)
             (~(del by locals) who.det)
           %+  ~(put by locals)  who.det
-          %+  change-status
+          %+  change-status:hall-lib
             (fall (~(get by locals) who.det) *status)
           dif.det
         ==
@@ -2196,7 +2196,7 @@
         ?:  ?=($remove -.dif.det)
           +>(mirrors (~(del by mirrors) cir.det))
         =/  new/config
-          %+  change-config
+          %+  change-config:hall-lib
           (fall (~(get by mirrors) cir.det) *config)
           dif.det
         +>.$(mirrors (~(put by mirrors) cir.det new))
@@ -2208,7 +2208,7 @@
           =+  ole=(fall (~(get by remotes) cir.det) *group)
           ?:  ?=($remove -.dif.det)  (~(del by ole) who.det)
           =+  old=(fall (~(get by ole) who.det) *status)
-          (~(put by ole) who.det (change-status old dif.det))
+          (~(put by ole) who.det (change-status:hall-lib old dif.det))
         ==
       ==
     ::
@@ -2370,7 +2370,7 @@
     (welp /circle t.t.t.wir)
   ::
       {$burden *}
-    :-  (above [our now our]:bol)
+    :-  (above:hall-lib [our now our]:bol)
     /burden/(scot %p our.bol)
   ::
       {$report @ *}
@@ -2730,7 +2730,7 @@
   ::
       $report
     ::  only send changes we didn't get from above.
-    ?:  =(src.bol (above [our now our]:bol))  ~
+    ?:  =(src.bol (above:hall-lib [our now our]:bol))  ~
     ::  only send story reports about grams and status.
     ?.  ?=($story -.det)  ~
     ?.  ?=(?($gram $status) -.det.det)  ~
@@ -2739,7 +2739,7 @@
     ?.  inherited.soy  ~
     ::  only burden channels for now.
     ?.  =(%channel sec.con.shape.soy)  ~
-    `[%burden nom.det (dedicate (above [our now our]:bol) nom.det det.det)]
+    `[%burden nom.det (dedicate (above:hall-lib [our now our]:bol) nom.det det.det)]
   ::
       $peers
     ?.  ?=($story -.det)      ~
@@ -2825,7 +2825,7 @@
   ?~  pax  qer
   ::TODO  can probably do this a bit better...
   ?+  i.pax
-    qer(ran (path-to-range pax))
+    qer(ran (path-to-range:hall-lib pax))
   ::
     circle-data   %_  $  pax  t.pax
                     wat.qer   (~(put in wat.qer) i.pax)
@@ -2862,7 +2862,7 @@
   ::  parse a list of coins into a query structure.
   ::
   ^-  $-((list coin) query)
-  =>  depa
+  =>  depa:hall-lib
   |^  %-  af  :~
           [%client ul]
           [%circles (at /[%p])]
@@ -2889,10 +2889,10 @@
     $circles  =(who who.qer)
     $public   &
     $burden   ?&  =(who who.qer)
-                  =(our.bol (above our.bol now.bol who))
+                  =(our.bol (above:hall-lib our.bol now.bol who))
               ==
     $peers    =(who our.bol)  ::TODO  or so-visible?
-    $report   =(who (above [our now our]:bol))
+    $report   =(who (above:hall-lib [our now our]:bol))
   ::
       $circle
     ?.  (~(has by stories) nom.qer)  |
@@ -3276,7 +3276,7 @@
   ?:  =(a 'refederate')
     ~&  'refederating. may take a while...'
     :_  +>
-    =+  bov=(above [our now our]:bol)
+    =+  bov=(above:hall-lib [our now our]:bol)
     ?:  =(bov our.bol)  ~
     :~  [ost.bol %pull /burden [bov dap.bol] ~]
         (wire-to-peer /burden)

--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -13,15 +13,12 @@
 ::  since that's the only thing the client ever
 ::  subscribes to.
 ::
-/-    hall-sur=hall, sole-sur=sole                      ::  structures
-/+    hall-lib=hall, sole-lib=sole                      ::  libraries
+/-    sole-sur=sole                                     ::  structures
+/+    *hall, sole-lib=sole                              ::  libraries
 /=    seed  /~  !>(.)
 ::
 ::::
   ::
-=,  hall-sur
-=,  sole-sur
-=,  hall-lib
 =>  ::  #
     ::  #  %arch
     ::  #
@@ -47,7 +44,7 @@
     ++  shell                                           ::  console session
       $:  id/bone                                       ::  identifier
           latest/@ud                                    ::  latest shown msg num
-          say/sole-share                                ::  console state
+          say/sole-share:sole-sur                       ::  console state
           active/audience                               ::  active targets
           settings/(set term)                           ::  frontend settings
           width/@ud                                     ::  display width
@@ -55,7 +52,7 @@
       ==                                                ::
     ++  move  (pair bone card)                          ::  all actions
     ++  lime                                            ::  diff fruit
-      $%  {$sole-effect sole-effect}                    ::
+      $%  {$sole-effect sole-effect:sole-sur}           ::
       ==                                                ::
     ++  pear                                            ::  poke fruit
       $%  {$hall-command command}                       ::
@@ -330,7 +327,7 @@
     :_  +>
     ::  seperate our sole-effects from other moves.
     =/  yop
-      |-  ^-  (pair (list move) (list sole-effect))
+      |-  ^-  (pair (list move) (list sole-effect:sole-sur))
       ?~  moves  [~ ~]
       =+  mor=$(moves t.moves)
       ?:  ?&  =(id.cli p.i.moves)
@@ -340,7 +337,7 @@
       [[i.moves p.mor] q.mor]
     ::  flop moves, flop and squash sole-effects into a %mor.
     =+  moz=(flop p.yop)
-    =/  foc/(unit sole-effect)
+    =/  foc/(unit sole-effect:sole-sur)
       ?~  q.yop  ~
       ?~  t.q.yop  `i.q.yop                             ::  single sole-effect
       `[%mor (flop q.yop)]                              ::  more sole-effects
@@ -590,7 +587,7 @@
   ++  ta-sole
     ::  apply sole input
     ::
-    |=  act/sole-action
+    |=  act/sole-action:sole-sur
     ^+  +>
     ?.  =(id.cli ost.bol)
       ~&(%strange-sole !!)
@@ -626,7 +623,7 @@
     ++  sh-fact
       ::  adds a console effect to ++ta's moves.
       ::
-      |=  fec/sole-effect
+      |=  fec/sole-effect:sole-sur
       ^+  +>
       +>(moves [[id.she %diff %sole-effect fec] moves])
     ::
@@ -655,7 +652,7 @@
     ++  sh-sole
       ::  applies sole action.
       ::
-      |=  act/sole-action
+      |=  act/sole-action:sole-sur
       ^+  +>
       ?-  -.act
         $det  (sh-edit +.act)
@@ -669,7 +666,7 @@
       ::  called when typing into the cli prompt.
       ::  applies the change and does sanitizing.
       ::
-      |=  cal/sole-change
+      |=  cal/sole-change:sole-sur
       ^+  +>
       =^  inv  say.she  (~(transceive sole-lib say.she) cal)
       =+  fix=(sh-sane inv buf.say.she)
@@ -991,14 +988,14 @@
       ::  parses cli prompt input using ++sh-read and
       ::  sanitizes when invalid.
       ::
-      |=  {inv/sole-edit buf/(list @c)}
-      ^-  {lit/(list sole-edit) err/(unit @u)}
+      |=  {inv/sole-edit:sole-sur buf/(list @c)}
+      ^-  {lit/(list sole-edit:sole-sur) err/(unit @u)}
       =+  res=(rose (tufa buf) sh-read)
       ?:  ?=(%| -.res)  [[inv]~ `p.res]
       :_  ~
       ?~  p.res  ~
       =+  wok=u.p.res
-      |-  ^-  (list sole-edit)
+      |-  ^-  (list sole-edit:sole-sur)
       ?+  -.wok
         ~
       ::
@@ -1009,11 +1006,11 @@
     ++  sh-slug
       ::  corrects invalid prompt input.
       ::
-      |=  {lit/(list sole-edit) err/(unit @u)}
+      |=  {lit/(list sole-edit:sole-sur) err/(unit @u)}
       ^+  +>
       ?~  lit  +>
       =^  lic  say.she
-          (~(transmit sole-lib say.she) `sole-edit`?~(t.lit i.lit [%mor lit]))
+          (~(transmit sole-lib say.she) `sole-edit:sole-sur`?~(t.lit i.lit [%mor lit]))
       (sh-fact [%mor [%det lic] ?~(err ~ [%err u.err]~)])
     ::
     ++  sh-obey
@@ -1374,7 +1371,7 @@
         ::
         |=  cis/(set circle)  ^+  ..sh-work
         =<  (sh-fact %mor (murn (sort ~(tap by remotes) aor) .))
-        |=  {cir/circle gop/group}  ^-  (unit sole-effect)
+        |=  {cir/circle gop/group}  ^-  (unit sole-effect:sole-sur)
         ?.  |(=(~ cis) (~(has in cis) cir))  ~
         ?:  =(%mailbox sec.con:(fall (~(get by mirrors) cir) *config))  ~
         ?.  (~(has in sources) cir)  ~
@@ -1407,14 +1404,14 @@
         %+  sh-fact  %mor
         %-  ~(rep by binds)
         |=  $:  {gyf/char aus/(set audience)}
-                lis/(list sole-effect)
+                lis/(list sole-effect:sole-sur)
             ==
         %+  weld  lis
-        ^-  (list sole-effect)
+        ^-  (list sole-effect:sole-sur)
         %-  ~(rep in aus)
-        |=  {a/audience l/(list sole-effect)}
+        |=  {a/audience l/(list sole-effect:sole-sur)}
         %+  weld  l
-        ^-  (list sole-effect)
+        ^-  (list sole-effect:sole-sur)
         [%txt [gyf ' ' ~(ar-phat ar a)]]~
       ::
       ++  number
@@ -1466,7 +1463,7 @@
           =-  ~(tap in (~(del in src:-) [cir ~]))
           (fall (~(get by mirrors) cir) *config)
         |=  s/^source
-        ^-  sole-effect
+        ^-  sole-effect:sole-sur
         :-  %txt
         %+  weld  ~(cr-phat cr cir.s)
         %+  roll  (range-to-path ran.s)
@@ -2234,7 +2231,7 @@
     ::  produces sole-effect for printing message
     ::  details.
     ::
-    ^-  sole-effect
+    ^-  sole-effect:sole-sur
     ~[%mor [%tan tr-meta] tr-body]
   ::
   ++  tr-rend
@@ -2306,7 +2303,7 @@
     ::  long-form display of message contents, specific
     ::  to each speech type.
     ::
-    |-  ^-  sole-effect
+    |-  ^-  sole-effect:sole-sur
     ?-  -.sep
         $lin
       tan+~[leaf+"{?:(pat.sep "@ " "")}{(trip msg.sep)}"]
@@ -2509,7 +2506,7 @@
 ++  poke-sole-action
   ::  incoming sole action. process it.
   ::
-  |=  act/sole-action
+  |=  act/sole-action:sole-sur
   ta-done:(ta-sole:ta act)
 ::
 ::TODO  for debug purposes. remove eventually.

--- a/lib/hall.hoon
+++ b/lib/hall.hoon
@@ -1,11 +1,10 @@
 ::
 ::::  /lib/hall/hoon
   ::
-/-    hall
+/-    *hall
 ::
 ::::
   ::
-=,  hall
 |_  bol/bowl:gall
 ::
 ::TODO  add to zuse?

--- a/lib/hood/drum.hoon
+++ b/lib/hood/drum.hoon
@@ -2,9 +2,8 @@
 ::::  /hoon/drum/hood/lib                               ::  ::
   ::                                                    ::  ::
 /?    310                                               ::  version
-/-    sole, hall
+/-    *sole, hall
 /+    sole
-=,    ^sole
 ::                                                      ::  ::
 ::::                                                    ::  ::
   ::                                                    ::  ::

--- a/lib/pill.hoon
+++ b/lib/pill.hoon
@@ -1,6 +1,6 @@
 ::  |pill: helper functions for making pills
 ::
-^|
+^?
 |%
 ::  +module-ova: vane load operations.
 ::

--- a/lib/pill.hoon
+++ b/lib/pill.hoon
@@ -1,5 +1,6 @@
 ::  |pill: helper functions for making pills
 ::
+^|
 |%
 ::  +module-ova: vane load operations.
 ::

--- a/lib/sole.hoon
+++ b/lib/sole.hoon
@@ -2,9 +2,7 @@
 ::::  /hoon/sole/lib
   ::
 /?    310
-/-    sole
-=,  sole
-::
+/-    *sole
 ::::
   ::
 |_  sole-share                                          ::  shared-state engine

--- a/sur/asn1.hoon
+++ b/sur/asn1.hoon
@@ -3,6 +3,7 @@
 ::    A minimal representation of some basic ASN.1 types,
 ::    created to support PKCS keys, digests, and cert requests.
 ::
+^?
 |%
 ::  +bespoke:asn1: context-specific, generic ASN.1 tag type
 ::
@@ -65,6 +66,7 @@
 ::  |obj:asn1: constant object ids, pre-encoded
 ::
 ++  obj
+  ^?
   |%                                                ::    rfc4055
   ++  sha-256      0x1.0204.0365.0148.8660          ::  2.16.840.1.101.3.4.2.1
   ++  rsa          0x1.0101.0df7.8648.862a          ::  1.2.840.113549.1.1.1

--- a/sur/hall.hoon
+++ b/sur/hall.hoon
@@ -1,6 +1,7 @@
 ::
 ::::  /sur/hall/hoon
   ::
+^?
 |%
 ::
 ::TODO  use different words for different kinds of burdens

--- a/sur/lens.hoon
+++ b/sur/lens.hoon
@@ -1,3 +1,4 @@
+^?
 |%
 ++  command
   $:  source/source

--- a/sur/plan/diff.hoon
+++ b/sur/plan/diff.hoon
@@ -1,3 +1,2 @@
 /-    plan-acct
-^?
 {inf/(unit {@txname @txloc}) del/(map knot ~) put/(map knot plan-acct)}

--- a/sur/plan/diff.hoon
+++ b/sur/plan/diff.hoon
@@ -1,2 +1,3 @@
 /-    plan-acct
+^?
 {inf/(unit {@txname @txloc}) del/(map knot ~) put/(map knot plan-acct)}

--- a/sur/sole.hoon
+++ b/sur/sole.hoon
@@ -1,7 +1,8 @@
 ::
 ::::  /hoon/sole/sur
   ::
-=>  |%
+^?
+|%
 ++  sole-action                                         ::  sole to app
   $%  ::  {$abo ~}                                      ::  reset interaction
       {$det sole-change}                                ::  command line edit
@@ -78,8 +79,6 @@
       (unit knot)
     hiss:eyre
   $-(httr:eyre (sole-request out))
---
-|%
 ::                                                      ::
 ++  sole-gen                                            ::  XX virtual type
   $%  {$say $-((sole-args) (cask))}                     ::  direct noun


### PR DESCRIPTION
This removes some redundant libraries, replaces some `=,` with explicit references, locks some libraries and structures with `^?` and removes some `^`.