### PR TITLE
Fix Behn bug that broke Clay

### DIFF
--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -86,8 +86,9 @@
           :~  timers+[%& timers]
           ==
         ==
+      ::  reverse moves, since they were constructed backward, and return
       ::
-      [moves ..^^$]
+      [(flop moves) ..^^$]
   ::  +set-timer: set a timer, maintaining the sort order of the :timers list
   ::
   ++  set-timer
@@ -140,14 +141,14 @@
     ::
     ?~  timers
       ?~  next-wake
-        [~ state]
+        [moves state]
       :_  state(next-wake ~)
       [[unix-duct %give %doze ~] moves]
     ::  if :next-wake is in the past or not soon enough, reset it
     ::
     ?^  next-wake
       ?:  &((gte date.i.timers u.next-wake) (lte now u.next-wake))
-        [~ state]
+        [moves state]
       :_  state(next-wake `date.i.timers)
       [[unix-duct %give %doze `date.i.timers] moves]
     ::  there was no unix wakeup timer; set one

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -96,9 +96,9 @@
     ::
     ?~  timers
       ~[t]
-    ::  timers at the same date form a lifo queue; for fifo, change +lte to +lth
+    ::  timers at the same date form a fifo queue
     ::
-    ?:  (lte date.t date.i.timers)
+    ?:  (lth date.t date.i.timers)
       [t timers]
     ::
     [i.timers $(timers t.timers)]


### PR DESCRIPTION
Clay expected responses to its timers to come back in the same order it sent them. So needy!

Now Behn actually does this.