### PR TITLE
single-home the vanes

### DIFF
--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -117,7 +117,7 @@
           [%build wire ? schematic:ford]
           [%kill wire ~]
           {$deal wire sock term club}                   ::
-          {$info wire @p toro:clay}                     ::
+          {$info wire toro:clay}                        ::
       ==                                                ::
     ++  move  (pair bone card)                          ::  user-level move
     ++  sign                                            ::
@@ -586,7 +586,6 @@
         %-  he-card(poy ~)  :*
           %info
           /file
-          our.hid
           (foal:space:userlib (en-beam:format p.p.mad) cay)
         ==
       ::

--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -114,7 +114,7 @@
               mark 
               {$hiss hiss:eyre}
           ==
-          [%build wire @p ? schematic:ford]
+          [%build wire ? schematic:ford]
           [%kill wire @p]
           {$deal wire sock term club}                   ::
           {$info wire @p toro:clay}                     ::
@@ -363,7 +363,7 @@
       ?>  ?=($~ pux)
       ::  pin all builds to :now.hid so they don't get cached forever
       ::
-      (he-card(poy `+>+<(pux `way)) %build way our.hid live=%.n schematic)
+      (he-card(poy `+>+<(pux `way)) %build way live=%.n schematic)
     ::
     ++  dy-eyre                                         ::  send work to eyre
       |=  {way/wire usr/(unit knot) req/hiss:eyre}

--- a/app/dojo.hoon
+++ b/app/dojo.hoon
@@ -115,7 +115,7 @@
               {$hiss hiss:eyre}
           ==
           [%build wire ? schematic:ford]
-          [%kill wire @p]
+          [%kill wire ~]
           {$deal wire sock term club}                   ::
           {$info wire @p toro:clay}                     ::
       ==                                                ::
@@ -376,7 +376,7 @@
       =.  poy  ~
       ?~  pux  +>
       %.  [%txt "! cancel {<u.pux>}"]
-      he-diff:(he-card [%kill u.pux our.hid])
+      he-diff:(he-card [%kill u.pux ~])
     ::
     ++  dy-slam                                         ::  call by ford
       |=  {way/wire gat/vase sam/vase}

--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -99,7 +99,7 @@
       ==                                                ::
     ++  card                                            ::  general card
       $%  {$diff lime}                                  ::
-          {$info wire ship term nori:clay}              ::
+          {$info wire term nori:clay}                   ::
           {$peer wire dock path}                        ::
           {$poke wire dock pear}                        ::
           {$pull wire dock ~}                          ::
@@ -3114,7 +3114,6 @@
   :*  ost.bol
       %info
       /jamfile
-      our.bol
       (foal:space:userlib paf [%hall-telegrams !>(-)])
   ==
 ::
@@ -3211,7 +3210,6 @@
   :*  ost.bol
       %info
       /jamfile
-      our.bol
       (foal:space:userlib paf [%hall-telegrams !>(-)])
   ==
 ::

--- a/app/test.hoon
+++ b/app/test.hoon
@@ -69,8 +69,7 @@
   |=  [a=spur b=(list spur)]
   ~&  >>  (flop a)
   :-  %build
-  :^    a-core+a
-      our
+  :+  a-core+a
     live=|
   ^-  schematic:ford
   :-  [%core now-disc %hoon a]
@@ -100,8 +99,7 @@
   |=  [a=term b=(list term)]
   ~&  >>  [%ren a]
   :-  %build
-  :^    a-rend+/[a]
-      our
+  :+  a-rend+/[a]
     live=|
   ^-  schematic:ford
   =/  bem=beam  (need (de-beam %/example))

--- a/lib/collections.hoon
+++ b/lib/collections.hoon
@@ -12,7 +12,7 @@
 +=  card
   $%  [%info wire toro:clay]
       [%poke wire dock poke]
-      [%perm wire ship desk path rite:clay]
+      [%perm wire desk path rite:clay]
   ==
 +=  poke
   $%  [%hall-action action:hall]
@@ -849,14 +849,14 @@
     |=  [pax=path r=rule:clay w=rule:clay]
     ^+  ta-this
     %+  ta-emit  ost.bol
-    [%perm (weld /perms pax) our.bol q.byk.bol pax [%rw `r `w]]
+    [%perm (weld /perms pax) q.byk.bol pax [%rw `r `w]]
   ::
   ++  ta-flush-permissions
     ~/  %coll-ta-flush-permissions
     |=  pax=path
     ^+  ta-this
     %+  ta-emit  ost.bol
-    [%perm (weld /perms pax) our.bol q.byk.bol pax [%rw ~ ~]]
+    [%perm (weld /perms pax) q.byk.bol pax [%rw ~ ~]]
   ::
   ::  hall
   ::

--- a/lib/collections.hoon
+++ b/lib/collections.hoon
@@ -10,7 +10,7 @@
 |%
 +=  move  [bone card]
 +=  card
-  $%  [%info wire ship toro:clay]
+  $%  [%info wire toro:clay]
       [%poke wire dock poke]
       [%perm wire ship desk path rite:clay]
   ==
@@ -830,7 +830,7 @@
     =/  bek  byk.bol(r [%da now.bol])
     =.  pax  (en-beam:format bek (flop pax))
     %+  ta-emit  ost.bol
-    [%info (weld /ta-write pax) our.bol (foal pax cay)]
+    [%info (weld /ta-write pax) (foal pax cay)]
   ::
   ++  ta-remove
     =,  space:userlib
@@ -840,7 +840,7 @@
     =.  pax  (en-beam:format bek (flop pax))
     ^+  ta-this
     %+  ta-emit  ost.bol
-    [%info (weld /ta-remove pax) our.bol (fray pax)]
+    [%info (weld /ta-remove pax) (fray pax)]
   ::
   ::  permissions
   ::

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -63,7 +63,7 @@
     ++  card                                            ::
       $%  {$build wire ? schematic:ford}                ::
           {$drop wire @tas}                             ::
-          {$info wire @p @tas nori}                     ::
+          {$info wire @tas nori}                        ::
           {$mont wire @tas beam}                        ::
           {$dirk wire @tas}                             ::
           {$ogre wire $@(@tas beam)}                    ::
@@ -160,7 +160,7 @@
   |=  {mez/tape tor/(unit toro)}
   ?~  tor
     abet:(spam leaf+mez ~)
-  abet:(emit:(spam leaf+mez ~) %info /kiln our u.tor)
+  abet:(emit:(spam leaf+mez ~) %info /kiln u.tor)
 ::
 ++  poke-rm
   |=  a/path
@@ -643,7 +643,7 @@
     =<  win
     %-  blab:(spam tan)
     :_  ~
-    :*  ost  %info  /kiln/[syd]  our
+    :*  ost  %info  /kiln/[syd]
         (cat 3 syd '-scratch')  %&
         %+  murn  can
         |=  {p/path q/(unit miso)}

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -73,7 +73,7 @@
           {$wipe wire @ud}                              ::
           [%keep wire compiler-cache-size=@ud build-cache-size=@ud]
           {$wait wire @da}                              ::
-          {$warp wire sock riff}                        ::
+          {$warp wire ship riff}                        ::
       ==                                                ::
     ++  pear                                            ::  poke fruit
       $%  {$hall-command command:hall}                  ::
@@ -225,7 +225,7 @@
   ++  subscribe-next
     %-  emit
     ^-  card
-    [%warp /kiln/autoload [our our] %home `[%next %z da+now /sys]]
+    [%warp /kiln/autoload our %home `[%next %z da+now /sys]]
   ::
   ++  writ  =>(check-new subscribe-next)
   ++  check-new
@@ -364,26 +364,20 @@
   ++  spam  |*(* %_(+> ..auto (^spam +<)))
   ++  stop
     =>  (spam (render "ended autosync" sud her syd) ~)
-    %-  blab  :_  ~
-    :*  ust  %warp
-        /kiln/sync/[syd]/(scot %p her)/[sud]
-        [our her]  sud  ~
-    ==
+    =/  =wire  /kiln/sync/[syd]/(scot %p her)/[sud]
+    (blab [ust %warp wire her sud ~] ~)
   ::  XX duplicate of start-sync? see |track
   ::
   ++  start-track
     =>  (spam (render "activated track" sud her syd) ~)
     =.  let  1
-    %-  blab
-    :~  :*  ost  %warp
-            /kiln/sync/[syd]/(scot %p her)/[sud]
-            [our her]  sud  ~  %sing  %y  ud+let  /
-    ==  ==
+    =/  =wire  /kiln/sync/[syd]/(scot %p her)/[sud]
+    (blab [ost %warp wire her sud `[%sing %y ud+let /]] ~)
   ::
   ++  start-sync
     =<  (spam (render "activated sync" sud her syd) ~)
     =/  =wire  /kiln/sync/[syd]/(scot %p her)/[sud]
-    (blab [ost %warp wire [our her] sud `[%sing %w [%da now] /]] ~)
+    (blab [ost %warp wire her sud `[%sing %w [%da now] /]] ~)
   ::
   ++  writ
     |=  rot=riot
@@ -434,7 +428,7 @@
         ==
       ==
     =/  =wire  /kiln/sync/[syd]/(scot %p her)/[sud]
-    (blab [ost %warp wire [our her] sud `[%sing %y ud+let /]] ~)
+    (blab [ost %warp wire her sud `[%sing %y ud+let /]] ~)
   --
 ::
 ++  work                                              ::  state machine

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -62,7 +62,7 @@
 =>  |%                                                  ::  arvo structures
     ++  card                                            ::
       $%  {$build wire ? schematic:ford}                ::
-          {$drop wire @p @tas}                          ::
+          {$drop wire @tas}                             ::
           {$info wire @p @tas nori}                     ::
           {$mont wire @tas beam}                        ::
           {$dirk wire @tas}                             ::
@@ -154,7 +154,7 @@
 ::
 ++  poke-cancel
   |=  syd/desk
-  abet:(emit %drop /cancel our syd)
+  abet:(emit %drop /cancel syd)
 ::
 ++  poke-info
   |=  {mez/tape tor/(unit toro)}

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -67,7 +67,7 @@
           {$mont wire @tas beam}                        ::
           {$dirk wire @tas}                             ::
           {$ogre wire $@(@tas beam)}                    ::
-          {$merg wire @p @tas @p @tas case germ}        ::
+          {$merg wire @tas @p @tas case germ}           ::
           {$perm wire ship desk path rite}              ::
           {$poke wire dock pear}                        ::
           {$wipe wire @ud}                              ::
@@ -410,7 +410,7 @@
     =<  %-  spam
         ?:  =(our her)  ~
         [(render "beginning sync" sud her syd) ~]
-    (blab [ost %merg wire our syd her sud ud+let germ] ~)
+    (blab [ost %merg wire syd her sud ud+let germ] ~)
   ::
   ++  mere
     |=  mes=(each (set path) (pair term tang))
@@ -469,7 +469,7 @@
   ::
   ++  perform                                         ::
     ^+  .
-    (blab [ost %merg /kiln/[syd] our syd her sud cas gem] ~)
+    (blab [ost %merg /kiln/[syd] syd her sud cas gem] ~)
   ::
   ++  fancy-merge                                     ::  send to self
     |=  {syd/desk her/@p sud/desk gem/?($auto germ)}
@@ -495,7 +495,7 @@
     ?~  saw
       =>  (spam leaf+"%melding %{(trip sud)} into scratch space" ~)
       %-  blab  :_  ~
-      [ost %merg /kiln/[syd] our (cat 3 syd '-scratch') her sud cas gem]
+      [ost %merg /kiln/[syd] (cat 3 syd '-scratch') her sud cas gem]
     =+  :-  "failed to set up conflict resolution scratch space"
         "I'm out of ideas"
     lose:(spam leaf+-< leaf+-> u.saw)

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -68,7 +68,7 @@
           {$dirk wire @tas}                             ::
           {$ogre wire $@(@tas beam)}                    ::
           {$merg wire @tas @p @tas case germ}           ::
-          {$perm wire ship desk path rite}              ::
+          {$perm wire desk path rite}                   ::
           {$poke wire dock pear}                        ::
           {$wipe wire @ud}                              ::
           [%keep wire compiler-cache-size=@ud build-cache-size=@ud]
@@ -185,8 +185,8 @@
 ++  poke-permission
   |=  {syd/desk pax/path pub/?}
   =<  abet
-  %^  emit  %perm  /kiln/permission
-  [our syd pax %r ~ ?:(pub %black %white) ~]
+  %-  emit
+  [%perm /kiln/permission syd pax %r ~ ?:(pub %black %white) ~]
 ::
 ++  poke-autoload  |=(lod/(unit ?) abet:(poke:autoload lod))
 ++  poke-start-autoload  |=(~ abet:start:autoload)

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -61,7 +61,7 @@
 ?>  =(src our)
 =>  |%                                                  ::  arvo structures
     ++  card                                            ::
-      $%  {$build wire @p ? schematic:ford}             ::
+      $%  {$build wire ? schematic:ford}                ::
           {$drop wire @p @tas}                          ::
           {$info wire @p @tas nori}                     ::
           {$mont wire @tas beam}                        ::
@@ -514,7 +514,7 @@
         =+  tic=(cat 3 syd '-scratch')
         %-  blab  :_  ~
         =,  ford
-        :*  ost  %build  /kiln/[syd]  our  live=%.n
+        :*  ost  %build  /kiln/[syd]  live=%.n
             ^-  schematic
             :-  %list
             ^-  (list schematic)

--- a/lib/hood/write.hoon
+++ b/lib/hood/write.hoon
@@ -17,7 +17,7 @@
 |%
 ++  data  $%({$json json} {$mime mime})
 ++  card  $%  {$build wire ? schematic:ford}
-              {$info wire @p toro:clay}
+              {$info wire toro:clay}
           ==
 --
 ::
@@ -34,7 +34,7 @@
   =+  ext=%md
   ?~  (file (en-beam beak-now [ext sup]))
     ~|(not-found+[ext `path`(flop sup)] !!)
-  =-  abet:(emit %info write+~ our -)
+  =-  abet:(emit %info write+~ -)
   (fray (en-beam beak-now [ext sup]))
 ::
 ++  poke-tree
@@ -57,7 +57,7 @@
     =+  .^(path %e /(scot %p our)/serv/(scot %da now))
     ?>(?=({@tas @tas *} -) -)
   =;  sob/soba:clay
-    ?~(sob abet abet:(emit %info write+~ our `toro:clay`[i.t.sev %& sob]))
+    ?~(sob abet abet:(emit %info write+~ `toro:clay`[i.t.sev %& sob]))
   =+  pax=`path`/web/plan
   =+  paf=(en-beam beak-now (flop pax))
   ?~  [fil:.^(arch %cy paf)]
@@ -156,7 +156,7 @@
   ::
   =/  =cage  (result-to-cage:ford build-result)
   ::
-  =-  abet:(emit %info write+~ our -)
+  =-  abet:(emit %info write+~ -)
   ::
   (foal :(welp (en-beam beak-now ~) pax /[-.cage]) cage)
 --

--- a/lib/hood/write.hoon
+++ b/lib/hood/write.hoon
@@ -16,7 +16,7 @@
   ::
 |%
 ++  data  $%({$json json} {$mime mime})
-++  card  $%  {$build wire @p ? schematic:ford}
+++  card  $%  {$build wire ? schematic:ford}
               {$info wire @p toro:clay}
           ==
 --
@@ -134,7 +134,6 @@
   %-  emit  :*
     %build
     write+pax
-    our
     live=%.n                ::  XX defer %nice
     ^-  schematic:ford   ::  SYNTAX ERROR AT START OF LINE?
     =/  =beak  beak-now

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -68,7 +68,7 @@
   ++  go                                                ::    go
     |_  ton=town                                        ::  ames state
     ++  as                                              ::    as:go
-      |_  [our=ship saf=sufi]                           ::  per server
+      |_  our=ship                                      ::  per server
       ++  lax                                           ::    lax:as:go
         |_  [her=ship dur=dore]                         ::  per client
         ++  cluy                                        ::    cluy:lax:as:go
@@ -222,7 +222,7 @@
                       &(!?=(%czar rac) =(our seg))
                   ==
                 ~
-              `law.saf
+              `law.ton
             =/  yig  sen
             =/  hom  (jam ham)
             ?:  =(~ lew.wod.dur)
@@ -257,37 +257,35 @@
         |=  her=ship
         ^+  lax
         =/  fod=dore
-          (fall (~(get by hoc.saf) her) (gur her))
+          (fall (~(get by hoc.ton) her) (gur her))
         ~(. lax [her fod])
       ::
       ++  nux                                           ::  install dore
         |=  new=_lax
         ^+  +>
-        +>(hoc.saf (~(put by hoc.saf) her.new dur.new))
+        +>(hoc.ton (~(put by hoc.ton) her.new dur.new))
       ::
       ++  sen                                           ::  current crypto
         ^-  [lyf=life cub=acru]
-        ?~(val.saf !! [p.i.val.saf r.i.val.saf])
+        ?~(val.ton !! [p.i.val.ton r.i.val.ton])
       ::
       ++  sev                                           ::  crypto by life
         |=  mar=life
         ^-  [p=? q=acru]
-        ?~  val.saf  !!
-        ?:  =(mar p.i.val.saf)
-          [& r.i.val.saf]
-        ?>  (lth mar p.i.val.saf)
+        ?~  val.ton  !!
+        ?:  =(mar p.i.val.ton)
+          [& r.i.val.ton]
+        ?>  (lth mar p.i.val.ton)
         :-  |
         |-  ^-  acru
-        ?>  ?=(^ t.val.saf)
-        ?:  =(mar p.i.t.val.saf)
-          r.i.t.val.saf
-        $(t.val.saf t.t.val.saf)
+        ?>  ?=(^ t.val.ton)
+        ?:  =(mar p.i.t.val.ton)
+          r.i.t.val.ton
+        $(t.val.ton t.t.val.ton)
       --                                                ::  --as:go
     ::
     ++  su                                              ::  install safe
-      |=  new=_as
-      ^-  town
-      ton(urb (~(put by urb.ton) our.new saf.new))
+      |=(new=_as `town`ton.new)
     ::
     ++  ti                                              ::  expire by time
       |=  now=@da
@@ -295,11 +293,7 @@
       !!
     ::
     ++  us                                              ::  produce safe
-      |=  our=ship
-      ^-  (unit _as)
-      =+  goh=(~(get by urb.ton) our)
-      ?~  goh  ~
-      [~ ~(. as [our u.goh])]
+      |=(our=ship `_as`~(. as our))
     --                                                ::  --go
   --
   ::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -555,23 +549,26 @@
               =(life (roll ~(tap in ~(key by vein)) max))
           ==
         ~|  [%vein-mismatch +<]  !!
-      ::  XX single-home
+      %=  fox
+          hoc.ton
+        ::  reset connections
+        ::
+        (~(run by hoc.ton.fox) |=(=dore dore(caq *clot)))
       ::
-      ?.  ?|  (~(has by urb.ton.fox) our)
-              =(~ urb.ton.fox)
-          ==
-        ~|  [%strange-vein +<]  !!
-      =/  suf=sufi  (fall (~(get by urb.ton.fox) our) *sufi)
-      ::  reset symmetric keys
+          seh.ton
+        ::  reset symmetric key cache
+        ::
+        ~
       ::
-      =.  hoc.suf  (~(run by hoc.suf) |=(=dore dore(caq *clot)))
-      =.  seh.suf  ~
-      ::  save our deed (for comet/moon communication)
-      ::
-      =.  law.suf  (deed our life)
       ::  save our secrets, ready for action
+          law.ton
+        ::  save our deed (for comet/moon communication)
+        ::
+        (deed our life)
       ::
-      =.  val.suf
+          val.ton
+        ::  save our secrets, ready for action
+        ::
         ^-  wund
         %+  turn
           %+  sort
@@ -580,10 +577,6 @@
           (gth life.a life.b)
         |=  [=^life =ring]
         [life ring (nol:nu:crub:crypto ring)]
-      =/  con=corn  (fall (~(get by zac.fox) our) *corn)
-      %=  fox
-        urb.ton  (~(put by urb.ton.fox) our suf)
-        zac      (~(put by zac.fox) our con)
       ==
     ::
     ++  gnaw                                            ::    gnaw:am
@@ -608,19 +601,6 @@
       |=  him=ship
       |
     ::
-    ++  hall                                            ::    hall:am
-      ^-  (list sock)                                   ::  all sockets
-      =|  sox=(list sock)                               ::  XX hideous
-      |-  ^+  sox
-      ?~  zac.fox  sox
-      =.  sox  $(zac.fox l.zac.fox)
-      =.  sox  $(zac.fox r.zac.fox)
-      |-  ^+  sox
-      ?~  wab.q.n.zac.fox  sox
-      =.  sox  $(wab.q.n.zac.fox l.wab.q.n.zac.fox)
-      =.  sox  $(wab.q.n.zac.fox r.wab.q.n.zac.fox)
-      [[p.n.zac.fox p.n.wab.q.n.zac.fox] sox]
-    ::
     ++  kick                                            ::    kick:am
       |=  hen=duct                                      ::  refresh net
       ^-  [p=(list boon) q=fort]
@@ -631,15 +611,10 @@
       =/  doz=(unit @da)  [~ (add now ~s32)]
       =.  doz
         |-  ^+  doz
-        ?~  zac.fox  doz
-        =.  doz  $(zac.fox l.zac.fox)
-        =.  doz  $(zac.fox r.zac.fox)
-        =+  yem=q.n.zac.fox
-        |-  ^+  doz
-        ?~  wab.yem  doz
-        =.  doz  $(wab.yem l.wab.yem)
-        =.  doz  $(wab.yem r.wab.yem)
-        =+  bah=q.n.wab.yem
+        ?~  wab.zac.fox  doz
+        =.  doz  $(wab.zac.fox l.wab.zac.fox)
+        =.  doz  $(wab.zac.fox r.wab.zac.fox)
+        =+  bah=q.n.wab.zac.fox
         (hunt lth doz rtn.sop.bah)
       =/  nex  (hunt lth doz tim.fox)
       ?:  =(tim.fox nex)
@@ -659,14 +634,14 @@
       |=  hen=duct                                      ::  harvest packets
       ^-  [p=(list boon) q=fort]
       =.  tim.fox  ~
-      =+  sox=hall
+      =/  neb=(list ship)  ~(tap in ~(key by wab.zac.fox))
       =|  bin=(list boon)
       |-  ^-  [p=(list boon) q=fort]
-      ?~  sox
+      ?~  neb
         =^  ban  fox  (kick hen)
         [:(weld bin p.ban next) fox]
-      =^  bun  fox  zork:zank:thaw:(ho:(um p.i.sox) q.i.sox)
-      $(sox t.sox, bin (weld p.bun bin))
+      =^  bun  fox  zork:zank:thaw:(ho:um i.neb)
+      $(neb t.neb, bin (weld p.bun bin))
     ::
     ++  wise                                            ::    wise:am
       |=  [soq=sock hen=duct cha=path val=*]            ::  send a statement
@@ -676,8 +651,8 @@
     ::
     ++  um                                              ::  per server
       |=  our=ship
-      =/  gus   (need (~(us go ton.fox) our))
-      =/  weg=corn  (fall (~(get by zac.fox) our) *corn)
+      =/  gus   (~(us go ton.fox) our)
+      =/  weg=corn  zac.fox
       =|  bin=(list boon)
       |%
       ++  ho                                            ::    ho:um:am
@@ -862,7 +837,7 @@
                       !=(her bos)
                       ?|  !?=(?(%earl %pawn) rac)
                           ?&  ?=(%earl rac)
-                              =/  fod  (~(get by hoc.saf.gus) seg)
+                              =/  fod  (~(get by hoc.ton.fox) seg)
                               ?|  ?=(~ fod)
                                   ?=(~ lew.wod.u.fod)
                   ==  ==  ==  ==
@@ -1215,7 +1190,7 @@
         :-  (flop bin)
         %_  fox
           ton  (~(su go ton.fox) gus)
-          zac  (~(put by zac.fox) our.gus weg)
+          zac  weg
         ==
       --                                                ::  --um:am
     --                                                  ::  --am
@@ -1371,7 +1346,7 @@
         ~&  [%strange-pubs tea]
         [~ +>]
       =/  her=ship  (slav %p i.t.tea)
-      =/  gus  (need (~(us go ton.fox) our))
+      =/  gus  (~(us go ton.fox) our)
       =/  diz  (myx:gus her)
       ?:  =(0 life.sih)
           ::  this should clear lew.wod.dur.diz because it means
@@ -1481,11 +1456,8 @@
             %sunk
           =*  who  p.kyz
           =*  lyf  q.kyz
-          =/  saf=sufi  (~(got by urb.ton.fox) our)
-          =/  con=corn  (~(got by zac.fox) our)
-          ::
           ?:  =(our who)
-            ?:  (lth lyf p:(head val.saf))
+            ?:  (lth lyf p:(head val.ton.fox))
               ::  replaying our old sinkage, ignore
               ::  XX review
               ::
@@ -1495,14 +1467,10 @@
             :_  fox
             [%wine [our who] ", you have sunk"]~
           ::
-          =.  saf       saf(hoc (~(del by hoc.saf) who))
-          =.  con       con(wab (~(del by wab.con) who))
-          ::
-          :-  [%wine [our who] " has sunk"]~
-          %=  fox
-            urb.ton  (~(put by urb.ton.fox) our saf)
-            zac      (~(put by zac.fox) our con)
-          ==
+          =:  hoc.ton.fox  (~(del by hoc.ton.fox) who)
+              wab.zac.fox  (~(del by wab.zac.fox) who)
+            ==
+          [[%wine [our who] " has sunk"]~ fox]
         ::
             %wake
           (~(wake am [our now fox ski]) hen)

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1277,7 +1277,7 @@
       ?>  ?=([@ @ *] q.q.bon)
       ?>  ?=(?(%a %c %e %g %j) i.q.q.bon)
       =/  =wire  [(scot %p our) (scot %p p.bon) q.q.bon]
-      :_  fox  [hen %pass wire i.q.q.bon %west [our p.bon] t.q.q.bon r.bon]~
+      :_  fox  [hen %pass wire i.q.q.bon %west p.bon t.q.q.bon r.bon]~
     ::
         %ouzo
       ::  ~&  [%send now p.bon `@p`(mug (shaf %flap q.bon))]

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -594,7 +594,7 @@
       =<  zork
       =<  zank
       ::  ~&  [%hear p.p.kec ryn `@p`(mug (shaf %flap pac))]
-      %-  ~(chew la:(ho:(um our) p.p.kec) kay ryn %none (shaf %flap pac))
+      %-  ~(chew la:(ho:um p.p.kec) kay ryn %none (shaf %flap pac))
       [q.kec r.kec]
     ::
     ++  goop                                            ::  blacklist
@@ -604,7 +604,7 @@
     ++  kick                                            ::    kick:am
       |=  hen=duct                                      ::  refresh net
       ^-  [p=(list boon) q=fort]
-      zork:(kick:(um our) hen)
+      zork:(kick:um hen)
     ::
     ++  next
       ^-  (list boon)
@@ -623,8 +623,8 @@
     ::
     ++  rack                                            ::    rack:am
       ~/  %rack
-      |=  [soq=sock cha=path cop=coop]                  ::  e2e ack
-      =+  oh=(ho:(um p.soq) q.soq)
+      |=  [her=ship cha=path cop=coop]                  ::  e2e ack
+      =/  oh  (ho:um her)
       =^  gud  oh  (cook:oh cop cha ~)
       ?.  gud  oh
       (cans:oh cha)
@@ -644,13 +644,12 @@
       $(neb t.neb, bin (weld p.bun bin))
     ::
     ++  wise                                            ::    wise:am
-      |=  [soq=sock hen=duct cha=path val=*]            ::  send a statement
+      |=  [hen=duct her=ship cha=path val=*]            ::  send a statement
       ^-  [p=(list boon) q=fort]
-      =^  ban  fox  zork:zank:(wool:(ho:(um p.soq) q.soq) hen cha val)
+      =^  ban  fox  zork:zank:(wool:(ho:um her) hen cha val)
       [(weld p.ban next) fox]
     ::
     ++  um                                              ::  per server
-      |=  our=ship
       =/  gus   (~(us go ton.fox) our)
       =/  weg=corn  zac.fox
       =|  bin=(list boon)
@@ -1385,10 +1384,10 @@
           ?:  ?=([%ye ~] tea)
             [~ fox]
           ?>  ?=([@ @ @ *] tea)
-          =+  soq=[(slav %p i.tea) (slav %p i.t.tea)]
-          =+  pax=t.t.tea
+          =/  her  (slav %p i.t.tea)
+          =*  pax  t.t.tea
           =<  zork  =<  zank
-          %^  ~(rack am [our now fox ski])  soq  pax
+          %^  ~(rack am [our now fox ski])  her  pax
           ::  ~&  [%knap-ack ?-(+<.sih %mean `p.+.sih, %nice ~)]
           ?-(+<.sih %mean `p.+.sih, %nice ~)
         ==
@@ -1476,7 +1475,7 @@
           (~(wake am [our now fox ski]) hen)
         ::
             %want
-          (~(wise am [our now fox ski]) p.kyz hen q.kyz r.kyz)
+          (~(wise am [our now fox ski]) hen q.p.kyz q.kyz r.kyz)
         ==
     =>  %_(. fox q.fuy)
     =|  out=(list move)
@@ -1492,12 +1491,12 @@
     ^-  (unit (unit cage))
     ?:  ?=([?(%show %tell) *] tyl)
       ?^  t.tyl  [~ ~]
-      =+  zet=zest:(ho:(~(um am [our now fox ski]) our) his)
+      =+  zet=zest:(ho:~(um am [our now fox ski]) his)
       ``[%noun ?:(=(%show i.tyl) !>(>zet<) !>(zet))]
     ?:  ?=([%pals ~] tyl)
       ?.  =(our his)
         ~
-      ``[%noun !>(pals:(~(um am [our now fox ski]) our))]
+      ``[%noun !>(pals:~(um am [our now fox ski]))]
     ~
   ::
   ++  wegh

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1284,7 +1284,7 @@
         %beer
       =/  wir=wire
         /our/(scot %p p.p.bon)/her/(scot %p q.p.bon)
-      :_  fox  [hen [%pass wir %j %pubs p.p.bon q.p.bon]]~
+      :_  fox  [hen [%pass wir %j %pubs q.p.bon]]~
     ::
         %bock
       :_  fox  [hen %give %turf tuf.fox]~
@@ -1323,10 +1323,9 @@
       [gad.fox %pass /ames %b %rest u.tim.fox]~
     ::
         %raki
-      =*  our  p.p.bon
       =*  her  q.p.bon
       =/  moz=(list move)
-        [hen [%pass / %j %meet our her life=q.bon pass=r.bon]]~
+        [hen [%pass / %j %meet her life=q.bon pass=r.bon]]~
       ::  poke :dns with an indirect binding if her is a planet we're spnsoring
       ::
       =?  moz  ?&  ?=(%duke (clan:title her))
@@ -1341,7 +1340,7 @@
         %sake
       =/  wir=wire
         /our/(scot %p p.bon)
-      :_  fox  [hen [%pass wir %j %vein p.bon]]~
+      :_  fox  [hen [%pass wir %j %vein ~]]~
     ::
         %wine
       :_  fox

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -716,7 +716,7 @@
               bin
             :_  bin
             :^    %milk
-                [our her]
+                her
               `soap`[[lyf:sen:gus clon:diz] cha did.rum]
             u.s.u.cun
           ==
@@ -828,7 +828,7 @@
               ::    XX update state so we only ask once?
               ::
               =?  +>.$  &(=(~ lew.wod.dur.diz) =(her bos))
-                (emit %beer our her)
+                (emit %beer her)
               ::  request keys and drop packet if :her is (or is a moon of)
               ::  an unfamilar on-chain ship (and not our sponsor)
               ::
@@ -840,22 +840,22 @@
                               ?|  ?=(~ fod)
                                   ?=(~ lew.wod.u.fod)
                   ==  ==  ==  ==
-                (emit %beer our ?:(?=(%earl rac) seg her))
+                (emit %beer ?:(?=(%earl rac) seg her))
               =/  oub  bust:puz
               =/  neg  =(~ yed.caq.dur.diz)
               =.  +>.$  east
               =/  eng  =(~ yed.caq.dur.diz)
               =/  bou  bust:puz
               =?  +>.$  &(oub !bou)
-                (emit [%wine [our her] " is ok"])
+                (emit [%wine her " is ok"])
               ::  the presence of a symmetric key indicates neighboring
               ::  XX use deed instead?
               ::
               =?  +>.$  &(neg !eng)
                 %-  emir  :~
-                  [%wine [our her] " is your neighbor"]
+                  [%wine her " is your neighbor"]
                   ?>  ?=(^ lew.wod.dur.diz)
-                  [%raki [our her] [life pass]:u.lew.wod.dur.diz]
+                  [%raki her [life pass]:u.lew.wod.dur.diz]
                 ==
               +>.$
             ::
@@ -1050,7 +1050,7 @@
           =+  bou=bust:puz
           =.  bin
               ?.  &(bou !oub)  bin
-              :_(bin [%wine [our her] " not responding still trying"])
+              :_(bin [%wine her " not responding still trying"])
           =.  diz  ?:((boom:puz now) (pode:diz now) diz)
           (busk xong yem)
         ::
@@ -1066,7 +1066,7 @@
             %=    +>.$
                 bin
               :_  bin
-              `boon`[%cake [our her] [[lyf:sen:gus clon:diz] u.p.yoh] cop u.hud]
+              `boon`[%cake her [[lyf:sen:gus clon:diz] u.p.yoh] cop u.hud]
             ==
           (busk xong q.yoh)
         ::
@@ -1090,7 +1090,7 @@
           ::
           ::    XX update state so we only ask once?
           ::
-          =?  bin  =(~ lew.wod.dur.diz)  :_(bin [%beer our her])
+          =?  bin  =(~ lew.wod.dur.diz)  :_(bin [%beer her])
           =.  ryl.bah
               %+  ~(put by ryl.bah)  cha
               %=  rol
@@ -1253,8 +1253,8 @@
     ^-  [(list move) fort]
     ?-    -.bon
         %beer
-      =/  =wire  /pubs/(scot %p q.p.bon)
-      :_  fox  [hen [%pass wire %j %pubs q.p.bon]]~
+      =/  =wire  /pubs/(scot %p p.bon)
+      :_  fox  [hen [%pass wire %j %pubs p.bon]]~
     ::
         %bock
       :_  fox  [hen %give %turf tuf.fox]~
@@ -1265,7 +1265,7 @@
         %cake
       ::  ~?  ?=(^ r.bon)  [%cake-woot-bad hen r.bon]
       :_  fox
-      :~  [s.bon %give %woot q.p.bon r.bon]
+      :~  [s.bon %give %woot p.bon r.bon]
       ==
     ::
         %mead
@@ -1276,8 +1276,8 @@
       ::  ~&  [%milk p.bon q.bon]
       ?>  ?=([@ @ *] q.q.bon)
       ?>  ?=(?(%a %c %e %g %j) i.q.q.bon)
-      =+  pax=[(scot %p p.p.bon) (scot %p q.p.bon) q.q.bon]
-      :_  fox  [hen %pass pax i.q.q.bon %west p.bon t.q.q.bon r.bon]~
+      =/  =wire  [(scot %p our) (scot %p p.bon) q.q.bon]
+      :_  fox  [hen %pass wire i.q.q.bon %west [our p.bon] t.q.q.bon r.bon]~
     ::
         %ouzo
       ::  ~&  [%send now p.bon `@p`(mug (shaf %flap q.bon))]
@@ -1293,7 +1293,7 @@
       [gad.fox %pass /ames %b %rest u.tim.fox]~
     ::
         %raki
-      =*  her  q.p.bon
+      =*  her  p.bon
       =/  moz=(list move)
         [hen [%pass / %j %meet her life=q.bon pass=r.bon]]~
       ::  poke :dns with an indirect binding if her is a planet we're spnsoring
@@ -1308,13 +1308,12 @@
       [moz fox]
     ::
         %sake
-      =/  wir=wire
-        /our/(scot %p p.bon)
-      :_  fox  [hen [%pass wir %j %vein ~]]~
+      =/  =wire  /our/(scot %p our)
+      :_  fox  [hen [%pass wire %j %vein ~]]~
     ::
         %wine
       :_  fox
-      =+  fom=~(rend co %$ %p q.p.bon)
+      =+  fom=~(rend co %$ %p p.bon)
       :~  :-  hen
           :+  %slip  %d
           :+  %flog  %text
@@ -1430,7 +1429,7 @@
           (~(gnaw am [our now fox ski]) %dead p.kyz q.kyz)
         ::
             %init
-          :_  fox  [[%sake p.kyz] [%brew ~] ~]
+          :_  fox  [[%sake ~] [%brew ~] ~]
         ::
           ::  XX this is unused, but they only way to set
           ::  entropy for symmetric keys. Review.
@@ -1464,12 +1463,12 @@
             ::  XX include some helpful instructions here
             ::
             :_  fox
-            [%wine [our who] ", you have sunk"]~
+            [%wine who ", you have sunk"]~
           ::
           =:  hoc.ton.fox  (~(del by hoc.ton.fox) who)
               wab.zac.fox  (~(del by wab.zac.fox) who)
             ==
-          [[%wine [our who] " has sunk"]~ fox]
+          [[%wine who " has sunk"]~ fox]
         ::
             %wake
           (~(wake am [our now fox ski]) hen)

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1474,7 +1474,7 @@
           (~(wake am [our now fox ski]) hen)
         ::
             %want
-          (~(wise am [our now fox ski]) hen q.p.kyz q.kyz r.kyz)
+          (~(wise am [our now fox ski]) hen p.kyz q.kyz r.kyz)
         ==
     =>  %_(. fox q.fuy)
     =|  out=(list move)

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -515,23 +515,23 @@
   |%
   ++  am                                                ::    am
     ~%  %ames-am  ..is  ~
-    |_  [now=@da fox=fort ski=sley]                     ::  protocol engine
+    |_  [our=ship now=@da fox=fort ski=sley]            ::  protocol engine
     ::  +deed: scry for our deed
     ::
     ++  deed
       ~/  %deed
-      |=  [our=ship now=@da lyf=life]
+      |=  [who=ship lyf=life]
       ;;  ^deed
       %-  need  %-  need
       %-  (sloy-light ski)
       =/  pur=spur
-        /(scot %ud lyf)/(scot %p our)
+        /(scot %ud lyf)/(scot %p who)
       [[151 %noun] %j our %deed da+now pur]
     ::  +sein: scry for sponsor
     ::
     ++  sein
       ~/  %sein
-      |=  [our=ship now=@da who=ship]
+      |=  who=ship
       ;;  ship
       %-  need  %-  need
       %-  (sloy-light ski)
@@ -540,7 +540,7 @@
     ::
     ++  saxo
       ~/  %saxo
-      |=  [our=ship now=@da who=ship]
+      |=  who=ship
       ;;  (list ship)
       %-  need  %-  need
       %-  (sloy-light ski)
@@ -548,7 +548,7 @@
     ::
     ++  vein                                            ::    vein:am
       ~/  %vein
-      |=  [our=ship =life vein=(map life ring)]         ::  new private keys
+      |=  [=life vein=(map life ring)]                  ::  new private keys
       ^-  fort
       ::
       ?.  ?&  (~(has by vein) life)
@@ -568,7 +568,7 @@
       =.  seh.suf  ~
       ::  save our deed (for comet/moon communication)
       ::
-      =.  law.suf  (deed our now life)
+      =.  law.suf  (deed our life)
       ::  save our secrets, ready for action
       ::
       =.  val.suf
@@ -592,15 +592,16 @@
       ^-  [p=(list boon) q=fort]
       ?.  =(protocol-version (end 0 3 pac))  [~ fox]
       =+  kec=(bite pac)
-      ?:  (goop p.p.kec)  [~ fox]
-      ?.  (~(has by urb.ton.fox) q.p.kec)
+      ?:  (goop p.p.kec)
+        [~ fox]
+      ?.  =(our q.p.kec)
         [~ fox]
       =;  zap=[p=(list boon) q=fort]
         [(weld p.zap next) q.zap]
       =<  zork
       =<  zank
       ::  ~&  [%hear p.p.kec ryn `@p`(mug (shaf %flap pac))]
-      %-  ~(chew la:(ho:(um q.p.kec) p.p.kec) kay ryn %none (shaf %flap pac))
+      %-  ~(chew la:(ho:(um our) p.p.kec) kay ryn %none (shaf %flap pac))
       [q.kec r.kec]
     ::
     ++  goop                                            ::  blacklist
@@ -622,12 +623,8 @@
     ::
     ++  kick                                            ::    kick:am
       |=  hen=duct                                      ::  refresh net
-      =+  aks=(turn ~(tap by urb.ton.fox) |=([p=ship q=sufi] p))
-      |-  ^-  [p=(list boon) q=fort]
-      ?~  aks  [~ fox]
-      =^  buz  fox  zork:(kick:(um i.aks) hen)
-      =^  biz  fox  $(aks t.aks)
-      [(weld p.buz p.biz) fox]
+      ^-  [p=(list boon) q=fort]
+      zork:(kick:(um our) hen)
     ::
     ++  next
       ^-  (list boon)
@@ -768,7 +765,7 @@
             ?^  ram  raz.bah
             %+  ~(put by raz.bah)  cha
             rum(dod &, bum ?~(cop bum.rum (~(put by bum.rum) did.rum u.cop)))
-          =/  seg  (sein our now her)
+          =/  seg  (sein her)
           =^  roc  diz  (zuul:diz now seg [%back cop dam ~s0])
           (busk(diz (wast:diz ryn)) xong roc)
         ::  XX move this logic into %zuse, namespaced under %jael?
@@ -814,7 +811,7 @@
                 ::  our sponsor
                 ::
                 ?&  !?=(%czar (clan:title our))
-                    =(her (sein our now our))
+                    =(her (sein our))
                 ==
               ==
           diz(lew.wod.dur law)
@@ -844,10 +841,10 @@
               ^+  +>.$
               ::  bos: our sponsor
               ::
-              =/  bos  (sein our now our)
+              =/  bos  (sein our)
               ::  seg:  her sponsor
               ::
-              =/  seg  (sein our now her)
+              =/  seg  (sein her)
               ::  rac:  her rank
               ::
               =/  rac  (clan:title her)
@@ -950,7 +947,7 @@
             ^+  .                                       ::  send new ack
             ::  ~&  [%back kay dam]
             =*  cop  `coop`?:(=(%good kay) ~ ``[%dead-packet ~])
-            =/  seg  (sein our now her)
+            =/  seg  (sein her)
             =^  pax  diz  (zuul:diz now seg [%back cop dam ~s0])
             +>(+> (busk(diz (wast:diz ryn)) xong pax))
           ::
@@ -1103,7 +1100,7 @@
           |=  [gom=soup ham=meal]
           ::  ~&  [%wind her gom]
           ^+  +>
-          =/  seg  (sein our now her)
+          =/  seg  (sein her)
           =^  wyv  diz  (zuul:diz now seg ham)
           =^  feh  puz  (whap:puz now gom wyv)
           (busk xong feh)
@@ -1179,8 +1176,8 @@
         ::
         ++  xong                                        ::    xong:ho:um:am
           ^-  (list ship)                               ::  route unto
-          =/  fro  (saxo our now our)
-          =/  too  (saxo our now her)
+          =/  fro  (saxo our)
+          =/  too  (saxo her)
           =+  ^=  oot  ^-  (list ship)
               =|  oot=(list ship)
               |-  ^+  oot
@@ -1194,7 +1191,7 @@
       ++  kick                                          ::    kick:um:am
         |=  hen=duct                                    ::  test connection
         ^+  +>
-        =/  hoy  (tail (saxo our now our))
+        =/  hoy  (tail (saxo our))
         |-  ^+  +>.^$
         ?~  hoy
           +>.^$
@@ -1263,7 +1260,7 @@
       ?.  ?=([$$ %da @] lot)
         ~
       ?.  =(now q.p.lot)  ~
-      (temp p.why u.hun [syd t.tyl])
+      (temp u.hun [syd t.tyl])
     ::
     ++  stay  fox
     ++  take                                            ::  accept response
@@ -1282,9 +1279,8 @@
     ^-  [(list move) fort]
     ?-    -.bon
         %beer
-      =/  wir=wire
-        /our/(scot %p p.p.bon)/her/(scot %p q.p.bon)
-      :_  fox  [hen [%pass wir %j %pubs q.p.bon]]~
+      =/  =wire  /pubs/(scot %p q.p.bon)
+      :_  fox  [hen [%pass wire %j %pubs q.p.bon]]~
     ::
         %bock
       :_  fox  [hen %give %turf tuf.fox]~
@@ -1330,7 +1326,7 @@
       ::
       =?  moz  ?&  ?=(%duke (clan:title her))
                    ?=(%king (clan:title our))
-                   =(our (~(sein am [now fox ski]) our now her))
+                   =(our (~(sein am [our now fox ski]) her))
                ==
         =/  cmd  [%meet her]
         =/  pok  [%dns %poke `cage`[%dns-command !>(cmd)]]
@@ -1371,11 +1367,10 @@
       [~ +>.$]
     ::
         %pubs
-      ?.  ?=([%our @ %her @ ~] tea)
+      ?.  ?=([%pubs @ ~] tea)
         ~&  [%strange-pubs tea]
         [~ +>]
-      =/  our=ship  (slav %p i.t.tea)
-      =/  her=ship  (slav %p i.t.t.t.tea)
+      =/  her=ship  (slav %p i.t.tea)
       =/  gus  (need (~(us go ton.fox) our))
       =/  diz  (myx:gus her)
       ?:  =(0 life.sih)
@@ -1398,8 +1393,7 @@
       ?.  ?=([%our @ ~] tea)
         ~&  [%strange-vein tea]
         [~ +>]
-      =/  our=ship  (slav %p i.t.tea)
-      =.  fox  (~(vein am [now fox ski]) our life.sih vein.sih)
+      =.  fox  (~(vein am [our now fox ski]) life.sih vein.sih)
       [~ +>.$]
     ::
         %woot  [~ +>]
@@ -1410,7 +1404,7 @@
         ?-  +<.sih
         ::
             %wake
-          (~(wake am [now fox ski]) hen)
+          (~(wake am [our now fox ski]) hen)
         ::
             ?(%mean %nice)                              ::  XX obsolete
           ?:  ?=([%ye ~] tea)
@@ -1419,7 +1413,7 @@
           =+  soq=[(slav %p i.tea) (slav %p i.t.tea)]
           =+  pax=t.t.tea
           =<  zork  =<  zank
-          %^  ~(rack am [now fox ski])  soq  pax
+          %^  ~(rack am [our now fox ski])  soq  pax
           ::  ~&  [%knap-ack ?-(+<.sih %mean `p.+.sih, %nice ~)]
           ?-(+<.sih %mean `p.+.sih, %nice ~)
         ==
@@ -1453,13 +1447,13 @@
           [%bock ~]~
         ::
             %hear
-          (~(gnaw am [now fox ski]) %good p.kyz q.kyz)
+          (~(gnaw am [our now fox ski]) %good p.kyz q.kyz)
         ::
             %halo
-          (~(gnaw am [now fox ski]) %dead p.kyz q.kyz)
+          (~(gnaw am [our now fox ski]) %dead p.kyz q.kyz)
         ::
             %hole
-          (~(gnaw am [now fox ski]) %dead p.kyz q.kyz)
+          (~(gnaw am [our now fox ski]) %dead p.kyz q.kyz)
         ::
             %init
           :_  fox  [[%sake p.kyz] [%brew ~] ~]
@@ -1471,10 +1465,10 @@
           [~ fox(any.ton (shax (mix any.ton.fox p.kyz)))]
         ::
             %kick
-          =^  ban  fox  (~(kick am [now fox(hop p.kyz) ski]) hen)
+          =^  ban  fox  (~(kick am [our now fox(hop p.kyz) ski]) hen)
           ::  +next:am called here because +wake calls +kick in a loop
           ::
-          [(weld p.ban ~(next am [now fox ski])) fox]
+          [(weld p.ban ~(next am [our now fox ski])) fox]
         ::
             %nuke
           :-  ~
@@ -1485,11 +1479,6 @@
           fox(bad (~(put in bad.fox) p.kyz))
         ::
             %sunk
-          ::  XX single-home properly
-          ::
-          =/  our=ship
-            =/  key  ~(key by urb.ton.fox)
-            ?>(?=([@ ~ ~] key) n.key)
           =*  who  p.kyz
           =*  lyf  q.kyz
           =/  saf=sufi  (~(got by urb.ton.fox) our)
@@ -1516,10 +1505,10 @@
           ==
         ::
             %wake
-          (~(wake am [now fox ski]) hen)
+          (~(wake am [our now fox ski]) hen)
         ::
             %want
-          (~(wise am [now fox ski]) p.kyz hen q.kyz r.kyz)
+          (~(wise am [our now fox ski]) p.kyz hen q.kyz r.kyz)
         ==
     =>  %_(. fox q.fuy)
     =|  out=(list move)
@@ -1531,18 +1520,16 @@
   ::
   ++  temp
     ~/  %temp
-    |=  [our=ship his=ship tyl=path]
+    |=  [his=ship tyl=path]
     ^-  (unit (unit cage))
     ?:  ?=([?(%show %tell) *] tyl)
       ?^  t.tyl  [~ ~]
-      =+  gys=(~(us go ton.fox) our)
-      ?~  gys  [~ ~]
-      =+  zet=zest:(ho:(~(um am [now fox ski]) our) his)
+      =+  zet=zest:(ho:(~(um am [our now fox ski]) our) his)
       ``[%noun ?:(=(%show i.tyl) !>(>zet<) !>(zet))]
     ?:  ?=([%pals ~] tyl)
       ?.  =(our his)
         ~
-      ``[%noun !>(pals:(~(um am [now fox ski]) our))]
+      ``[%noun !>(pals:(~(um am [our now fox ski]) our))]
     ~
   ::
   ++  wegh

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -334,7 +334,7 @@
   ==  ==                                                ::
       $:  $c                                            ::  to %clay
   $%  {$info q/@tas r/nori}                             ::  internal edit
-      {$merg p/@p q/@tas r/@p s/@tas t/case u/germ}     ::  merge desks
+      {$merg p/@tas q/@p r/@tas s/case t/germ:clay}     ::  merge desks
       {$warp p/sock q/riff}                             ::
       {$werp p/ship q/sock r/riff}                      ::
   ==  ==                                                ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -342,7 +342,7 @@
   $%  {$flog p/{$crud p/@tas q/(list tank)}}            ::  to %dill
   ==  ==                                                ::
       $:  $f                                            ::
-  $%  [%build our=@p live=? schematic=schematic:ford]      ::
+  $%  [%build live=? schematic=schematic:ford]          ::
   ==  ==
       $:  $b                                            ::
   $%  {$wait p/@da}                                     ::
@@ -620,7 +620,7 @@
       (emit hen %give %writ ~ [p.mun q.mun syd] r.mun p.dat)
     %-  emit
     :*  hen  %pass  [%blab p.mun (scot q.mun) syd r.mun]
-        %f  %build  our  live=%.n  %pin
+        %f  %build  live=%.n  %pin
         (case-to-date q.mun)
         (lobe-to-schematic:ze [her syd] r.mun p.dat)
     ==
@@ -836,7 +836,7 @@
     %-  emit
     ^-  move
     :*  hen  %pass  [%ergoing (scot %p her) syd ~]  %f
-        %build  our  live=%.n  %list
+        %build  live=%.n  %list
         ^-  (list schematic:ford)
         %+  turn  `(list path)`mus
         |=  a/path
@@ -1207,7 +1207,7 @@
       ^-  (list move)
       :~  :*  hen  %pass
               [%inserting (scot %p her) syd (scot %da wen) ~]
-              %f  %build  our  live=%.n  %pin  wen  %list
+              %f  %build  live=%.n  %pin  wen  %list
               ^-  (list schematic:ford)
               %+  turn  ins.nuz
               |=  {pax/path mis/miso}
@@ -1218,7 +1218,7 @@
           ==
           :*  hen  %pass
               [%diffing (scot %p her) syd (scot %da wen) ~]
-              %f  %build  our  live=%.n  %pin  wen  %list
+              %f  %build  live=%.n  %pin  wen  %list
               ^-  (list schematic:ford)
               %+  turn  dif.nuz
               |=  {pax/path mis/miso}
@@ -1230,7 +1230,7 @@
           ==
           :*  hen  %pass
               [%castifying (scot %p her) syd (scot %da wen) ~]
-              %f  %build  our  live=%.n  %pin  wen  %list
+              %f  %build  live=%.n  %pin  wen  %list
               ::~  [her syd %da wen]  %tabl
               ^-  (list schematic:ford)
               %+  turn  mut.nuz
@@ -1401,7 +1401,7 @@
     %-  emit
     :*  hen  %pass
         [%mutating (scot %p her) syd (scot %da wen) ~]
-        %f  %build  our  live=%.n  %pin  wen  %list
+        %f  %build  live=%.n  %pin  wen  %list
         ^-  (list schematic:ford)
         %+  turn  cat
         |=  {pax/path cay/cage}
@@ -1498,7 +1498,7 @@
     ^+  +>
     %-  emit
     :*  hen  %pass  [%patching (scot %p her) syd ~]  %f
-        %build  our  live=%.n  %list
+        %build  live=%.n  %list
         ^-  (list schematic:ford)
         %+  turn  (sort ~(tap by hat) sort-by-head)
         |=  {a/path b/lobe}
@@ -1585,7 +1585,7 @@
     ::  =-  ~&  %formed-ergo  -
     %-  emit(dok ~)
     :*  hen  %pass  [%ergoing (scot %p her) syd ~]  %f
-        %build  our  live=%.n  %list
+        %build  live=%.n  %list
         ^-  (list schematic:ford)
         %+  turn  ~(tap in sum)
         |=  a/path
@@ -1759,7 +1759,7 @@
     %-  emit
     :*  hen  %pass
         [%foreign-x (scot %p our) (scot %p her) syd car (scot cas) pax]
-        %f  %build  our  live=%.n  %pin
+        %f  %build  live=%.n  %pin
         (case-to-date cas)
         (vale-page [her syd] peg)
     ==
@@ -1868,7 +1868,7 @@
     %-  emit
     :*  hen  %pass
         [%foreign-plops (scot %p our) (scot %p her) syd lum ~]
-        %f  %build  our  live=%.n  %pin  (case-to-date cas)
+        %f  %build  live=%.n  %pin  (case-to-date cas)
         %list
         ^-  (list schematic:ford)
         %+  turn  ~(tap in pop)
@@ -3171,7 +3171,7 @@
         :*  hen  %pass
             =+  (cat 3 %diff- nam)
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali - ~]
-            %f  %build  p.bob  live=%.n  %pin  (case-to-date r.oth)  %list
+            %f  %build  live=%.n  %pin  (case-to-date r.oth)  %list
             ^-  (list schematic:ford)
             %+  murn  ~(tap by q.bas.dat)
             |=  {pax/path lob/lobe}
@@ -3300,7 +3300,7 @@
           %-  emit(wat.dat %merge)
           :*  hen  %pass
               [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %merge ~]
-              %f  %build  p.bob  live=%.n  %list
+              %f  %build  live=%.n  %list
               ^-  (list schematic:ford)
               %+  turn  ~(tap by (~(int by can.dal.dat) can.dob.dat))
               |=  {pax/path *}
@@ -3340,7 +3340,7 @@
         %-  emit(wat.dat %build)
         :*  hen  %pass
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %build ~]
-            %f  %build  p.bob  live=%.n  %list
+            %f  %build  live=%.n  %list
             ^-  (list schematic:ford)
             %+  murn  ~(tap by bof.dat)
             |=  {pax/path cay/(unit cage)}
@@ -3486,7 +3486,7 @@
         %-  emit(wat.dat %checkout)
         :*  hen  %pass
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %checkout ~]
-            %f  %build  p.bob  live=%.n  %pin  (case-to-date r.val)  %list
+            %f  %build  live=%.n  %pin  (case-to-date r.val)  %list
 ::            ~  val  %tabl
             ^-  (list schematic:ford)
             %+  murn  ~(tap by q.new.dat)
@@ -3544,7 +3544,7 @@
         %-  emit(wat.dat %ergo)
         :*  hen  %pass
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %ergo ~]
-            %f  %build  p.bob  live=%.n  %pin  (case-to-date r.val)  %list
+            %f  %build  live=%.n  %pin  (case-to-date r.val)  %list
             ^-  (list schematic:ford)
             %+  turn  ~(tap in sum)
             |=  a/path

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -333,7 +333,7 @@
   $%  {$want p/ship q/path r/*}                         ::
   ==  ==                                                ::
       $:  $c                                            ::  to %clay
-  $%  {$info p/@p q/@tas r/nori}                        ::  internal edit
+  $%  {$info q/@tas r/nori}                             ::  internal edit
       {$merg p/@p q/@tas r/@p s/@tas t/case u/germ}     ::  merge desks
       {$warp p/sock q/riff}                             ::
       {$werp p/ship q/sock r/riff}                      ::
@@ -3807,12 +3807,12 @@
               ?=($mime p.p.b)
               ?=({$hoon ~} (slag (dec (lent a)) a))
           ==
-      :~  [hen %pass /one %c %info our q.bem %& one]
-          [hen %pass /two %c %info our q.bem %& two]
+      :~  [hen %pass /one %c %info q.bem %& one]
+          [hen %pass /two %c %info q.bem %& two]
       ==
     =+  yak=(~(got by hut.ran.ruf) (~(got by hit.dom.u.dos) let.dom.u.dos))
     =+  cos=(mode-to-soba q.yak (flop s.bem) all.req fis.req)
-    [hen %pass /both %c %info our q.bem %& cos]~
+    [hen %pass /both %c %info q.bem %& cos]~
   ::
       $merg                                               ::  direct state up
     ?:  =(%$ des.req)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -330,7 +330,7 @@
 ++  move  {p/duct q/(wind note gift:able)}              ::  local move
 ++  note                                                ::  out request $->
   $%  $:  $a                                            ::  to %ames
-  $%  {$want p/sock q/path r/*}                         ::
+  $%  {$want p/ship q/path r/*}                         ::
   ==  ==                                                ::
       $:  $c                                            ::  to %clay
   $%  {$info p/@p q/@tas r/nori}                        ::  internal edit
@@ -700,7 +700,7 @@
   ::
   ++  send-over-ames
     |=  {a/duct b/path c/ship d/{p/@ud q/riff}}
-    (emit a %pass b %a %want [our c] [%c %question p.q.d (scot %ud p.d) ~] q.d)
+    (emit a %pass b %a %want c [%c %question p.q.d (scot %ud p.d) ~] q.d)
   ::
   ::  Create a request that cannot be filled immediately.
   ::
@@ -4226,7 +4226,7 @@
     =+  him=(slav %p i.t.tea)
     :_  ..^$
     :~  :*  hen  %pass  /writ-want  %a
-            %want  [our him]  [%c %answer t.t.tea]
+            %want  him  [%c %answer t.t.tea]
             (bind p.+.q.hin rant-to-rand)
         ==
     ==

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -335,8 +335,8 @@
       $:  $c                                            ::  to %clay
   $%  {$info q/@tas r/nori}                             ::  internal edit
       {$merg p/@tas q/@p r/@tas s/case t/germ:clay}     ::  merge desks
-      {$warp p/sock q/riff}                             ::
-      {$werp p/ship q/sock r/riff}                      ::
+      {$warp p/ship q/riff}                             ::
+      {$werp p/ship q/ship r/riff}                      ::
   ==  ==                                                ::
       $:  $d                                            ::
   $%  {$flog p/{$crud p/@tas q/(list tank)}}            ::  to %dill
@@ -2923,8 +2923,7 @@
         %-  emit(wat.dat %ali)
         :*  hen  %pass
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali %ali ~]
-            %c  %warp  [p.bob p.ali]  q.ali
-            `[%sing %v cas.dat /]
+            [%c %warp p.ali q.ali `[%sing %v cas.dat /]]
         ==
       ::
       ::  Parse the state of ali's desk, and get the most recent commit.
@@ -3880,16 +3879,19 @@
       $sunk  [~ ..^$]
   ::
       ?($warp $werp)
+    ::  capture whether this read is on behalf of another ship
+    ::  for permissions enforcement
+    ::
     =^  for  req
       ?:  ?=($warp -.req)
         [~ req]
-      :_  [%warp wer.req rif.req]
-      ?:  =(who.req p.wer.req)  ~
-      `who.req
+      :-  ?:(=(our who.req) ~ `who.req)
+      [%warp wer.req rif.req]
+    ::
     ?>  ?=($warp -.req)
     =*  rif  rif.req
     =^  mos  ruf
-      =/  den  ((de our now hen ruf) q.wer.req p.rif)
+      =/  den  ((de our now hen ruf) wer.req p.rif)
       =<  abet
       ?~  q.rif
         cancel-request:den
@@ -3907,10 +3909,9 @@
       =+  ryf=((hard riff) res.req)
       :_  ..^$
       :~  [hen %give %mack ~]
-          :-  hen
-          :^  %pass  [(scot %p our) (scot %p wer) t.pax]
-            %c
-          [%werp wer [our our] ryf]
+          =/  =wire
+            [(scot %p our) (scot %p wer) t.pax]
+          [hen %pass wire %c %werp wer our ryf]
       ==
     ?>  ?=({$answer @ @ ~} pax)
     =+  syd=(slav %tas i.t.pax)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3925,15 +3925,15 @@
       :_  ..^$
       :~  [hen %give %mack ~]
           :-  hen
-          :^  %pass  [(scot %p p.wer) (scot %p q.wer) t.pax]
+          :^  %pass  [(scot %p our) (scot %p wer) t.pax]
             %c
-          [%werp q.wer [p.wer p.wer] ryf]
+          [%werp wer [our our] ryf]
       ==
     ?>  ?=({$answer @ @ ~} pax)
     =+  syd=(slav %tas i.t.pax)
     =+  inx=(slav %ud i.t.t.pax)
     =^  mos  ruf
-      =+  den=((de now hen ruf) wer syd)
+      =+  den=((de now hen ruf) [our wer] syd)
       abet:(take-foreign-update:den inx ((hard (unit rand)) res.req))
     [[[hen %give %mack ~] mos] ..^$]
   ::

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -42,7 +42,7 @@
   ==                                                    ::
 ++  note-clay                                           ::
   $%  {$merg p/@tas q/@p r/@tas s/case t/germ:clay}     ::  merge desks
-      {$warp p/sock q/riff:clay}                        ::  wait for clay hack
+      {$warp p/ship q/riff:clay}                        ::  wait for clay hack
       {$wegh $~}                                        ::
       {$perm p/desk q/path r/rite:clay}                 ::  change permissions
   ==                                                    ::
@@ -319,12 +319,7 @@
             tem  `(turn gyl |=(a/gill [%yow a]))
             moz
           :_  moz
-          :*  hen
-              %pass
-              /
-              %c
-              [%warp [our our] %base `[%sing %y [%ud 1] /]]
-          ==
+          [hen %pass / %c %warp our %base `[%sing %y [%ud 1] /]]
         ==
       ::
       ++  send                                          ::  send action

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -44,7 +44,7 @@
   $%  {$merg p/@tas q/@p r/@tas s/case t/germ:clay}     ::  merge desks
       {$warp p/sock q/riff:clay}                        ::  wait for clay hack
       {$wegh $~}                                        ::
-      {$perm p/ship q/desk r/path s/rite:clay}          ::  change permissions
+      {$perm p/desk q/path r/rite:clay}                 ::  change permissions
   ==                                                    ::
 ++  note-dill                                           ::  note to self, odd
   $%  {$crud p/@tas q/(list tank)}                      ::
@@ -347,9 +347,7 @@
         %_    +>.$
             moz
           :_  moz
-          :*  hen  %pass  /show  %c  %perm  our
-              des  /  r+`[%black ~]
-          ==
+          [hen %pass /show %c %perm des / r+`[%black ~]]
         ==
       ::
       ++  sync

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -10,7 +10,6 @@
 ++  all-axle  ?(axle)                                   ::
 ++  axle                                                ::
   $:  $0                                                ::
-      ore/(unit ship)                                   ::  identity once set
       hey/(unit duct)                                   ::  default duct
       dug/(map duct axon)                               ::  conversations
       $=  hef                                           ::  other weights
@@ -139,9 +138,7 @@
 =>  |%
     ++  as                                              ::  per cause
       =|  moz/(list move)
-      |_  $:  {hen/duct our/ship}
-              axon
-          ==
+      |_  [hen=duct axon]
       ++  abet                                          ::  resolve
         ^-  {(list move) axle}
         [(flop moz) all(dug (~(put by dug.all) hen +<+))]
@@ -440,7 +437,7 @@
         ^-  mass
         :-  %dill
         :-  %|
-        :~  all+[%& [ore hey dug]:all]
+        :~  all+[%& [hey dug]:all]
         ==
       ::
       ++  wegt
@@ -472,10 +469,9 @@
     ++  ax                                              ::  make ++as
       |=  hen/duct
       ^-  (unit _as)
-      ?~  ore.all  ~
       =/  nux  (~(get by dug.all) hen)
       ?~  nux  ~
-      (some ~(. as [hen u.ore.all] u.nux))
+      (some ~(. as hen u.nux))
     --
 |%                                                      ::  poke+peek pattern
 ++  call                                                ::  handle request
@@ -502,17 +498,14 @@
   ::
   ?:  ?=(%init -.task)
     ?>  =(~ dug.all)
-    ?>  =(~ ore.all)
-    =.  ore.all  `p.task
     ::  configure new terminal, setup :hood and %clay
     ::
-    =*  our  p.task
     =*  duc  (need hey.all)
     =/  app  %hood
     =/  see  (tuba "<awaiting {(trip app)}, this may take a minute>")
     =/  zon=axon  [app input=[~ ~] width=80 cursor=0 see]
     ::
-    =^  moz  all  abet:(~(into as [duc our] zon) ~)
+    =^  moz  all  abet:(~(into as duc zon) ~)
     [moz ..^$]
   ::  %flog tasks are unwrapped and sent back to us on our default duct
   ::
@@ -531,8 +524,8 @@
   ::
   =/  nus  (ax hen)
   ?~  nus
-    ::  we got this on an unknown duct or
-    ::  before %boot or %init (or one of those crashed)
+    ::  :hen is an unrecognized duct
+    ::  could be before %boot (or %boot failed)
     ::
     ~&  [%dill-call-no-flow hen -.task]
     =/  tan  ?:(?=(%crud -.task) q.task ~)
@@ -544,8 +537,6 @@
 ++  load                                                ::  trivial
   |=  old/all-axle
   ..^$(all old)
-  ::  |=  old=*   ::  diable
-  ::  ..^$(ore.all `~zod)
 ::
 ++  scry
   |=  {fur/(unit (set monk)) ren/@tas why/shop syd/desk lot/coin tyl/path}
@@ -561,8 +552,8 @@
   ^+  [*(list move) ..^$]
   =/  nus  (ax hen)
   ?~  nus
-    ::  we got this on an unknown duct or
-    ::  before %boot or %init (or one of those crashed)
+    ::  :hen is an unrecognized duct
+    ::  could be before %boot (or %boot failed)
     ::
     ~&  [%dill-take-no-flow hen -.q.hin +<.q.hin]
     [~ ..^$]

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -41,7 +41,7 @@
   $%  {$wegh $~}                                        ::
   ==                                                    ::
 ++  note-clay                                           ::
-  $%  {$merg p/@p q/@tas r/@p s/@tas t/case u/germ:clay}::  merge desks
+  $%  {$merg p/@tas q/@p r/@tas s/case t/germ:clay}     ::  merge desks
       {$warp p/sock q/riff:clay}                        ::  wait for clay hack
       {$wegh $~}                                        ::
       {$perm p/ship q/desk r/path s/rite:clay}          ::  change permissions
@@ -298,7 +298,7 @@
         =/  myt  (flop (need tem))
         =/  can  (clan:title our)
         =.  tem  ~
-        =.  moz  :_(moz [hen %pass / %c %merg our %home our %base da+now %init])
+        =.  moz  :_(moz [hen %pass / %c %merg %home our %base da+now %init])
         =.  moz  :_(moz [hen %pass ~ %g %conf [[our ram] %load our %home]])
         =.  +>  (sync %home our %base)
         =.  +>  ?:  ?=(?($czar $pawn) can)  +>

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -28,7 +28,7 @@
               {$meta vase}                              ::  type check
           ==  ==                                        ::
               $:  $f                                            ::
-          $%  [%build our=@p live=? schematic=schematic:ford]
+          $%  [%build live=? schematic=schematic:ford]
               [%kill our=@p]
           ==  ==
               $:  $g                                    ::  to %gall
@@ -1135,7 +1135,7 @@
     ~/  %execute-turbo
     |=  [tea=whir live=? request=schematic:ford]
     %+  pass-note  tea
-    :*  %f  %build  our  live
+    :*  %f  %build  live
         [%dude |.([%leaf "eyre: execute {<tea>}"]) request]
     ==
   ::

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -836,21 +836,22 @@
       ::    by molding the incoming thing into a gram shape before we try to
       ::    soft it.
       ::
+      =*  him  p.kyz
       ?~  -.q.kyz
-        ~&  e+[%strange-west-wire p.kyz]
+        ~&  e+[%strange-west-wire him]
         ~!(%strange-west-wire !!)
       =+  mez=((soft gram) [i.-.q.kyz +.q.kyz])
       ?~  mez
-        ~&  e+[%strange-west p.kyz]
+        ~&  e+[%strange-west him]
         ~|(%strange-west !!)
       ?-  -.u.mez
-        $aut  abet:(logon:(ses-ya p.u.mez) q.p.kyz)
-        $hat  (foreign-hat:(ses-ya p.u.mez) q.p.kyz q.u.mez)
-        $gib  (pass-note ay+(dray p+uv+~ q.p.kyz p.u.mez) [%e %thud ~])
-        $get  (pass-note ay+(dray p+uv+~ q.p.kyz p.u.mez) [%e %this q.u.mez])
+        $aut  abet:(logon:(ses-ya p.u.mez) him)
+        $hat  (foreign-hat:(ses-ya p.u.mez) him q.u.mez)
+        $gib  (pass-note ay+(dray p+uv+~ him p.u.mez) [%e %thud ~])
+        $get  (pass-note ay+(dray p+uv+~ him p.u.mez) [%e %this q.u.mez])
         $got
           ?.  (~(has by pox) p.u.mez)
-            ~&  lost-gram-thou+p.kyz^p.u.mez
+            ~&  lost-gram-thou+him^p.u.mez
             +>.$
           =:  hen  (~(got by pox) p.u.mez)
               pox  (~(del by pox) p.u.mez)
@@ -860,17 +861,17 @@
         $lon
           ::  ~&  ses-ask+[p.u.mez sop (~(run by wup) ~)]
           ?:  (ses-authed p.u.mez)
-            (ames-gram q.p.kyz %aut p.u.mez)
-          =.  sop  (~(put by sop) p.u.mez q.p.kyz |)
-          (ames-gram q.p.kyz %hat p.u.mez our-host)
+            (ames-gram him %aut p.u.mez)
+          =.  sop  (~(put by sop) p.u.mez him |)
+          (ames-gram him %hat p.u.mez our-host)
       ::
         $get-inner
-          %+  exec-turbo-live  ay+(dray p+uv+~ q.p.kyz p.u.mez)
+          %+  exec-turbo-live  ay+(dray p+uv+~ him p.u.mez)
           [%bake q.u.mez r.u.mez [[p q] s]:s.u.mez]
       ::
         $got-inner
           ?.  (~(has by pox) p.u.mez)
-            ~&  lost-gram-inner+p.kyz^p.u.mez
+            ~&  lost-gram-inner+him^p.u.mez
             +>.$
           =:  hen  (~(got by pox) p.u.mez)
               pox  (~(del by pox) p.u.mez)
@@ -895,7 +896,7 @@
             [%vale [p q]:norm res]
           ==
       ::
-        $not  +>.$(mow :_(mow [ged [%give %that q.p.kyz p.u.mez]]))
+        $not  +>.$(mow :_(mow [ged [%give %that him p.u.mez]]))
       ==
     ::
       $wegh  !!                                         ::  handled elsewhere

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -95,7 +95,6 @@
       por/{clr/@ud sek/(unit @ud)}                      ::  live ports
       wel/wank                                          ::  .well-known
       gub/@t                                            ::  random identity
-      hov/(unit ship)                                   ::  master for remote
       top/beam                                          ::  ford serve prefix
       ged/duct                                          ::  client interface
       ded/(set duct)                                    ::  killed requests
@@ -639,7 +638,6 @@
   ++  apex                                              ::  accept request
     |=  kyz/task:able
     ^+  +>
-    =.  our  ?~(hov our u.hov)  ::  XX
     =.  p.top  our              ::  XX necessary?
     ?-    -.kyz
         ::  new unix process - learn of first boot or a restart.
@@ -725,10 +723,8 @@
       +>.$(mow [[hen %slip %d %flog kyz] mow])
     ::
         $init                                           ::  register ownership
-      =.  our  ?~(hov p.kyz (min u.hov p.kyz))
       %=  +>.$
         fig  [~ ?=(%king (clan:title our)) & &]
-        hov  [~ our]
         top  [[our %home ud+0] /web]
       ==
     ::
@@ -917,7 +913,6 @@
   ++  axon                                              ::  accept response
     |=  {tee/whir sih/sign}
     ^+  +>
-    =.  our  ?~(hov our u.hov)  ::  XX
     ?:  &(?=({?($of $ow) ^} tee) !(~(has by wix) p.tee))
       ~&(dead-ire+[`whir`tee] +>)
     ?-    &2.sih
@@ -981,7 +976,6 @@
       (give-json 200 ~ (frond:enjs %beat %b &))
     ::
         $made
-      =.  our  (need hov)                             ::  XX
       =|  ses/(unit hole)
       |-  ^+  ..axon
       ?+    tee  ~&  [%tee tee]  !!
@@ -1074,7 +1068,9 @@
   ++  ses-ya  |=(ses/hole ~(. ya ses (~(got by wup) ses)))
   ++  our-host
     ^-  hart
-    :: XX get actual -F flag value
+    ::  XX get actual -F flag value
+    ::  XX scry into %jael?
+    ::
     ?:  [fake=|]  [| [~ 8.443] &+/localhost]
     `hart`[& ~ %& /org/urbit/(rsh 3 1 (scot %p our))]
   ::
@@ -1274,8 +1270,6 @@
     ++  apex
       =<  abet
       ^+  done
-      =+  oar=(host-to-ship r.hat)
-      =.  our  ?~(oar our u.oar)  ::  XX
       =+  pez=process
       ?:  ?=(%| -.pez)  p.pez
       (resolve ~ p.pez)
@@ -2272,7 +2266,6 @@
         hosts+[%& dop]
         misc+[%& bol]
     ==
-  =+  our=`@p`0x100  ::  XX  sentinel
   =+  ska=(sloy ski)
   =+  sky=|=({* *} `(unit)`=+(a=(ska +<) ?~(a ~ ?~(u.a ~ [~ u.u.a]))))
   =.  ney  (shax :(mix (shax now) +(eny) ney))          ::  XX!!  shd not need
@@ -2291,7 +2284,6 @@
   ^-  (unit (unit cage))
   ?.  ?=(%& -.why)  ~
   =*  who  p.why
-  =+  our=(need hov)                  :: XX single home
   =+  ska=(sloy ski)
   =+  sky=|=({* *} `(unit)`=+(a=(ska +<) ?~(a ~ ?~(u.a ~ [~ u.u.a]))))
   ?.  ?=($$ ren)  [~ ~]
@@ -2326,7 +2318,6 @@
 ++  take                                                ::  accept response
   |=  {tea/wire hen/duct hin/(hypo sign)}
   ^+  [*(list move) ..^$]
-  =+  our=`@p`0x100  ::  XX  sentinel
   =+  ska=(sloy ski)
   =+  sky=|=({* *} `(unit)`=+(a=(ska +<) ?~(a ~ ?~(u.a ~ [~ u.u.a]))))
   =.  ney  (shax :(mix (shax now) +(eny) ney))          ::  XX!!  shd not need

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -29,7 +29,7 @@
           ==  ==                                        ::
               $:  $f                                            ::
           $%  [%build live=? schematic=schematic:ford]
-              [%kill our=@p]
+              [%kill ~]
           ==  ==
               $:  $g                                    ::  to %gall
           $%  {$deal p/sock q/cush:gall}               ::  full transmission
@@ -799,7 +799,7 @@
       :: ~&  did-thud+[-.lid hen]
       ?-  -.lid
           $exec
-        (pass-note p.lid %f [%kill our])
+        (pass-note p.lid %f %kill ~)
       ::
           $poll
         ?.  (~(has by wix) p.lid)

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -13,7 +13,7 @@
 ++  move  {p/duct q/(wind note gift:able)}              ::  local move
 ++  note                                                ::  out request $->
           $%  $:  $a                                    ::  to %ames
-          $%  {$want p/sock q/{path *}}                 ::
+          $%  {$want p/ship q/{path *}}                 ::
           ==  ==                                        ::
               $:  $b                                    ::  to  %behn
           $%  {$wait p/@da}                             ::
@@ -1083,7 +1083,7 @@
     ::  TODO: To make this work
     ::
     ~!  -.gam
-    (pass-note ~ %a %want [our him] [%e -.gam ~] +.gam)
+    (pass-note ~ %a %want him [%e -.gam ~] +.gam)
   ::
   ++  back-turbo
     |=  [tea=whir mar=mark cay=cage]

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -151,9 +151,9 @@
           ::  %warp: internal (intra-ship) file request
           ::
           $%  $:  %warp
-                  ::  sock: pair of requesting ship, requestee ship
+                  ::  ship: target for request
                   ::
-                  =sock
+                  =ship
                   ::  riff: clay request contents
                   ::
                   riff=riff:clay
@@ -5960,7 +5960,7 @@
       ::
       =+  [their desk]=disc.subscription
       ::
-      :^  %c  %warp  sock=[our their]
+      :^  %c  %warp  ship=their
       ^-  riff:clay
       [desk `[%mult `case`[%da date.subscription] request-contents]]
     ::
@@ -5985,7 +5985,7 @@
     ::
     =/  =note
       =+  [their desk]=disc.subscription
-      [%c %warp sock=[our their] `riff:clay`[desk ~]]
+      [%c %warp ship=their `riff:clay`[desk ~]]
     ::
     =.  moves  [`move`[u.originator [%pass wire note]] moves]
     ::
@@ -6024,7 +6024,7 @@
     =/  =note
       =,  scry-request
       =/  =disc  [p q]:beam
-      :*  %c  %warp  sock=[our their=ship.disc]  desk.disc
+      :*  %c  %warp  their=ship.disc  desk.disc
           `[%sing care case=r.beam (flop s.beam)]
       ==
     ::
@@ -6048,7 +6048,7 @@
     ::
     =/  =note
       =+  [their desk]=[p q]:beam.scry-request
-      [%c %warp sock=[our their] `riff:clay`[desk ~]]
+      [%c %warp ship=their `riff:clay`[desk ~]]
     ::
     =.  moves  [`move`[u.originator [%pass wire note]] moves]
     ::

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -6110,9 +6110,9 @@
       %build
     ::  perform the build indicated by :task
     ::
-    ::    First, we dispatch to the |ev by constructing :event-args and
-    ::    using them to create :start-build, which performs the build.
-    ::    The result of :start-build is a pair of :moves and a mutant :state.
+    ::    We call :start-build on :this-event, which is the |per-event core
+    ::    with the our event-args already bound. :start-build performs the
+    ::    build and produces a pair of :moves and a mutant :state.
     ::    We update our :state and produce it along with :moves.
     ::
     =/  =build  [now schematic.task]

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -190,17 +190,12 @@
 +=  axle
   $:  ::  date: date at which ford's state was updated to this data structure
       ::
-      date=%~2018.6.28
-      ::  state-by-ship: storage for all the @p's this ford has been
+      date=%~2018.12.13
+      ::  state: all persistent state
       ::
-      ::    Once the cc-release boot sequence lands, we can remove this
-      ::    mapping, since an arvo will not change @p identities. until
-      ::    then, we need to support a ship booting as a comet before
-      ::    becoming its adult identity.
-      ::
-      state-by-ship=(map ship ford-state)
+      state=ford-state
   ==
-::  +ford-state: all state that ford maintains for a @p ship identity
+::  +ford-state: all state that ford maintains
 ::
 +=  ford-state
   $:  ::  builds: per-build state machine for all builds
@@ -6093,12 +6088,8 @@
 ::      %kill: cancel a build
 ::      %wipe: clear memory
 ::
-::    The general procedure is for Ford to determine the `our` identity
-::    for this +task and operate on the :ship-state for that identity.
-::
 ::    Most requests get converted into operations to be performed inside
-::    the +per-event core, which is Ford's main build engine. The %keep
-::    and %wipe requests work across all identities stored in Ford, though.
+::    the +per-event core, which is Ford's main build engine.
 ::
 ++  call
   |=  [=duct type=* wrapped-task=(hobo task:able)]
@@ -6109,6 +6100,9 @@
     ?.  ?=(%soft -.wrapped-task)
       wrapped-task
     ((hard task:able) p.wrapped-task)
+  ::  we wrap +per-event with a call that binds our event args
+  ::
+  =*  this-event  (per-event [our duct now scry-gate] state.ax)
   ::
   ?-    -.task
       ::  %build: request to perform a build
@@ -6116,19 +6110,13 @@
       %build
     ::  perform the build indicated by :task
     ::
-    ::    First, we find or create the :ship-state for :our.task,
-    ::    modifying :state-by-ship as necessary. Then we dispatch to the |ev
-    ::    by constructing :event-args and using them to create :start-build,
-    ::    which performs the build. The result of :start-build is a pair of
-    ::    :moves and a mutant :ship-state. We update our :state-by-ship map
-    ::    with the new :ship-state and produce it along with :moves.
+    ::    First, we dispatch to the |ev by constructing :event-args and
+    ::    using them to create :start-build, which performs the build.
+    ::    The result of :start-build is a pair of :moves and a mutant :state.
+    ::    We update our :state and produce it along with :moves.
     ::
-    =^  ship-state  state-by-ship.ax  (find-or-create-ship-state our.task)
     =/  =build  [now schematic.task]
-    =*  event-args  [[our.task duct now scry-gate] ship-state]
-    =*  start-build  start-build:(per-event event-args)
-    =^  moves  ship-state  (start-build build live.task)
-    =.  state-by-ship.ax  (~(put by state-by-ship.ax) our.task ship-state)
+    =^  moves  state.ax  (start-build:this-event build live.task)
     ::
     [moves ford-gate]
   ::
@@ -6136,21 +6124,7 @@
       ::
       %keep
     ::
-    =/  ship-states=(list [ship=@p state=ford-state])
-      ~(tap by state-by-ship.ax)
-    ::
-    =.  state-by-ship.ax
-      |-  ^+  state-by-ship.ax
-      ?~  ship-states  state-by-ship.ax
-      ::
-      =,  i.ship-states
-      =*  event-args   [[ship duct now scry-gate] state]
-      ::
-      =.  state-by-ship.ax
-        %+  ~(put by state-by-ship.ax)  ship
-        (keep:(per-event event-args) [compiler-cache build-cache]:task)
-      ::
-      $(ship-states t.ship-states)
+    =.  state.ax  (keep:this-event [compiler-cache build-cache]:task)
     ::
     [~ ford-gate]
   ::
@@ -6158,10 +6132,7 @@
       ::
       %kill
     ::
-    =/  ship-state  ~|(our+our.task (~(got by state-by-ship.ax) our.task))
-    =*  event-args  [[our.task duct now scry-gate] ship-state]
-    =^  moves  ship-state  cancel:(per-event event-args)
-    =.  state-by-ship.ax  (~(put by state-by-ship.ax) our.task ship-state)
+    =^  moves  state.ax  cancel:this-event
     ::
     [moves ford-gate]
   ::
@@ -6175,21 +6146,7 @@
       ::
       %wipe
     ::
-    =/  ship-states=(list [ship=@p state=ford-state])
-      ~(tap by state-by-ship.ax)
-    ::
-    =.  state-by-ship.ax
-      |-  ^+  state-by-ship.ax
-      ?~  ship-states  state-by-ship.ax
-      ::
-      =,  i.ship-states
-      =*  event-args   [[ship duct now scry-gate] state]
-      ::
-      =.  state-by-ship.ax
-        %+  ~(put by state-by-ship.ax)  ship
-        (wipe:(per-event event-args) percent-to-remove.task)
-      ::
-      $(ship-states t.ship-states)
+    =.  state.ax  (wipe:this-event percent-to-remove.task)
     ::
     [~ ford-gate]
   ::
@@ -6200,13 +6157,12 @@
     ^-  mass
     :-  %ford
     :-  %|
-    %+  turn  ~(tap by state-by-ship.ax)     :: XX single-home
-    |=  [our=@ ford-state]  ^-  mass
-    :+  (scot %p our)  %|
-    ::
-    :~  [%builds [%& builds]]
-        [%compiler-cache [%& compiler-cache]]
-    ==
+    :~  ^-  mass
+        :+  (scot %p our)  %|
+        ::
+        :~  [%builds [%& builds.state.ax]]
+            [%compiler-cache [%& compiler-cache.state.ax]]
+    ==  ==
   ==
 ::  +take: receive a response from another vane
 ::
@@ -6225,9 +6181,6 @@
 ::        If Ford receives this, it will continue building one or more builds
 ::        that were blocked on this resource.
 ::
-::    The general procedure is for Ford to determine the `our` identity
-::    for this +task and operate on the :ship-state for that identity.
-::
 ::    The +sign gets converted into operations to be performed inside
 ::    the +per-event core, which is Ford's main build engine.
 ::
@@ -6240,26 +6193,14 @@
   ::  :wire must at least contain :our and a tag for dispatching
   ::
   ?>  ?=([@ @ *] wire)
-  ::  :parse our from the head of :wire
-  ::
-  =/  our=@p  (slav %p i.wire)
-  ::
-  ::
-  =/  ship-state
-    ::  we know :our is already in :state-by-ship because we sent this request
-    ::
-    ~|  [%take-our our]
-    (~(got by state-by-ship.ax) our)
   ::
   |^  ^-  [(list move) _ford-gate]
       ::
-      =^  moves  ship-state
+      =^  moves  state.ax
         ?+  i.t.wire     ~|([%bad-take-wire wire] !!)
           %clay-sub      take-rebuilds
           %scry-request  take-unblocks
         ==
-      ::
-      =.  state-by-ship.ax  (~(put by state-by-ship.ax) our ship-state)
       ::
       [moves ford-gate]
     ::  +take-rebuilds: rebuild all live builds affected by the Clay changes
@@ -6273,7 +6214,7 @@
       ::
       =/  =subscription
         ~|  [%ford-take-bad-clay-sub wire=wire duct=duct]
-        =/  =duct-status  (~(got by ducts.ship-state) duct)
+        =/  =duct-status  (~(got by ducts.state.ax) duct)
         ?>  ?=(%live -.live.duct-status)
         ?>  ?=(^ last-sent.live.duct-status)
         ?>  ?=(^ subscription.u.last-sent.live.duct-status)
@@ -6281,15 +6222,15 @@
       ::
       =/  ducts=(list ^duct)
         ~|  [%ford-take-missing-subscription subscription]
-        (get-request-ducts pending-subscriptions.ship-state subscription)
+        (get-request-ducts pending-subscriptions.state.ax subscription)
       ::
       =|  moves=(list move)
-      |-  ^+  [moves ship-state]
-      ?~  ducts  [moves ship-state]
+      |-  ^+  [moves state.ax]
+      ?~  ducts  [moves state.ax]
       ::
-      =*  event-args  [[our i.ducts now scry-gate] ship-state]
+      =*  event-args  [[our i.ducts now scry-gate] state.ax]
       =*  rebuild  rebuild:(per-event event-args)
-      =^  duct-moves  ship-state
+      =^  duct-moves  state.ax
         (rebuild subscription p.case.sign disc care-paths.sign)
       ::
       $(ducts t.ducts, moves (weld moves duct-moves))
@@ -6315,17 +6256,17 @@
       ::
       =/  ducts=(list ^duct)
         ~|  [%ford-take-missing-scry-request scry-request]
-        (get-request-ducts pending-scrys.ship-state scry-request)
+        (get-request-ducts pending-scrys.state.ax scry-request)
       ::
       =|  moves=(list move)
-      |-  ^+  [moves ship-state]
-      ?~  ducts  [moves ship-state]
+      |-  ^+  [moves state.ax]
+      ?~  ducts  [moves state.ax]
       ::
-      =*  event-args  [[our i.ducts now scry-gate] ship-state]
+      =*  event-args  [[our i.ducts now scry-gate] state.ax]
       ::  unblock the builds that had blocked on :resource
       ::
       =*  unblock  unblock:(per-event event-args)
-      =^  duct-moves  ship-state  (unblock scry-request scry-result)
+      =^  duct-moves  state.ax  (unblock scry-request scry-result)
       ::
       $(ducts t.ducts, moves (weld moves duct-moves))
   --
@@ -6350,18 +6291,4 @@
 ::+|
 ::
 ++  ford-gate  ..$
-::  +find-or-create-ship-state: find or create a ford-state for a @p
-::
-::    Accesses and modifies :state-by-ship.
-::
-++  find-or-create-ship-state
-  |=  our=@p
-  ^-  [ford-state _state-by-ship.ax]
-  ::
-  =/  existing  (~(get by state-by-ship.ax) our)
-  ?^  existing
-    [u.existing state-by-ship.ax]
-  ::
-  =|  new-state=ford-state
-  [new-state (~(put by state-by-ship.ax) our new-state)]
 --

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -107,17 +107,15 @@
     ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ++  mo
   ~%  %gall-mo  +>  ~ 
-  |_  $:  $:  our/@p 
-              hen/duct
-              moz/(list move)
+  |_  $:  $:  hen=duct
+              moz=(list move)
           ==
           mast
       ==
   ++  mo-abed                                           ::  initialize
-    |=  {our/@p hen/duct}
+    |=  hen=duct
     ^+  +>
     %_    +>
-      our  our
       hen  hen
       +<+  (~(got by pol.all) our)
     ==
@@ -1310,14 +1308,14 @@
     ?.  (~(has by pol.all) p.p.q.hic)
       ~&  [%gall-not-ours p.p.q.hic]
       [~ ..^$]
-    mo-abet:(mo-conf:(mo-abed:mo p.p.q.hic hen) q.p.q.hic q.q.hic)
+    mo-abet:(mo-conf:(mo-abed:mo hen) q.p.q.hic q.q.hic)
   ::
       $deal
     =<  mo-abet
     ?.  (~(has by pol.all) q.p.q.hic)                   ::  either to us
       ?>  (~(has by pol.all) p.p.q.hic)                 ::  or from us
-      (mo-away:(mo-abed:mo p.p.q.hic hen) q.p.q.hic q.q.hic)
-    (mo-come:(mo-abed:mo q.p.q.hic hen) p.p.q.hic q.q.hic)
+      (mo-away:(mo-abed:mo hen) q.p.q.hic q.q.hic)
+    (mo-come:(mo-abed:mo hen) p.p.q.hic q.q.hic)
   ::
       $init 
     ::  ~&  [%gall-init p.q.hic]
@@ -1332,10 +1330,10 @@
     ?:  ?=($ge i.q.q.hic)
       =+  mes=((hard {@ud rook}) r.q.hic)
       =<  mo-abet
-      (mo-gawk:(mo-abed:mo our hen) him dap mes)
+      (mo-gawk:(mo-abed:mo hen) him dap mes)
     =+  mes=((hard {@ud roon}) r.q.hic)
     =<  mo-abet
-    (mo-gawd:(mo-abed:mo our hen) him dap mes)
+    (mo-gawd:(mo-abed:mo hen) him dap mes)
   ::
       $wegh
     :_  ..^$  :_  ~
@@ -1381,7 +1379,7 @@
     [~ ~]
   ?.  ?=(^ tyl)
     ~
-  (mo-peek:(mo-abed:mo his *duct) syd high+`his ren tyl)
+  (mo-peek:(mo-abed:mo *duct) syd high+`his ren tyl)
 ::
 ++  stay                                                ::  save w+o cache
   `axle`all
@@ -1392,8 +1390,7 @@
   ^+  [*(list move) ..^$]
   ~|  [%gall-take tea]
   ?>  ?=({@ ?($sys $use) *} tea) 
-  =+  our=(need (slaw %p i.tea))
-  =+  mow=(mo-abed:mo our hen)
+  =+  mow=(mo-abed:mo hen)
   ?-  i.t.tea
     $sys  mo-abet:(mo-cyst:mow t.t.tea q.hin)
     $use  mo-abet:(mo-cook:mow t.t.tea hin)

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -241,7 +241,7 @@
         ==
     %+  mo-pass  
       [%sys %way -.q.caz ~]
-    `note-arvo`[%a %want [our him] [%g %ge p.caz ~] [num roc]]
+    `note-arvo`[%a %want him [%g %ge p.caz ~] [num roc]]
   ::
   ++  mo-baal                                           ::  error convert a
     |=  art/(unit ares)
@@ -351,7 +351,7 @@
           ~&  [%diff-bad-ack %mack]
           (slog (flop q.,.+>.q.+>.sih))
       =.  +>.$  (mo-pass [%sys pax] %g %deal [him our] dap %pull ~)
-      (mo-pass [%sys pax] %a %want [our him] [%g %gh dap ~] [num %x ~])
+      (mo-pass [%sys pax] %a %want him [%g %gh dap ~] [num %x ~])
     ::
         %rep                                            ::  reverse request
       ?>  ?=({@ @ @ ~} t.pax)
@@ -400,9 +400,9 @@
       ?-    -.cuf
         $coup  (mo-give %mack p.cuf)
         $diff  %+  mo-pass  [%sys %red t.pax]
-               [%a %want [our him] [%g %gh dap ~] [num %d p.p.cuf q.q.p.cuf]]
+               [%a %want him [%g %gh dap ~] [num %d p.p.cuf q.q.p.cuf]]
         $quit  %+  mo-pass  [%sys pax]
-               [%a %want [our him] [%g %gh dap ~] [num %x ~]]
+               [%a %want him [%g %gh dap ~] [num %x ~]]
         $reap  (mo-give %mack p.cuf)
       ==
     ::

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -36,7 +36,7 @@
     ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ++  axle                                                ::  all state
   $:  $0                                                ::  state version
-      pol/(map ship mast)                               ::  apps by ship
+      =mast                                             ::  apps by ship
   ==                                                    ::
 ++  gest                                                ::  subscriber data
   $:  sup/bitt                                          ::  incoming subscribers
@@ -106,23 +106,19 @@
 |%  ::::::::::::::::::::::::::::::::::::::::::::::::::::::  state machine
     ::::::::::::::::::::::::::::::::::::::::::::::::::::::
 ++  mo
-  ~%  %gall-mo  +>  ~ 
-  |_  $:  $:  hen=duct
-              moz=(list move)
-          ==
-          mast
+  ~%  %gall-mo  +>  ~
+  =*  mas  mast.all
+  |_  $:  hen=duct
+          moz=(list move)
       ==
   ++  mo-abed                                           ::  initialize
-    |=  hen=duct
+    |=  =duct
     ^+  +>
-    %_    +>
-      hen  hen
-      +<+  (~(got by pol.all) our)
-    ==
+    +>(hen duct)
   ::
   ++  mo-abet                                           ::  resolve to 
     ^+  [*(list move) +>+]
-    :_  +>+(pol.all (~(put by pol.all) our +<+))
+    :_  +>+
     %-  flop
     %+  turn  moz
     |=  a/move
@@ -165,11 +161,11 @@
     ::
     =/  result-cage=cage  (result-to-cage:ford build-result)
     ::
-    =/  app-data=(unit seat)  (~(get by bum) dap)
+    =/  app-data=(unit seat)  (~(get by bum.mas) dap)
     ?^  app-data
       ::  update the path
       ::
-      =.  bum  (~(put by bum) dap u.app-data(byk byk))
+      =.  bum.mas  (~(put by bum.mas) dap u.app-data(byk byk))
       ::  magic update string from +mo-boon, "complete old boot"
       ::
       ap-abet:(ap-peep:(ap-abed:ap dap [%high [~ our]]) q.result-cage)
@@ -190,8 +186,8 @@
     |=  {dap/dude byk/beak hav/vase}
     =+  sat=*seat
     %_    +>.$
-        bum
-      %+  ~(put by bum)  dap
+        bum.mas
+      %+  ~(put by bum.mas)  dap
       %_  sat
         mom  hen
         byk  byk
@@ -267,13 +263,13 @@
   ++  mo-bale                                           ::  assign outbone
     |=  him/ship 
     ^-  {@ud _+>}
-    =+  sad=(fall (~(get by sap) him) `scad`[1 ~ ~])
+    =+  sad=(fall (~(get by sap.mas) him) `scad`[1 ~ ~])
     =+  nom=(~(get by q.sad) hen)
     ?^  nom  [u.nom +>.$]
     :-  p.sad
     %_    +>.$
-        sap
-      %+  ~(put by sap)  him
+        sap.mas
+      %+  ~(put by sap.mas)  him
       %_  sad
         p  +(p.sad)
         q  (~(put by q.sad) hen p.sad)
@@ -284,7 +280,7 @@
   ++  mo-ball                                           ::  outbone by index
     |=  {him/ship num/@ud}
     ^-  duct
-    (~(got by r:(~(got by sap) him)) num)
+    (~(got by r:(~(got by sap.mas) him)) num)
   ::
   ++  mo-come                                           ::  handle locally
     |=  {her/ship caz/cush}
@@ -459,12 +455,12 @@
   ++  mo-claw                                           ::  clear queue
     |=  dap/dude
     ^+  +>
-    ?.  (~(has by bum) dap)  +>
-    =+  suf=(~(get by wub) dap)
+    ?.  (~(has by bum.mas) dap)  +>
+    =+  suf=(~(get by wub.mas) dap)
     ?~  suf  +>.$
     |-  ^+  +>.^$
     ?:  =(~ kys.u.suf)
-      +>.^$(wub (~(del by wub) dap))
+      +>.^$(wub.mas (~(del by wub.mas) dap))
     =^  lep  kys.u.suf  [p q]:~(get to kys.u.suf)
     $(moz :_(moz [p.lep %slip %g %deal [q.q.q.lep our] dap r.lep]))
     ::  $(+>.^$ (mo-clip(hen p.lep) dap q.lep r.lep))
@@ -473,7 +469,7 @@
     |=  dap/dude
     =-  ?.(=(p our) - -(r [%da now])) ::  soft dependencies
     ^-  beak
-    byk:(~(got by bum) dap)
+    byk:(~(got by bum.mas) dap)
   ::
   ++  mo-peek
     ~/  %mo-peek
@@ -501,11 +497,11 @@
   ++  mo-club                                           ::  local action
     |=  {dap/dude pry/prey cub/club}
     ^+  +>
-    ?:  |(!(~(has by bum) dap) (~(has by wub) dap))
+    ?:  |(!(~(has by bum.mas) dap) (~(has by wub.mas) dap))
       ~&  >>  [%mo-not-running dap -.cub]
       ::  ~&  [%mo-club-qeu dap cub]
-      =+  syf=(fall (~(get by wub) dap) *sofa)
-      +>.$(wub (~(put by wub) dap syf(kys (~(put to kys.syf) [hen pry cub]))))
+      =+  syf=(fall (~(get by wub.mas) dap) *sofa)
+      +>.$(wub.mas (~(put by wub.mas) dap syf(kys (~(put to kys.syf) [hen pry cub]))))
     (mo-clip dap pry cub)
   ::
   ++  mo-gawk                                           ::  ames forward
@@ -551,7 +547,7 @@
       ^+  +>
       =:  ^dap   dap
           ^pry   pry
-          +>+<+  `seat`(~(got by bum) dap)
+          +>+<+  `seat`(~(got by bum.mas) dap)
         ==
       =+  unt=(~(get by q.zam) hen)
       =:  act.tyc  +(act.tyc)
@@ -571,7 +567,7 @@
       ^+  +>
       =>  ap-abut
       %_  +>
-        bum  (~(put by bum) dap +<+)
+        bum.mas  (~(put by bum.mas) dap +<+)
         moz  :(weld (turn zip ap-aver) (turn dub ap-avid) moz)
       ==
     ::
@@ -1305,21 +1301,20 @@
   =>  .(q.hic ?.(?=($soft -.q.hic) q.hic ((hard task:able) p.q.hic)))
   ?-    -.q.hic
       $conf
-    ?.  (~(has by pol.all) p.p.q.hic)
+    ?.  =(our p.p.q.hic)
       ~&  [%gall-not-ours p.p.q.hic]
       [~ ..^$]
     mo-abet:(mo-conf:(mo-abed:mo hen) q.p.q.hic q.q.hic)
   ::
       $deal
     =<  mo-abet
-    ?.  (~(has by pol.all) q.p.q.hic)                   ::  either to us
-      ?>  (~(has by pol.all) p.p.q.hic)                 ::  or from us
+    ?.  =(our q.p.q.hic)                                ::  either to us
+      ?>  =(our p.p.q.hic)                              ::  or from us
       (mo-away:(mo-abed:mo hen) q.p.q.hic q.q.hic)
     (mo-come:(mo-abed:mo hen) p.p.q.hic q.q.hic)
   ::
       $init 
-    ::  ~&  [%gall-init p.q.hic]
-    [~ ..^$(pol.all (~(put by pol.all) p.q.hic %*(. *mast sys hen)))]
+    [~ ..^$(sys.mast.all hen)]
   ::
       $sunk  [~ ..^$]
   ::
@@ -1336,17 +1331,17 @@
     (mo-gawd:(mo-abed:mo hen) him dap mes)
   ::
       $wegh
-    :_  ..^$  :_  ~
-    :^  hen  %give  %mass
-    :-  %gall
-    :-  %|
-    %+  turn  ~(tap by pol.all)     :: XX single-home
-    |=  {our/@ mast}  ^-  mass
-    :+  (scot %p our)  %|
-    :~  [%foreign [%& sap]]
-        [%blocked [%| (sort ~(tap by (~(run by wub) |=(sofa [%& +<]))) aor)]]
-        [%active [%| (sort ~(tap by (~(run by bum) |=(seat [%& +<]))) aor)]]
-    ==
+    =/  =mass
+      =*  mas  mast.all
+      :+  (scot %p our)  %|
+      :~  [%foreign [%& sap.mast.all]]
+          :+  %blocked  %|
+          (sort ~(tap by (~(run by wub.mast.all) |=(sofa [%& +<]))) aor)
+          :+  %active   %|
+          (sort ~(tap by (~(run by bum.mast.all) |=(seat [%& +<]))) aor)
+      ==
+    =/  =move  [hen %give %mass %gall %| [mass ~]]
+    [[move ~] ..^$]
   ::  
       $went  !!   ::  XX fixme
   ==
@@ -1367,19 +1362,19 @@
   ?:  ?&  =(%u ren)
           =(~ tyl)
           =([%$ %da now] lot)
-          (~(has by pol.all) his)
-          (~(has by bum:(~(got by pol.all) his)) syd)
+          =(our his)
+          (~(has by bum.mast.all) syd)
       ==
     ``[%null !>(~)]
-  ?.  (~(has by pol.all) his)
+  ?.  =(our his)
     ~
   ?.  =([%$ %da now] lot)
     ~
-  ?.  (~(has by bum:(~(got by pol.all) his)) syd)
+  ?.  (~(has by bum.mast.all) syd)
     [~ ~]
   ?.  ?=(^ tyl)
     ~
-  (mo-peek:(mo-abed:mo *duct) syd high+`his ren tyl)
+  (mo-peek:mo-abed:mo syd high+`his ren tyl)
 ::
 ++  stay                                                ::  save w+o cache
   `axle`all

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -204,7 +204,7 @@
     ^+  +>
     %+  mo-pass  [%sys %core dap (scot %p p.byk) q.byk (scot r.byk) ~]
     ^-  note-arvo
-    [%f %build our live=%.y [%core [[p q]:byk [%hoon dap %app ~]]]]
+    [%f %build live=%.y [%core [[p q]:byk [%hoon dap %app ~]]]]
   ::
   ++  mo-away                                           ::  foreign request
     ~/  %mo-away
@@ -482,11 +482,11 @@
     ?:  ?=($puff -.cub)
       %+  mo-pass
         [%sys %val (scot %p q.q.pry) dap ~]
-      [%f %build our live=%.n [%vale [p q]:(mo-beak dap) +.cub]]
+      [%f %build live=%.n [%vale [p q]:(mo-beak dap) +.cub]]
     ?:  ?=($punk -.cub)
       %+  mo-pass
         [%sys %val (scot %p q.q.pry) dap ~]
-      :*  %f  %build  our  live=%.n
+      :*  %f  %build  live=%.n
           ^-  schematic:ford
           [%cast [p q]:(mo-beak dap) p.cub [%$ q.cub]]
       ==
@@ -524,7 +524,7 @@
         $d
       %+  mo-pass
         [%sys %rep (scot %p him) dap (scot %ud num) ~]
-      [%f %build our live=%.n [%vale [p q]:(mo-beak dap) p.ron q.ron]]
+      [%f %build live=%.n [%vale [p q]:(mo-beak dap) p.ron q.ron]]
     ::
         $x  =.  +>  (mo-give %mack ~)                  ::  XX should crash
             (mo-give(hen (mo-ball him num)) %unto %quit ~)
@@ -604,7 +604,7 @@
         ?:  =(mar p.cay)  [%give %unto p.q.cov]
         :+  %pass
           [%sys %pel dap ~]
-        [%f %build our live=%.n [%cast [p q]:(mo-beak dap) mar [%$ cay]]]
+        [%f %build live=%.n [%cast [p q]:(mo-beak dap) mar [%$ cay]]]
       ::
           $pass
         :+  %pass  `path`[%use dap p.q.cov]

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1326,13 +1326,9 @@
       $sunk  [~ ..^$]
   ::
       $west
-    ?.  (~(has by pol.all) p.p.q.hic)
-      ~&  [%gall-not-ours p.q.hic]
-      [~ ..^$]
     ?>  ?=({?($ge $gh) @ ~} q.q.hic)
-    =+  dap=i.t.q.q.hic
-    =+  our=p.p.q.hic
-    =+  him=q.p.q.hic
+    =*  dap  i.t.q.q.hic
+    =*  him  p.q.hic
     ?:  ?=($ge i.q.q.hic)
       =+  mes=((hard {@ud rook}) r.q.hic)
       =<  mo-abet

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -701,7 +701,7 @@
       ::  our initial private key, as a +tree of +rite
       ::
       =/  rit  (sy [%jewel (my [lyf.seed.tac key.seed.tac] ~)] ~)
-      =.  +>.$  $(tac [%mint our our rit])
+      =.  +>.$  $(tac [%mint our rit])
       ::  our initial galaxy table as a +map from +life to +public
       ::
       =/  kyz
@@ -741,12 +741,12 @@
       +>.$
     ::
     ::  boot fake
-    ::    {$fake our/ship}
+    ::    [%fake =ship]
     ::
         %fake
       ::  single-homed
       ::
-      ?>  =(our our.tac)
+      ?>  =(our ship.tac)
       ::  fake keys are deterministically derived from the ship
       ::
       =/  cub  (pit:nu:crub:crypto 512 our)
@@ -769,7 +769,7 @@
       ::    so we do this first.
       ::
       =/  rit  (sy [%jewel (my [1 sec:ex:cub] ~)] ~)
-      =.  +>.$  $(tac [%mint our our rit])
+      =.  +>.$  $(tac [%mint our rit])
       ::  set the fake bit
       ::
       =.  fak.own.sub  &
@@ -839,18 +839,18 @@
       ==
     ::
     ::  watch public keys
-    ::    [%pubs our=ship who=ship]
+    ::    [%pubs =ship]
     ::
         %pubs
       %-  curd  =<  abet
-      (~(pubs ~(feed su hen our urb sub etn sap) hen) who.tac)
+      (~(pubs ~(feed su hen our urb sub etn sap) hen) ship.tac)
     ::
     ::  seen after breach
     ::    [%meet our=ship who=ship]
     ::
         %meet
       %+  cure  hen
-      [[%meet who.tac life.tac pass.tac]~ urb]
+      [[%meet ship.tac life.tac pass.tac]~ urb]
     ::
     ::  XX should be a subscription
     ::  XX reconcile with .dns.eth
@@ -915,7 +915,7 @@
       ::    [%vent ~]
       ::
           %vent
-        $(tac [%vent our])
+        $(tac [%vent ~])
       ::
       ::
           %vent-result
@@ -1003,7 +1003,7 @@
     =.  +>.$  (restore-block hen block)
     %=    +>.$
         moz
-      =-  [[hen %pass /wind/look %j %look our -] moz]
+      =-  [[hen %pass /wind/look %j %look -] moz]
       ?-  -.source.etn
         %&  &+p.source.etn
         %|  |+node.p.source.etn
@@ -2134,7 +2134,7 @@
         sap               sap(last-block 0)
         moves
       ?.  look  moves
-      =-  [[hen %pass /wind/look %j %look our -] moves]
+      =-  [[hen %pass /wind/look %j %look -] moves]
       ?-  -.source.etn
         %&  &+p.source.etn
         %|  |+node.p.source.etn

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -893,9 +893,8 @@
     ::    {$west p/ship q/path r/*}
     ::
         $west
-      =+  mes=((hard message) r.tac)
-      =*  our  p.p.tac
-      =*  dem  q.p.tac
+      =*  her  p.tac
+      =/  mes  ((hard message) r.tac)
       ?-    -.mes
       ::
       ::  reset remote rights
@@ -903,7 +902,7 @@
       ::
           %hail
         %+  cure  hen
-        abet:abet:(hail:(burb our) dem p.mes)
+        abet:abet:(hail:(burb our) her p.mes)
       ::
       ::  cancel trackers
       ::    [%nuke ~]
@@ -920,7 +919,7 @@
       ::
           %vent-result
         ::  ignore if not from currently configured source.
-        ?.  &(-.source.etn =(dem p.source.etn))
+        ?.  &(-.source.etn =(her p.source.etn))
           +>.$
         =.  moz  [[hen %give %mack ~] moz]
         %+  cute  hen  =<  abet

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -56,8 +56,6 @@
         ==                                              ::
       $=  own                                           ::  vault (vein)
         $:  yen/(set duct)                              ::  trackers
-            :: XX use this                              ::
-            our=ship                                    ::
             sig=(unit oath)                             ::  for a moon
             :: XX reconcile with .dns.eth               ::
             tuf=(list turf)                             ::  domains
@@ -601,12 +599,11 @@
   ::  vane interface when that gets cleaned up a bit.
   ::
   =|  moz/(list move)
-  =|  $:  ::  sys: system context
-          ::
-          $=  sys
-          $:  ::  now: current time
+  =|  $:  $:  ::  our: identity
+              ::  now: current time
               ::  eny: unique entropy
               ::
+              our=ship
               now=@da
               eny=@uvJ
           ==
@@ -668,8 +665,8 @@
     ::    {$burn p/ship q/safe}
     ::
         $burn
-      %^  cure  hen  our.tac
-      abet:abet:(deal:(burb our.tac) p.tac [~ q.tac])
+      %+  cure  hen
+      abet:abet:(deal:(burb our) p.tac [~ q.tac])
     ::
     ::  boot from keys
     ::    $:  $dawn
@@ -682,10 +679,9 @@
     ::    ==
     ::
         %dawn
-      =*  our  who.seed.tac
-      ::  sort-of single-homed
+      ::  single-homed
       ::
-      =.  our.own.sub  our
+      ?>  =(our who.seed.tac)
       ::  save our boot block
       ::
       =.  boq.own.sub  bloq.tac
@@ -723,7 +719,7 @@
       ::
       =.  +>.$
         ?~  snap.tac  +>.$
-        (restore-snap hen our u.snap.tac |)
+        (restore-snap hen u.snap.tac |)
       ::
       =.  moz
         %+  weld  moz
@@ -734,7 +730,7 @@
         ::    %jael init must be deferred (makes http requests)
         ::
         ^-  (list move)
-        :~  [hen %pass /(scot %p our)/init %b %wait +(now.sys)]
+        :~  [hen %pass /(scot %p our)/init %b %wait +(now)]
             [hen %give %init our]
             [hen %slip %e %init our]
             [hen %slip %d %init our]
@@ -748,10 +744,9 @@
     ::    {$fake our/ship}
     ::
         %fake
-      =*  our  our.tac
-      ::  sort-of single-homed
+      ::  single-homed
       ::
-      =.  our.own.sub  our
+      ?>  =(our our.tac)
       ::  fake keys are deterministically derived from the ship
       ::
       =/  cub  (pit:nu:crub:crypto 512 our)
@@ -798,15 +793,15 @@
     ::    {$hail p/ship q/remote}
     ::
         $hail
-      %^  cure  hen  our.tac
-      abet:abet:(hail:(burb our.tac) p.tac q.tac)
+      %+  cure  hen
+      abet:abet:(hail:(burb our) p.tac q.tac)
     ::
     ::  set ethereum source
     ::    [%look p=(each ship purl)]
     ::
         %look
-      %^  cute  hen  our.tac  =<  abet
-      (~(look et hen our.tac now.sys urb.lex sub.lex etn.lex sap.lex) src.tac)
+      %+  cute  hen  =<  abet
+      (~(look et hen our now urb.lex sub.lex etn.lex sap.lex) src.tac)
     ::
     ::  create promises
     ::    {$mint p/ship q/safe}
@@ -816,8 +811,8 @@
       ?<  ?&  fak.own.sub
               (~(exists up q.tac) %jewel)
           ==
-      %^  cure  hen  our.tac
-      abet:abet:(deal:(burb our.tac) p.tac [q.tac ~])
+      %+  cure  hen
+      abet:abet:(deal:(burb our) p.tac [q.tac ~])
     ::
     ::
     ::  move promises
@@ -825,11 +820,11 @@
     ::
         $move
       =.  +>
-        %^  cure  hen  our.tac
-        abet:abet:(deal:(burb our.tac) p.tac [~ r.tac])
+        %+  cure  hen
+        abet:abet:(deal:(burb our) p.tac [~ r.tac])
       =.  +>
-        %^  cure  hen  our.tac
-        abet:abet:(deal:(burb our.tac) q.tac [r.tac ~])
+        %+  cure  hen
+        abet:abet:(deal:(burb our) q.tac [r.tac ~])
       +>
     ::
     ::  cancel all trackers from duct
@@ -848,13 +843,13 @@
     ::
         %pubs
       %-  curd  =<  abet
-      (~(pubs ~(feed su hen our.tac urb sub etn sap) hen) who.tac)
+      (~(pubs ~(feed su hen our urb sub etn sap) hen) who.tac)
     ::
     ::  seen after breach
     ::    [%meet our=ship who=ship]
     ::
         %meet
-      %^  cure  hen  our.tac
+      %+  cure  hen
       [[%meet who.tac life.tac pass.tac]~ urb]
     ::
     ::  XX should be a subscription
@@ -873,20 +868,20 @@
     ::    {$vein $~}
     ::
         $vein
-      (curd abet:~(vein ~(feed su hen our.tac urb sub etn sap) hen))
+      (curd abet:~(vein ~(feed su hen our urb sub etn sap) hen))
     ::
     ::  watch ethereum events
     ::    [%vent ~]
     ::
         %vent
       =.  moz  [[hen %give %mack ~] moz]
-      (curd abet:~(vent ~(feed su hen our.tac urb sub etn sap) hen))
+      (curd abet:~(vent ~(feed su hen our urb sub etn sap) hen))
     ::
     ::  monitor assets
     ::    {$vest $~}
     ::
         $vest
-      (curd abet:~(vest ~(feed su hen our.tac urb sub etn sap) hen))
+      (curd abet:~(vest ~(feed su hen our urb sub etn sap) hen))
     ::
     ::  monitor all
     ::    {$vine $~}
@@ -907,7 +902,7 @@
       ::    [%hail p=remote]
       ::
           %hail
-        %^  cure  hen  our
+        %+  cure  hen
         abet:abet:(hail:(burb our) dem p.mes)
       ::
       ::  cancel trackers
@@ -928,22 +923,21 @@
         ?.  &(-.source.etn =(dem p.source.etn))
           +>.$
         =.  moz  [[hen %give %mack ~] moz]
-        %^  cute  hen  our  =<  abet
-        (~(hear-vent et hen our now.sys urb.lex sub.lex etn.lex sap.lex) p.mes)
+        %+  cute  hen  =<  abet
+        (~(hear-vent et hen our now urb.lex sub.lex etn.lex sap.lex) p.mes)
       ==
     ::
     ::  rewind to snapshot
     ::    {$wind p/@ud}
     ::
         %wind
-      (wind hen our.tac p.tac)
+      (wind hen p.tac)
     ==
   ::
   ++  take
     |=  [tea=wire hen=duct hin=sign]
     ^+  +>
     ?>  ?=([@ *] tea)
-    =+  our=(slav %p i.tea)
     =*  wir  t.tea
     ?-  hin
         [%a %woot *]
@@ -955,20 +949,20 @@
       +>.$
     ::
         [%e %sigh *]
-      %^  cute  hen  our  =<  abet
-      (~(sigh et hen our now.sys urb.lex sub.lex etn.lex sap.lex) wir p.hin)
+      %+  cute  hen  =<  abet
+      (~(sigh et hen our now urb.lex sub.lex etn.lex sap.lex) wir p.hin)
     ::
         [%b %wake ~]
-      %^  cute  hen  our
+      %+  cute  hen
       ::  XX cleanup
       ::
       ?.  ?=([%init ~] wir)
-        abet:~(wake et hen our now.sys urb.lex sub.lex etn.lex sap.lex)
-      abet:(~(init et hen our now.sys [urb sub etn sap]:lex) our (sein our))
+        abet:~(wake et hen our now urb.lex sub.lex etn.lex sap.lex)
+      abet:(~(init et hen our now [urb sub etn sap]:lex) our (sein our))
     ::
         [%j %vent *]
-      %^  cute  hen  our  =<  abet
-      (~(hear-vent et hen our now.sys urb.lex sub.lex etn.lex sap.lex) p.hin)
+      %+  cute  hen  =<  abet
+      (~(hear-vent et hen our now urb.lex sub.lex etn.lex sap.lex) p.hin)
     ==
   ::                                                    ::  ++curd:of
   ++  curd                                              ::  relative moves
@@ -980,14 +974,13 @@
     +>(sub sub, etn etn, sap sap, moz (weld (flop moz) ^moz))
   ::                                                    ::  ++cure:of
   ++  cure                                              ::  absolute edits
-    |=  {hen/duct our/ship hab/(list change) urb/state-absolute}
+    |=  [hen=duct hab=(list change) urb=state-absolute]
     ^+  +>
     =.  ^urb  urb
     (curd abet:(~(apex su hen our urb sub etn sap) hab))
   ::                                                    ::  ++cute:of
   ++  cute                                              ::  ethereum changes
     |=  $:  hen=duct
-            our=ship
             mos=(list move)
             ven=chain
             urb=state-absolute
@@ -1002,12 +995,12 @@
         ^sap  sap
     ==
     %-  cure(moz (weld (flop mos) moz))
-    [hen our abet:(link:(burb our) ven)]
+    [hen abet:(link:(burb our) ven)]
   ::                                                    ::  ++wind:of
   ++  wind                                              ::  rewind to snap
-    |=  [hen=duct our=@p block=@ud]
+    |=  [hen=duct block=@ud]
     ^+  +>
-    =.  +>.$  (restore-block hen our block)
+    =.  +>.$  (restore-block hen block)
     %=    +>.$
         moz
       =-  [[hen %pass /wind/look %j %look our -] moz]
@@ -1018,14 +1011,14 @@
     ==
   ::                                                    ::  ++restore-block:of
   ++  restore-block                                     ::  rewind before block
-    |=  [hen=duct our=@p block=@ud]
-    %^  cute  hen  our  =<  abet
-    (~(restore-block et hen our now.sys urb.lex sub.lex etn.lex sap.lex) block)
+    |=  [hen=duct block=@ud]
+    %+  cute  hen  =<  abet
+    (~(restore-block et hen our now urb.lex sub.lex etn.lex sap.lex) block)
   ::                                                    ::  ++restore-snap:of
   ++  restore-snap                                      ::  restore snapshot
-    |=  [hen=duct our=@p snap=snapshot look=?]
-    %^  cute  hen  our  =<  abet
-    %-  ~(restore-snap et hen our now.sys urb.lex sub.lex etn.lex sap.lex)
+    |=  [hen=duct snap=snapshot look=?]
+    %+  cute  hen  =<  abet
+    %-  ~(restore-snap et hen our now urb.lex sub.lex etn.lex sap.lex)
     [snap look]
   --
 ::                                                      ::  ++su
@@ -2200,10 +2193,12 @@
           hic/(hypo (hobo task:able))
       ==
   ^-  [(list move) _..^$]
-  =^  did  lex
-    =-  abet:(~(call of [now eny] lex) hen -)
-    ?.  ?=($soft -.q.hic)  q.hic
+  =/  =task:able
+    ?.  ?=($soft -.q.hic)
+      q.hic
     ((hard task:able) p.q.hic)
+  =^  did  lex
+    abet:(~(call of [our now eny] lex) hen task)
   [did ..^$]
 ::                                                      ::  ++load
 ++  load                                                ::  upgrade
@@ -2271,7 +2266,7 @@
   ::
       %deed
     ?.  ?=([@ @ ~] tyl)  [~ ~]
-    ?.  &(?=(%& -.why) =(p.why our.own.sub.lex))
+    ?.  &(?=(%& -.why) =(p.why our))
       [~ ~]
     =/  who  (slaw %p i.tyl)
     =/  lyf  (slaw %ud i.t.tyl)
@@ -2345,7 +2340,7 @@
     ?~  who  [~ ~]
     :^  ~  ~  %atom
     !>  ^-  ship
-    (~(sein of [now eny] lex) u.who)
+    (~(sein of [our now eny] lex) u.who)
   ::
       %saxo
     ?.  ?=([@ ~] tyl)  [~ ~]
@@ -2357,7 +2352,7 @@
     ?~  who  [~ ~]
     :^  ~  ~  %noun
     !>  ^-  (list ship)
-    (~(saxo of [now eny] lex) u.who)
+    (~(saxo of [our now eny] lex) u.who)
   ::
       %snap
     ?.  ?=(~ tyl)  [~ ~]
@@ -2385,6 +2380,6 @@
           hin/(hypo sign)
       ==
   ^-  [(list move) _..^$]
-  =^  did  lex  abet:(~(take of [now eny] lex) tea hen q.hin)
+  =^  did  lex  abet:(~(take of [our now eny] lex) tea hen q.hin)
   [did ..^$]
 --

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1097,7 +1097,7 @@
     :+  %pass
       /(scot %p our)/vent-result
     ^-  note:able
-    [%a %want [our who] /j/(scot %p our)/vent-result %vent-result res]
+    [%a %want who /j/(scot %p our)/vent-result %vent-result res]
   ::
   ++  extract-snap                                    ::  extract rewind point
     ^-  snapshot
@@ -1210,7 +1210,7 @@
         :_  moz
         :^  *duct  %pass  /vest/(scot %p p.hug)
         :+  %a  %want
-        :+  [our p.hug]  /j
+        :+  p.hug  /j
         ^-  message
         [%hail |+pig]
       ==
@@ -1702,7 +1702,7 @@
     |=  [our=ship who=ship]
     %-  put-move(source &+who)
     %+  wrap-note  /vent/(scot %p who)
-    [%a %want [our who] /j/(scot %p our)/vent `*`[%vent ~]]
+    [%a %want who /j/(scot %p our)/vent `*`[%vent ~]]
   ::
   ::  +unsubscribe-from-source: stop listening to current source ship
   ::
@@ -1713,7 +1713,7 @@
     %+  wrap-note  /vent/(scot %p p.source)
     ::TODO  should we maybe have a %nuke-vent,
     ::      or do we have a unique duct here?
-    [%a %want [our p.source] /j/(scot %p our)/vent `*`[%nuke ~]]
+    [%a %want p.source /j/(scot %p our)/vent `*`[%nuke ~]]
   ::
   ::  +listen-to-node: start syncing from a node
   ::
@@ -2161,7 +2161,7 @@
     :+  %pass
       /(scot %p our)/vent-result
     ^-  note:able
-    [%a %want [our who] /j/(scot %p our)/vent-result %vent-result res]
+    [%a %want who /j/(scot %p our)/vent-result %vent-result res]
   ::                                                    ::  ++feed:su
   --
 --

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -614,7 +614,7 @@
         hop/@da                                         ::  network boot date
         bad/(set @p)                                    ::  bad ships
         ton/town                                        ::  security
-        zac/(map ship corn)                             ::  flows by server
+        zac/corn                                        ::  flows by server
     ==                                                  ::
   ++  hand  @uvH                                        ::  128-bit hash
   ++  lane                                              ::  packet route
@@ -677,15 +677,12 @@
         lys/@da                                         ::  last sent
         pac/rock                                        ::  packet data
     ==                                                  ::
-  ++  sufi                                              ::  domestic host
-    $:  val/wund                                        ::  private keys
+  ++  town                                              ::  all security state
+    $:  any/@                                           ::  entropy
+        val/wund                                        ::  private keys
         law/deed                                        ::  server deed
         seh/(map hand {p/ship q/@da})                   ::  key cache
         hoc/(map ship dore)                             ::  neighborhood
-    ==                                                  ::
-  ++  town                                              ::  all security state
-    $:  any/@                                           ::  entropy
-        urb/(map ship sufi)                             ::  all keys and routes
     ==                                                  ::
   ++  wund  (list {p/life q/ring r/acru})               ::  secrets in action
   --  ::ames

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -747,7 +747,7 @@
           {$crew our/ship}                              ::  permission groups
           {$crow our/ship nom/@ta}                      ::  group usage
           {$crud p/@tas q/(list tank)}                  ::  error with trace
-          {$drop our/@p des/desk}                       ::  cancel pending merge
+          {$drop des/desk}                              ::  cancel pending merge
           {$info our/@p des/desk dit/nori}              ::  internal edit
           {$init our/@p}                                ::  report install
           {$into des/desk all/? fis/mode}               ::  external edit

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -531,7 +531,7 @@
           {$wake ~}                                     ::  timer activate
           {$wegh ~}                                     ::  report memory
           {$west p/sack q/path r/*}                     ::  network request
-          {$want p/sock q/path r/*}                     ::  forward message
+          {$want p/ship q/path r/*}                     ::  forward message
       ==                                                ::
     --  ::able
   ::
@@ -2102,7 +2102,7 @@
       $%  [%hiss p=(unit user) q=mark r=cage]           ::  outbound user req
       ==  ==                                            ::
           $:  %a                                        ::
-      $%  [%want p=sock q=path r=*]                     ::  send message
+      $%  [%want p=ship q=path r=*]                     ::  send message
       ==  ==                                            ::
           $:  %j                                        ::
       $%  [%vent-result p=vent-result]                  ::  tmp workaround

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -748,7 +748,7 @@
           {$crow our/ship nom/@ta}                      ::  group usage
           {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$drop des/desk}                              ::  cancel pending merge
-          {$info our/@p des/desk dit/nori}              ::  internal edit
+          {$info des/desk dit/nori}                     ::  internal edit
           {$init our/@p}                                ::  report install
           {$into des/desk all/? fis/mode}               ::  external edit
           $:  $merg                                     ::  merge desks

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1246,9 +1246,6 @@
       $%  ::  %build: perform a build, either live or once
           ::
           $:  %build
-              ::  our: who our ship is (remove after cc-release)
-              ::
-              our=@p
               ::  live: whether we run this build live
               ::
               ::    A live build will subscribe to further updates and keep the

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -480,10 +480,10 @@
       $%  {$flog p/flog:dill}                           ::
       ==  ==                                            ::
           $:  %j                                        ::  to %jael
-      $%  [%meet our=ship who=ship =life =pass]         ::  neighbor
-          [%pubs our=ship who=ship]                     ::  view public keys
+      $%  [%meet =ship =life =pass]                     ::  neighbor
+          [%pubs =ship]                                 ::  view public keys
           [%turf ~]                                     ::  view domains
-          [%vein our=ship]                              ::  view private keys
+          [%vein ~]                                     ::  view private keys
       ==  ==                                            ::
           $:  $g                                        ::  to %gall
       $%  {$deal p/sock q/cush:gall}                    ::
@@ -2109,7 +2109,7 @@
       ==  ==                                            ::
           $:  %j                                        ::
       $%  [%vent-result p=vent-result]                  ::  tmp workaround
-          [%look our=ship src=(each ship purl:eyre)]    ::
+          [%look src=(each ship purl:eyre)]             ::
       ==  ==                                            ::
           $:  @tas                                      ::
       $%  [%init p=ship]                                ::  report install
@@ -2137,8 +2137,8 @@
       action                                            ::  change
     ::
     +=  task                                            ::  in request ->$
-      $%  [%burn our=ship p=ship q=safe]                ::  destroy rights
-          [%hail our=ship p=ship q=remote]              ::  remote update
+      $%  [%burn p=ship q=safe]                         ::  destroy rights
+          [%hail p=ship q=remote]                       ::  remote update
           $:  %dawn                                     ::  boot from keys
               =seed:able:jael                           ::    identity params
               spon=(unit ship)                          ::    sponsor
@@ -2148,21 +2148,21 @@
               node=(unit purl:eyre)                     ::    gateway url
               snap=(unit snapshot)                      ::    head start
           ==                                            ::
-          [%fake our=ship]                              ::  fake boot
-          [%look our=ship src=(each ship purl:eyre)]    ::  set ethereum source
-          [%mint our=ship p=ship q=safe]                ::  create rights
-          [%move our=ship p=ship q=ship r=safe]         ::  transfer from=to
+          [%fake =ship]                                 ::  fake boot
+          [%look src=(each ship purl:eyre)]             ::  set ethereum source
+          [%mint p=ship q=safe]                         ::  create rights
+          [%move p=ship q=ship r=safe]                  ::  transfer from=to
           ::TODO  %next for generating/putting new private key
           [%nuke ~]                                     ::  cancel tracker from
-          [%pubs our=ship who=ship]                     ::  view public keys
-          [%meet our=ship who=ship =life =pass]         ::  met after breach
+          [%pubs =ship]                                 ::  view public keys
+          [%meet =ship =life =pass]                     ::  met after breach
           [%turf ~]                                     ::  view domains
-          [%vein our=ship]                              ::  view signing keys
-          [%vent our=ship]                              ::  view ethereum events
-          [%vest our=ship]                              ::  view public balance
+          [%vein ~]                                     ::  view signing keys
+          [%vent ~]                                     ::  view ethereum events
+          [%vest ~]                                     ::  view public balance
           [%vine ~]                                     ::  view secret history
           [%west p=sack q=path r=*]                     ::  remote request
-          [%wind our=ship p=@ud]                        ::  rewind before block
+          [%wind p=@ud]                                 ::  rewind before block
       ==                                                ::
     --                                                  ::
   ::                                                    ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -489,7 +489,7 @@
       $%  {$deal p/sock q/cush:gall}                    ::
       ==  ==                                            ::
           $:  @tas                                      ::  to any
-      $%  {$west p/sack q/path r/*}                     ::
+      $%  {$west p/ship q/path r/*}                     ::
       ==  ==  ==                                        ::
     ++  gift                                            ::  out result <-$
       $%  {$mack p/(unit tang)}                         ::  acknowledgement
@@ -530,7 +530,7 @@
           {$sunk p=ship q=life}                         ::  report death
           {$wake ~}                                     ::  timer activate
           {$wegh ~}                                     ::  report memory
-          {$west p/sack q/path r/*}                     ::  network request
+          {$west p/ship q/path r/*}                     ::  network request
           {$want p/ship q/path r/*}                     ::  forward message
       ==                                                ::
     --  ::able
@@ -764,8 +764,8 @@
           {$warp wer/sock rif/riff}                     ::  internal file req
           {$werp who/ship wer/sock rif/riff}            ::  external file req
           {$wegh ~}                                    ::  report memory
-          {$went wer/sack pax/path num/@ud ack/coop}    ::  response confirm
-          {$west wer/sack pax/path res/*}               ::  network request
+          {$went wer/ship pax/path num/@ud ack/coop}    ::  response confirm
+          {$west wer/ship pax/path res/*}               ::  network request
       ==                                                ::
     --  ::able
   ::
@@ -1030,8 +1030,8 @@
           [%thud ~]                                     ::  inbound cancel
           [%wegh ~]                                     ::  report memory
           [%well p=path q=(unit mime)]                  ::  put/del .well-known
-          [%went p=sack q=path r=@ud s=coop]            ::  response confirm
-          [%west p=sack q=[path *]]                     ::  network request
+          [%went p=ship q=path r=@ud s=coop]            ::  response confirm
+          [%west p=ship q=[path *]]                     ::  network request
           [%wise p=ship q=prox]                         ::  proxy notification
       ==                                                ::
     --  ::able
@@ -1963,8 +1963,8 @@
           {$init p/ship}                                ::  set owner
           {$deal p/sock q/cush}                         ::  full transmission
           {$sunk p=ship q/life}                         ::  report death
-          {$went p/sack q/path r/@ud s/coop}            ::  response confirm
-          {$west p/sack q/path r/*}                     ::  network request
+          {$went p/ship q/path r/@ud s/coop}            ::  response confirm
+          {$west p/ship q/path r/*}                     ::  network request
           {$wegh ~}                                    ::  report memory
       ==                                                ::
     --  ::able
@@ -2158,7 +2158,7 @@
           [%vent ~]                                     ::  view ethereum events
           [%vest ~]                                     ::  view public balance
           [%vine ~]                                     ::  view secret history
-          [%west p=sack q=path r=*]                     ::  remote request
+          [%west p=ship q=path r=*]                     ::  remote request
           [%wind p=@ud]                                 ::  rewind before block
       ==                                                ::
     --                                                  ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -761,8 +761,8 @@
           {$ogre pot/$@(desk beam)}                     ::  delete mount point
           {$perm des/desk pax/path rit/rite}            ::  change permissions
           {$sunk p=ship q=life}                         ::  report death
-          {$warp wer/sock rif/riff}                     ::  internal file req
-          {$werp who/ship wer/sock rif/riff}            ::  external file req
+          {$warp wer/ship rif/riff}                     ::  internal file req
+          {$werp who/ship wer/ship rif/riff}            ::  external file req
           {$wegh ~}                                    ::  report memory
           {$went wer/ship pax/path num/@ud ack/coop}    ::  response confirm
           {$west wer/ship pax/path res/*}               ::  network request

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -567,17 +567,17 @@
         ryl/(map path rill)                             ::  statements outbound
     ==                                                  ::
   ++  boon                                              ::  fort output
-    $%  {$beer p/sock}                                  ::  request public keys
-        {$bock ~}                                       ::  bind to domains
-        {$brew ~}                                       ::  request domains
-        {$cake p/sock q/soap r/coop s/duct}             ::  e2e message result
-        {$mead p/lane q/rock}                           ::  accept packet
-        {$milk p/sock q/soap r/*}                       ::  e2e pass message
-        {$ouzo p/lane q/rock}                           ::  transmit packet
-        {$pito p/@da}                                   ::  timeout
-        {$raki p/sock q/life r/pass}                    ::  neighbor'd
-        {$sake p/ship}                                  ::  our private keys
-        {$wine p/sock q/tape}                           ::  notify user
+    $%  [%beer p=ship]                                  ::  request public keys
+        [%bock ~]                                       ::  bind to domains
+        [%brew ~]                                       ::  request domains
+        [%cake p=ship q=soap r=coop s=duct]             ::  e2e message result
+        [%mead p=lane q=rock]                           ::  accept packet
+        [%milk p=ship q=soap r=*]                       ::  e2e pass message
+        [%ouzo p=lane q=rock]                           ::  transmit packet
+        [%pito p=@da]                                   ::  timeout
+        [%raki p=ship q=life r=pass]                    ::  neighbor'd
+        [%sake ~]                                       ::  our private keys
+        [%wine p=ship q=tape]                           ::  notify user
     ==                                                  ::
   ++  cake  {p/sock q/skin r/@}                         ::  top level packet
   ++  cape                                              ::  end-to-end result

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -80,7 +80,6 @@
 ++  life  @ud                                           ::  ship version
 ++  mime  {p/mite q/octs}                               ::  mimetyped data
 ++  octs  {p/@ud q/@t}                                  ::  octet-stream
-++  sack  {p/ship q/ship}                               ::  incoming [our his]
 ++  sock  {p/ship q/ship}                               ::  outgoing [our his]
 ::+|
 ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -752,7 +752,7 @@
           {$init our/@p}                                ::  report install
           {$into des/desk all/? fis/mode}               ::  external edit
           $:  $merg                                     ::  merge desks
-              our/@p  des/desk                          ::  target
+              des/desk                                  ::  target
               her/@p  dem/desk  cas/case                ::  source
               how/germ                                  ::  method
           ==                                            ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -759,7 +759,7 @@
           {$mont des/desk bem/beam}                     ::  mount to unix
           {$dirk des/desk}                              ::  mark mount dirty
           {$ogre pot/$@(desk beam)}                     ::  delete mount point
-          {$perm our/ship des/desk pax/path rit/rite}   ::  change permissions
+          {$perm des/desk pax/path rit/rite}            ::  change permissions
           {$sunk p=ship q=life}                         ::  report death
           {$warp wer/sock rif/riff}                     ::  internal file req
           {$werp who/ship wer/sock rif/riff}            ::  external file req

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -742,10 +742,10 @@
           {$wris p/{$da p/@da} q/(set (pair care path))}  ::  many changes
       ==                                                ::
     ++  task                                            ::  in request ->$
-      $%  {$boat ~}                                    ::  pier rebooted
-          {$cred our/ship nom/@ta cew/crew}             ::  set permission group
-          {$crew our/ship}                              ::  permission groups
-          {$crow our/ship nom/@ta}                      ::  group usage
+      $%  {$boat ~}                                     ::  pier rebooted
+          {$cred nom/@ta cew/crew}                      ::  set permission group
+          {$crew ~}                                     ::  permission groups
+          {$crow nom/@ta}                               ::  group usage
           {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$drop des/desk}                              ::  cancel pending merge
           {$info des/desk dit/nori}                     ::  internal edit

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1261,11 +1261,7 @@
           [%keep compiler-cache=@ud build-cache=@ud]
           ::  %kill: stop a build; send on same duct as original %build request
           ::
-          $:  %kill
-              ::  our: who our ship is (remove after cc-release)s
-              ::
-              our=@p
-          ==
+          [%kill ~]
           ::  %sunk: receive a report that a foreign ship has lost continuity
           ::
           [%sunk =ship =life]

--- a/tests/sys/vane/ames.hoon
+++ b/tests/sys/vane/ames.hoon
@@ -20,7 +20,7 @@
     :*  ames-gate
         now=~1234.5.6
         call-args=[hen type=*type %soft %init ~nul]
-        [[hen %pass wir %j %vein ~nul] [hen %pass / %j %turf ~] ~]
+        [[hen %pass wir %j %vein ~] [hen %pass / %j %turf ~] ~]
     ==
   ::
   results1
@@ -33,7 +33,7 @@
       ==
   ^-  [tang _ames-gate]
   ::
-  =/  ames  (ames-gate our=~zod now=now eny=`@`0xdead.beef scry=*sley)
+  =/  ames  (ames-gate our=~nul now=now eny=`@`0xdead.beef scry=*sley)
   ::
   =^  moves  ames-gate
     %-  call:ames  call-args

--- a/tests/sys/vane/clay.hoon
+++ b/tests/sys/vane/clay.hoon
@@ -50,7 +50,7 @@
                 :+  %pass  /castifying/~nul/home/~1111.1.1
                 ^-  note:clay-gate
                 :-  %f
-                [%build ~nul live=%.n [%pin ~1111.1.1 [%list ~]]]
+                [%build live=%.n [%pin ~1111.1.1 [%list ~]]]
             !>  i.moves
         ::
           %+  expect-eq
@@ -60,7 +60,7 @@
                 :+  %pass  /diffing/~nul/home/~1111.1.1
                 ^-  note:clay-gate
                 :-  %f
-                [%build ~nul live=%.n [%pin ~1111.1.1 [%list ~]]]
+                [%build live=%.n [%pin ~1111.1.1 [%list ~]]]
             !>  i.t.moves
         ::
           ^-  tang
@@ -84,9 +84,6 @@
           ::
           ?.  ?=([%f %build *] note)
             [%leaf "bad move, not a %build: {<move>}"]~
-          ::
-          %+  weld
-            (expect-eq !>(~nul) !>(our.note))
           ::
           %+  weld
             (expect-eq !>(%.n) !>(live.note))
@@ -144,9 +141,6 @@
         ::
         ?.  ?=([%f %build *] note)
           [%leaf "bad move, not a %build: {<move>}"]~
-        ::
-        %+  weld
-          (expect-eq !>(~nul) !>(our.note))
         ::
         %+  weld
           (expect-eq !>(%.n) !>(live.note))
@@ -233,9 +227,6 @@
         ::
         ?.  ?=([%f %build *] note)
           [%leaf "bad move, not a %build: {<move>}"]~
-        ::
-        %+  weld
-          (expect-eq !>(~nul) !>(our.note))
         ::
         %+  weld
           (expect-eq !>(%.n) !>(live.note))
@@ -380,7 +371,7 @@
                 :+  %pass  /castifying/~nul/home/~2222.2.2
                 ^-  note:clay-gate
                 :-  %f
-                [%build ~nul live=%.n [%pin ~2222.2.2 [%list ~]]]
+                [%build live=%.n [%pin ~2222.2.2 [%list ~]]]
             !>  i.moves
         ::
           %+  expect-eq
@@ -390,7 +381,7 @@
                 :+  %pass  /diffing/~nul/home/~2222.2.2
                 ^-  note:clay-gate
                 :-  %f
-                [%build ~nul live=%.n [%pin ~2222.2.2 [%list ~]]]
+                [%build live=%.n [%pin ~2222.2.2 [%list ~]]]
             !>  i.t.moves
         ::
           ^-  tang
@@ -414,9 +405,6 @@
           ::
           ?.  ?=([%f %build *] note)
             [%leaf "bad move, not a %build: {<move>}"]~
-          ::
-          %+  weld
-            (expect-eq !>(~nul) !>(our.note))
           ::
           %+  weld
             (expect-eq !>(%.n) !>(live.note))

--- a/tests/sys/vane/clay.hoon
+++ b/tests/sys/vane/clay.hoon
@@ -27,7 +27,7 @@
       ^=  call-args
         :+  duct=~[/info]  type=-:!>(*task:able:clay)
         ^-  task:able:clay
-        :^  %info  ~nul  %home
+        :+  %info  %home
         ^-  nori:clay
         :-  %&
         ^-  soba:clay
@@ -306,7 +306,7 @@
       ^=  call-args
         :+  duct=~[/info2]  type=-:!>(*task:able:clay)
         ^-  task:able:clay
-        :^  %info  ~nul  %home
+        :+  %info  %home
         ^-  nori:clay
         :-  %&
         ^-  soba:clay

--- a/tests/sys/vane/clay.hoon
+++ b/tests/sys/vane/clay.hoon
@@ -451,7 +451,7 @@
       ==
   ^-  [tang _clay-gate]
   ::
-  =/  clay-core  (clay-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  clay-core  (clay-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  clay-gate  (call:clay-core call-args)
   ::
@@ -472,7 +472,7 @@
       ==
   ^-  [tang _clay-gate]
   ::
-  =/  clay-core  (clay-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  clay-core  (clay-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  clay-gate  (call:clay-core call-args)
   ::
@@ -490,7 +490,7 @@
       ==
   ^-  [tang _clay-gate]
   ::
-  =/  clay-core  (clay-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  clay-core  (clay-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  clay-gate  (take:clay-core take-args)
   ::
@@ -511,7 +511,7 @@
       ==
   ^-  [tang _clay-gate]
   ::
-  =/  clay-core  (clay-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  clay-core  (clay-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  clay-gate  (take:clay-core take-args)
   ::

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -559,7 +559,7 @@
       ::  send a pinned literal, expects a %made response with pinned literal
       ::
       ^=  call-args
-        [duct=~ type=~ %build ~nul live=%.n [%$ %noun !>(**)]]
+        [duct=~ type=~ %build live=%.n [%$ %noun !>(**)]]
       ::
       ^=  moves
         :~  :*  duct=~  %give  %made  ~1234.5.6
@@ -581,7 +581,7 @@
       ::  if we autocons the same schematic, we should get two of it as a result
       ::
       ^=  call-args
-        :*  duct=~  type=~  %build  ~nul  live=%.n
+        :*  duct=~  type=~  %build  live=%.n
             [[%$ %noun !>(**)] [%$ %noun !>(**)]]
         ==
       ::
@@ -606,7 +606,7 @@
       :: if we autocons different schematics, we get different values
       ::
       ^=  call-args
-        :*  duct=~  type=~  %build  ~nul  live=%.n
+        :*  duct=~  type=~  %build  live=%.n
             [[%$ %noun !>(42)] [%$ %noun !>(43)]]
         ==
       ::
@@ -631,7 +631,7 @@
       ::  test a pinned scry which succeeds
       ::
       ^=  call-args
-        :*  duct=~  type=~  %build  ~nul  live=%.n
+        :*  duct=~  type=~  %build  live=%.n
             [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -654,7 +654,7 @@
       ::  attempting to scry a path which fails should produce an error
       ::
       ^=  call-args
-        :*  duct=~  type=~  %build  ~nul  live=%.n
+        :*  duct=~  type=~  %build  live=%.n
             [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -679,7 +679,7 @@
       ::  when we scry on a blocked path, expect a subscription move
       ::
       ^=  call-args
-        :*  duct=~  type=~  %build  ~nul  live=%.n
+        :*  duct=~  type=~  %build  live=%.n
             [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -724,7 +724,7 @@
       ::  when we scry on a blocked path, expect a subscription move
       ::
       ^=  call-args
-        :*  duct=~[/one]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/one]  type=~  %build  live=%.n
             [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -743,7 +743,7 @@
       ::  when we scry on a blocked path, expect a subscription move
       ::
       ^=  call-args
-        :*  duct=~[/two]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/two]  type=~  %build  live=%.n
             [%pin ~1234.5.6 [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]]
         ==
       ::
@@ -788,7 +788,7 @@
       ::  when we scry on a blocked path, expect a subscription move
       ::
       ^=  call-args
-        :*  duct=~[/one]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/one]  type=~  %build  live=%.n
             [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -828,7 +828,7 @@
       scry=(scry-succeed ~1234.5.6 [%noun !>(42)])
       ::
       ^=  call-args
-        :*  duct=~[/first]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/first]  type=~  %build  live=%.y
             [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -892,7 +892,7 @@
       ::  perform a live scry, we should get a %made and a clay subscription
       ::
       ^=  call-args
-        :*  duct=~[/first]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/first]  type=~  %build  live=%.y
             [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -912,7 +912,7 @@
       scry=(scry-succeed ~1234.5.7 [%noun !>(42)])
       ::
       ^=  call-args
-        :*  duct=~[/second]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/second]  type=~  %build  live=%.y
             [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -980,7 +980,7 @@
       now=~1234.5.6
       scry=(scry-blocks blocks)
       ::
-      call-args=[duct=~[/first] type=~ %build ~nul live=%.y autocons]
+      call-args=[duct=~[/first] type=~ %build live=%.y autocons]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -1068,7 +1068,7 @@
       now=~1234.5.6
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/pin] type=~ %build ~nul live=%.n schematic]
+      call-args=[duct=~[/pin] type=~ %build live=%.n schematic]
       ::
       ^=  expected-moves
         :~  :*  duct=~[/pin]  %give  %made  ~1234.5.6  %complete
@@ -1086,7 +1086,7 @@
       now=~1234.5.6
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/pin] type=~ %build ~nul live=%.n schematic]
+      call-args=[duct=~[/pin] type=~ %build live=%.n schematic]
       ::
       ^=  expected-moves
         :~  :*  duct=~[/pin]  %give  %made  ~1234.5.6  %complete
@@ -1103,7 +1103,7 @@
       scry=(scry-succeed ~1234.5.6 [%noun !>(42)])
       ::
       ^=  call-args
-        :*  duct=~[/pinned-in-pin]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/pinned-in-pin]  type=~  %build  live=%.n
             %pin  ~1234.5.7
             %pin  ~1234.5.6
             [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]
@@ -1140,7 +1140,7 @@
       now=~1234.5.6
       scry=scry-42
       ::
-      call-args=[duct=~[/live] type=~ %build ~nul live=%.y schematic]
+      call-args=[duct=~[/live] type=~ %build live=%.y schematic]
       moves=[duct=~[/live] %give %made ~1234.5.6 %complete result]~
     ==
   ::
@@ -1173,7 +1173,7 @@
       scry=scry-blocked
       ::
       ^=  call-args
-        :*  duct=~[/live]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/live]  type=~  %build  live=%.y
             [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -1259,7 +1259,7 @@
       scry=scry-blocked
       ::
       ^=  call-args
-        :*  duct=~[/live]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/live]  type=~  %build  live=%.y
             [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -1277,7 +1277,7 @@
       scry=scry-blocked
       ::
       ^=  call-args
-        :*  duct=~[/once]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/once]  type=~  %build  live=%.n
             [%pin ~1234.5.6 [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]]
         ==
       ::
@@ -1341,7 +1341,7 @@
       scry=scry-42
       ::
       ^=  call-args
-        :*  duct=~[/two-deep-4u]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/two-deep-4u]  type=~  %build  live=%.y
             [%same [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]]
         ==
       ::
@@ -1426,7 +1426,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/ride] type=~ %build ~nul live=%.y same]
+      call-args=[duct=~[/ride] type=~ %build live=%.y same]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %give  %made  ~1234.5.6  %complete
@@ -1502,7 +1502,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/ride] type=~ %build ~nul live=%.y autocons]
+      call-args=[duct=~[/ride] type=~ %build live=%.y autocons]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %give  %made  ~1234.5.6  %complete  %success
@@ -1590,7 +1590,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/static] type=~ %build ~nul live=%.y static]
+      call-args=[duct=~[/static] type=~ %build live=%.y static]
       ::
       ^=  moves
         :~  :*  duct=~[/static]  %give  %made  ~1234.5.6  %complete  %success
@@ -1604,7 +1604,7 @@
       now=~1234.5.7
       scry=scry
       ::
-      call-args=[duct=~[/autocons] type=~ %build ~nul live=%.y autocons]
+      call-args=[duct=~[/autocons] type=~ %build live=%.y autocons]
       ::
       ^=  moves
         :~  :*  duct=~[/autocons]  %give  %made  ~1234.5.7  %complete  %success
@@ -1661,7 +1661,7 @@
       now=~1234.5.6
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/call] type=~ %build ~nul live=%.y call-schematic]
+      call-args=[duct=~[/call] type=~ %build live=%.y call-schematic]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -1709,7 +1709,7 @@
       now=~1234.5.6
       scry=scry-42
       ::
-      call-args=[duct=~[/call] type=~ %build ~nul live=%.y call-schematic]
+      call-args=[duct=~[/call] type=~ %build live=%.y call-schematic]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -1757,7 +1757,7 @@
       now=~1234.5.6
       scry=scry-failed
       ::
-      call-args=[duct=~[/dead] type=~ %build ~nul live=%.y call-schematic]
+      call-args=[duct=~[/dead] type=~ %build live=%.y call-schematic]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -1809,7 +1809,7 @@
       now=~1234.5.6
       scry=scry-blocked
       ::
-      call-args=[duct=~[/live] type=~ %build ~nul live=%.y call-schematic]
+      call-args=[duct=~[/live] type=~ %build live=%.y call-schematic]
       ::
       ^=  moves
         :~  :*  duct=~[/live]  %pass
@@ -1901,7 +1901,7 @@
       scry=scry
       ::
       ^=  call-args
-        [duct=~[/call] type=~ %build ~nul live=%.y call-schematic]
+        [duct=~[/call] type=~ %build live=%.y call-schematic]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -1992,7 +1992,7 @@
       now=~1234.5.6
       scry=scry-42
       ::
-      call-args=[duct=~[/once] type=~ %build ~nul live=%.n schematic]
+      call-args=[duct=~[/once] type=~ %build live=%.n schematic]
       ::
       ^=  moves
         :~  :*  duct=~[/once]  %give  %made  ~1234.5.6  %complete  %success
@@ -2019,7 +2019,7 @@
       now=~1234.5.6
       scry=scry-42
       ::
-      call-args=[duct=~[/once] type=~ %build ~nul live=%.n schematic]
+      call-args=[duct=~[/once] type=~ %build live=%.n schematic]
       ::
       ^=  moves
         :~  :*  duct=~[/once]  %give  %made  ~1234.5.6  %complete
@@ -2055,7 +2055,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/hood] type=~ %build ~nul live=%.y schematic]
+      call-args=[duct=~[/hood] type=~ %build live=%.y schematic]
       ::
       ^=  moves
         :~  :*  duct=~[/hood]  %give  %made  ~1234.5.6
@@ -2106,7 +2106,7 @@
       scry=scry-is-forbidden
       ::
       ^=  call-args
-        [duct=~[/dead] type=~ %build ~nul live=%.y [%slim subject-type formula]]
+        [duct=~[/dead] type=~ %build live=%.y [%slim subject-type formula]]
       ::
       ^=  moves
         :~  :*  duct=~[/dead]  %give  %made  ~1234.5.6  %complete
@@ -2141,7 +2141,7 @@
       now=~1234.5.6
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/slit] type=~ %build ~nul live=%.y [%slit gate sample]]
+      call-args=[duct=~[/slit] type=~ %build live=%.y [%slit gate sample]]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -2188,7 +2188,7 @@
       now=~1234.5.6
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/slit] type=~ %build ~nul live=%.y [%slit gate sample]]
+      call-args=[duct=~[/slit] type=~ %build live=%.y [%slit gate sample]]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -2243,7 +2243,7 @@
       scry=scry-is-forbidden
       ::
       ^=  call-args
-        :*  duct=~[/dead]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/dead]  type=~  %build  live=%.y
             [%ride formula subject-schematic]
         ==
       ::
@@ -2289,7 +2289,7 @@
       scry=scry-42
       ::
       ^=  call-args
-        :*  duct=~[/dead]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/dead]  type=~  %build  live=%.y
             [%ride formula subject-schematic]
         ==
       ::
@@ -2335,7 +2335,7 @@
       scry=scry-failed
       ::
       ^=  call-args
-        :*  duct=~[/dead]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/dead]  type=~  %build  live=%.y
             [%ride formula subject-schematic]
         ==
       ::
@@ -2385,7 +2385,7 @@
       scry=scry-blocked
       ::
       ^=  call-args
-        :*  duct=~[/live]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/live]  type=~  %build  live=%.y
             [%ride formula subject-schematic]
         ==
       ::
@@ -2465,7 +2465,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/ride] type=~ %build ~nul live=%.y ride]
+      call-args=[duct=~[/ride] type=~ %build live=%.y ride]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %give  %made  ~1234.5.6  %complete
@@ -2557,7 +2557,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/post-a] type=~ %build ~nul live=%.y rendered-a]
+      call-args=[duct=~[/post-a] type=~ %build live=%.y rendered-a]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -2588,7 +2588,7 @@
       now=~1234.5.7
       scry=scry
       ::
-      call-args=[duct=~[/post-b] type=~ %build ~nul live=%.y rendered-b]
+      call-args=[duct=~[/post-b] type=~ %build live=%.y rendered-b]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -2731,7 +2731,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/alts] type=~ %build ~nul live=%.y alts]
+      call-args=[duct=~[/alts] type=~ %build live=%.y alts]
       ::
       ^=  moves
         :~  :*  duct=~[/alts]  %give  %made  ~1234.5.6  %complete  %error
@@ -2849,7 +2849,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/same] type=~ %build ~nul live=%.y same]
+      call-args=[duct=~[/same] type=~ %build live=%.y same]
       ::
       ^=  moves
         :~  :*  duct=~[/same]  %give  %made  ~1234.5.6  %complete
@@ -2873,7 +2873,7 @@
       now=~1234.5.7
       scry=scry
       ::
-      call-args=[duct=~[/alts] type=~ %build ~nul live=%.y alts]
+      call-args=[duct=~[/alts] type=~ %build live=%.y alts]
       ::
       ^=  moves
         :~  :*  duct=~[/alts]  %give  %made  ~1234.5.7  %complete
@@ -2999,7 +2999,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/first] type=~ %build ~nul live=%.y alts1]
+      call-args=[duct=~[/first] type=~ %build live=%.y alts1]
       ::
       ^=  moves
         :~  :*  duct=~[/first]  %give  %made  ~1234.5.6  %complete
@@ -3017,7 +3017,7 @@
       now=~1234.5.7
       scry=scry
       ::
-      call-args=[duct=~[/second] type=~ %build ~nul live=%.y alts2]
+      call-args=[duct=~[/second] type=~ %build live=%.y alts2]
       ::
       ^=  moves
         :~  :*  duct=~[/second]  %give  %made  ~1234.5.7  %complete
@@ -3119,7 +3119,7 @@
       ::  send a pinned literal, expects a %made response with pinned literal
       ::
       ^=  call-args
-        [duct=~[/trivial] type=~ %build ~nul live=%.n [%$ %noun !>(**)]]
+        [duct=~[/trivial] type=~ %build live=%.n [%$ %noun !>(**)]]
       ::
       ^=  moves
         :~  :*  duct=~[/trivial]  %give  %made  ~1234.5.6
@@ -3155,7 +3155,7 @@
       scry=(scry-succeed ~1234.5.6 [%noun !>(42)])
       ::
       ^=  call-args
-        :*  duct=~[/build]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/build]  type=~  %build  live=%.y
             [%scry %c care=%x rail=[[~nul %desk] /bar/foo]]
         ==
       ::
@@ -3251,7 +3251,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/ride] type=~ %build ~nul live=%.y same]
+      call-args=[duct=~[/ride] type=~ %build live=%.y same]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %give  %made  ~1234.5.6  %complete
@@ -3357,7 +3357,7 @@
       now=~1234.5.6
       scry=scry
       ::
-      call-args=[duct=~[/post-a] type=~ %build ~nul live=%.y rendered-a]
+      call-args=[duct=~[/post-a] type=~ %build live=%.y rendered-a]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -3387,7 +3387,7 @@
       now=~1234.5.7
       scry=scry
       ::
-      call-args=[duct=~[/post-b] type=~ %build ~nul live=%.y rendered-b]
+      call-args=[duct=~[/post-b] type=~ %build live=%.y rendered-b]
       ::
       ^=  comparator
         |=  moves=(list move:ford-gate)
@@ -3579,7 +3579,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/reef]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/reef]  type=~  %build  live=%.n
             [%reef [~nul %base]]
         ==
       ::
@@ -3622,7 +3622,7 @@
       scry=(scry-reef ~1234.5.6)
       ::
       ^=  call-args
-        :*  duct=~[/reef]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/reef]  type=~  %build  live=%.n
             [%reef [~nul %home]]
         ==
       ::
@@ -3674,7 +3674,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%path disc=[~nul %desk] prefix='lib' raw-path='foo-bar']
         ==
       ::
@@ -3699,7 +3699,7 @@
       scry=scry-is-forbidden
       ::
       ^=  call-args
-        :*  duct=~[/plan]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/plan]  type=~  %build  live=%.n
             %plan
             source-path=[[~nul %home] /bar/foo]
             query-string=`coin`[%$ *dime]
@@ -3750,7 +3750,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/foo-bar/lib]]
         ==
       ::
@@ -3809,7 +3809,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -3861,7 +3861,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -3906,7 +3906,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -3954,7 +3954,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -3999,7 +3999,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -4037,7 +4037,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -4086,7 +4086,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -4135,7 +4135,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -4179,7 +4179,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :*  %plan  [[~nul %home] /other/lib]  *coin
                 :*  source-rail=[[~nul %desk] /bar/foo]
                     zuse-version=309
@@ -4249,7 +4249,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             %core  [[~nul %home] /hoon/program/gen]
         ==
       ::
@@ -4302,7 +4302,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -4361,7 +4361,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -4407,7 +4407,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :*  %plan  [[~nul %home] /other/lib]
                 :~  %many
                     [%blob *cred:eyre]
@@ -4509,7 +4509,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/gen]]
         ==
       ::
@@ -4585,7 +4585,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             %core  [[~nul %home] /hoon/program/gen]
         ==
       ::
@@ -4645,7 +4645,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             %core  [[~nul %home] /hoon/program/gen]
         ==
       ::
@@ -4692,7 +4692,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%bunt [~nul %home] %foo]
         ==
       ::
@@ -4740,7 +4740,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%volt [~nul %home] %foo [12 13]]
         ==
       ::
@@ -4788,7 +4788,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%vale [~nul %home] %foo [12 13]]
         ==
       ::
@@ -4836,7 +4836,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%vale [~nul %home] %foo 42]
         ==
       ::
@@ -4900,7 +4900,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%cast [~nul %home] %foo [%vale [~nul %home] %bar [12 13]]]
         ==
       ::
@@ -4971,7 +4971,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%cast [~nul %home] %foo [%vale [~nul %home] %bar [12 13]]]
         ==
       ::
@@ -5005,7 +5005,7 @@
       scry=scry-is-forbidden
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             %mute  subject=[%$ %foo !>([a=42 b=[43 c=44]])]
             ^=  mutations  ^-  (list [wing schematic:ford-gate])
             :~
@@ -5061,7 +5061,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%bake %foo *coin `rail:ford-gate`[[~nul %home] /data]]
         ==
       ::
@@ -5137,7 +5137,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%bake %foo *coin `rail:ford-gate`[[~nul %home] /data]]
         ==
       ::
@@ -5208,7 +5208,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             [%bake %dat *coin `rail:ford-gate`[[~nul %home] /data]]
         ==
       ::
@@ -5263,7 +5263,7 @@
       ::
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :^  %diff  [~nul %home]
               [%$ %foo !>([12 13])]
             [%$ %foo !>([17 18])]
@@ -5337,7 +5337,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :^  %diff  [~nul %home]
               [%$ %txt !>(~[%a %b])]
             [%$ %txt !>(~[%a %d])]
@@ -5416,7 +5416,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :^  %pact  [~nul %home]
               [%$ %txt !>(~[%a %b])]
             [%$ %txt-diff !>(~[[%& 1] [%| ~[%b] ~[%d]]])]
@@ -5515,7 +5515,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :^  %pact  [~nul %home]
               :+  %$  %foo  !>
               '''
@@ -5574,7 +5574,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :^  %join  [~nul %home]  %txt
             ::  replace %a with %c on the first line
             ::
@@ -5646,7 +5646,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             :^  %join  [~nul %home]  %hoon
             ::  replace %a with %c on the first line
             ::
@@ -5687,7 +5687,7 @@
       scry=scry-is-forbidden
       ::
       ^=  call-args
-        :*  duct=~[/count]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/count]  type=~  %build  live=%.n
             %list
             :~  [%$ %noun ud-type 1]
                 [%$ %noun ud-type 2]
@@ -5732,7 +5732,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/path]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/path]  type=~  %build  live=%.n
             ^-  schematic:ford-gate
             :-  %mash
             :^  [~nul %home]  %txt
@@ -5855,7 +5855,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/gh]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/gh]  type=~  %build  live=%.y
             %core  [[~nul %home] /hoon/gh/app]
         ==
       ::
@@ -5987,7 +5987,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/gh2]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/gh2]  type=~  %build  live=%.y
             %core  [[~nul %home] /hoon/gh2/app]
         ==
       ::
@@ -6132,7 +6132,7 @@
       scry=(scry-with-results-and-failures scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/gh3]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/gh3]  type=~  %build  live=%.y
             %core  [[~nul %home] /hoon/gh3/app]
         ==
       ::
@@ -6523,7 +6523,7 @@
       scry=(scry-with-results scry-results)
       ::
       ^=  call-args
-        :*  duct=~[/walk]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/walk]  type=~  %build  live=%.y
             %walk  [~nul %home]  %one  %two
         ==
       ::
@@ -6572,7 +6572,7 @@
       scry=(scry-with-results large-mark-graph)
       ::
       ^=  call-args
-        :*  duct=~[/walk]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/walk]  type=~  %build  live=%.y
             %walk  [~nul %home]  %one  %four
         ==
       ::
@@ -6624,7 +6624,7 @@
       scry=(scry-with-results large-mark-graph)
       ::
       ^=  call-args
-        :*  duct=~[/large]  type=~  %build  ~nul  live=%.n
+        :*  duct=~[/large]  type=~  %build  live=%.n
             [%cast [~nul %home] %four [%volt [~nul %home] %one ["one" 1]]]
         ==
       ^=  comparator
@@ -6733,7 +6733,7 @@
       ::
       ^=  call-args
         ^-  [=duct type=* wrapped-task=(hobo task:able:ford-gate)]
-        :*  duct=~[/app]  type=~  %build  ~nul  live=%.y
+        :*  duct=~[/app]  type=~  %build  live=%.y
             [%core source-path=`rail:ford-gate`[[~nul %home] /hoon/program/app]]
         ==
       ::

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -805,7 +805,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/one] type=~ %kill ~nul]
+      call-args=[duct=~[/one] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/one]  %pass
@@ -868,7 +868,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/first] type=~ %kill ~nul]
+      call-args=[duct=~[/first] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
@@ -931,7 +931,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/first] type=~ %kill ~nul]
+      call-args=[duct=~[/first] type=~ %kill ~]
       ^=  moves
         :~  :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
                 %c  %warp  [~nul ~nul]  %desk  ~
@@ -943,7 +943,7 @@
       now=~1234.5.9
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/second] type=~ %kill ~nul]
+      call-args=[duct=~[/second] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/second]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
@@ -1045,7 +1045,7 @@
       now=~1234.5.9
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/first] type=~ %kill ~nul]
+      call-args=[duct=~[/first] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -1150,7 +1150,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/live] type=~ %kill ~nul]
+      call-args=[duct=~[/live] type=~ %kill ~]
       moves=~
     ==
   ::
@@ -1232,7 +1232,7 @@
       now=~1234.5.9
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/live] type=~ %kill ~nul]
+      call-args=[duct=~[/live] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/live]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
@@ -1314,7 +1314,7 @@
       now=~1234.5.9
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/live] type=~ %kill ~nul]
+      call-args=[duct=~[/live] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/live]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
@@ -1383,7 +1383,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/two-deep-4u] type=~ %kill ~nul]
+      call-args=[duct=~[/two-deep-4u] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/two-deep-4u]  %pass
@@ -1461,7 +1461,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/ride] type=~ %kill ~nul]
+      call-args=[duct=~[/ride] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
@@ -1542,7 +1542,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/ride] type=~ %kill ~nul]
+      call-args=[duct=~[/ride] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
@@ -1622,7 +1622,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/static] type=~ %kill ~nul]
+      call-args=[duct=~[/static] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -1633,7 +1633,7 @@
       now=~1234.5.9
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/autocons] type=~ %kill ~nul]
+      call-args=[duct=~[/autocons] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/autocons]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.7
@@ -1682,7 +1682,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/call] type=~ %kill ~nul]
+      call-args=[duct=~[/call] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -1731,7 +1731,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/call] type=~ %kill ~nul]
+      call-args=[duct=~[/call] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -1781,7 +1781,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/dead] type=~ %kill ~nul]
+      call-args=[duct=~[/dead] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -1849,7 +1849,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/live] type=~ %kill ~nul]
+      call-args=[duct=~[/live] type=~ %kill ~]
       moves=~
     ==
   ::
@@ -1963,7 +1963,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/call] type=~ %kill ~nul]
+      call-args=[duct=~[/call] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/call]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
@@ -2081,7 +2081,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/hood] type=~ %kill ~nul]
+      call-args=[duct=~[/hood] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/hood]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
@@ -2119,7 +2119,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/dead] type=~ %kill ~nul]
+      call-args=[duct=~[/dead] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -2166,7 +2166,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/slit] type=~ %kill ~nul]
+      call-args=[duct=~[/slit] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -2219,7 +2219,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/slit] type=~ %kill ~nul]
+      call-args=[duct=~[/slit] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -2265,7 +2265,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/dead] type=~ %kill ~nul]
+      call-args=[duct=~[/dead] type=~ %kill ~]
       moves=~
     ==
   ::
@@ -2311,7 +2311,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/dead] type=~ %kill ~nul]
+      call-args=[duct=~[/dead] type=~ %kill ~]
       moves=~
     ==
   ::
@@ -2361,7 +2361,7 @@
       now=~1234.5.7
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/dead] type=~ %kill ~nul]
+      call-args=[duct=~[/dead] type=~ %kill ~]
       moves=~
     ==
   ::
@@ -2428,7 +2428,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/live] type=~ %kill ~nul]
+      call-args=[duct=~[/live] type=~ %kill ~]
       moves=~
     ==
   ::
@@ -2500,7 +2500,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/ride] type=~ %kill ~nul]
+      call-args=[duct=~[/ride] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
@@ -2669,7 +2669,7 @@
       now=~1234.5.10
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/post-a] type=~ %kill ~nul]
+      call-args=[duct=~[/post-a] type=~ %kill ~]
       ::
       moves=~
     ==
@@ -2680,7 +2680,7 @@
       now=~1234.5.11
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/post-b] type=~ %kill ~nul]
+      call-args=[duct=~[/post-b] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/post-a]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
@@ -2800,7 +2800,7 @@
       now=~1234.5.9
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/alts] type=~ %kill ~nul]
+      call-args=[duct=~[/alts] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.8
@@ -2920,7 +2920,7 @@
       now=~1234.5.9
       scry=scry
       ::
-      call-args=[duct=~[/same] type=~ %kill ~nul]
+      call-args=[duct=~[/same] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/same]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
@@ -2933,7 +2933,7 @@
       now=~1234.5.10
       scry=scry
       ::
-      call-args=[duct=~[/alts] type=~ %kill ~nul]
+      call-args=[duct=~[/alts] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
@@ -3078,7 +3078,7 @@
       now=~1234.5.10
       scry=scry
       ::
-      call-args=[duct=~[/first] type=~ %kill ~nul]
+      call-args=[duct=~[/first] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.9
@@ -3091,7 +3091,7 @@
       now=~1234.5.11
       scry=scry
       ::
-      call-args=[duct=~[/second] type=~ %kill ~nul]
+      call-args=[duct=~[/second] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/second]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
@@ -3208,7 +3208,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/build] type=~ %kill ~nul]
+      call-args=[duct=~[/build] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/build]  %pass  wire=/~nul/clay-sub/~nul/desk
@@ -3299,7 +3299,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/ride] type=~ %kill ~nul]
+      call-args=[duct=~[/ride] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk
@@ -3509,7 +3509,7 @@
       now=~1234.5.10
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/post-b] type=~ %kill ~nul]
+      call-args=[duct=~[/post-b] type=~ %kill ~]
       moves=~
     ==
   ::
@@ -3519,7 +3519,7 @@
       now=~1234.5.11
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/post-a] type=~ %kill ~nul]
+      call-args=[duct=~[/post-a] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/post-a]  %pass  wire=/~nul/clay-sub/~nul/desk
@@ -6425,7 +6425,7 @@
       now=~1234.5.10
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/gh] type=~ %kill ~nul]
+      call-args=[duct=~[/gh] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/gh]  %pass  /~nul/clay-sub/~nul/home/~1234.5.9
@@ -6438,7 +6438,7 @@
       now=~1234.5.11
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/gh2] type=~ %kill ~nul]
+      call-args=[duct=~[/gh2] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/gh2]  %pass  /~nul/clay-sub/~nul/home/~1234.5.9
@@ -6451,7 +6451,7 @@
       now=~1234.5.12
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/gh3] type=~ %kill ~nul]
+      call-args=[duct=~[/gh3] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/gh3]  %pass  /~nul/clay-sub/~nul/home/~1234.5.9
@@ -6550,7 +6550,7 @@
       now=~1234.5.6
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/walk] type=~ %kill ~nul]
+      call-args=[duct=~[/walk] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/walk]  %pass  /~nul/clay-sub/~nul/home/~1234.5.6
@@ -6601,7 +6601,7 @@
       now=~1234.5.6
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/walk] type=~ %kill ~nul]
+      call-args=[duct=~[/walk] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/walk]  %pass  /~nul/clay-sub/~nul/home/~1234.5.6
@@ -6984,7 +6984,7 @@
       now=~1234.5.8
       scry=scry-is-forbidden
       ::
-      call-args=[duct=~[/app] type=~ %kill ~nul]
+      call-args=[duct=~[/app] type=~ %kill ~]
       ::
       ^=  moves
         :~  :*  duct=~[/app]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.8

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -686,7 +686,7 @@
       ^=  moves
         :~  :*  duct=~  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
     ==  ==  ==
   ::
@@ -731,7 +731,7 @@
       ^=  moves
         :~  :*  duct=~[/one]  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
     ==  ==  ==
   ::
@@ -795,7 +795,7 @@
       ^=  moves
         :~  :*  duct=~[/one]  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
     ==  ==  ==
   ::
@@ -810,7 +810,7 @@
       ^=  moves
         :~  :*  duct=~[/one]  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -837,7 +837,7 @@
                 [%scry %noun !>(42)]
             ==
             :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -858,7 +858,7 @@
                 [%scry %noun !>(43)]
             ==
             :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -872,7 +872,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -901,7 +901,7 @@
                 [%scry %noun !>(42)]
             ==
             :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -921,7 +921,7 @@
                 [%scry %noun !>(42)]
             ==
             :*  duct=~[/second]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -934,7 +934,7 @@
       call-args=[duct=~[/first] type=~ %kill ~]
       ^=  moves
         :~  :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   =^  results4  ford-gate
@@ -947,7 +947,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/second]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -990,12 +990,12 @@
           !>  %-  sy
               :~  :*  duct=~[/first]  %pass
                       wire=/~nul/scry-request/cx/~nul/desk/~1234.5.7/foo/bar
-                      %c  %warp  [~nul ~nul]  %desk
+                      %c  %warp  ~nul  %desk
                       `[%sing %x [%da ~1234.5.7] /foo/bar]
                   ==
                   :*  duct=~[/first]  %pass
                       wire=/~nul/scry-request/cx/~nul/desk/~1234.5.8/foo/bar
-                      %c  %warp  [~nul ~nul]  %desk
+                      %c  %warp  ~nul  %desk
                       `[%sing %x [%da ~1234.5.8] /foo/bar]
               ==  ==
           !>  (sy moves)
@@ -1180,7 +1180,7 @@
       ^=  moves
         :~  :*  duct=~[/live]  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
     ==  ==  ==
   ::
@@ -1201,7 +1201,7 @@
                 [%scry %noun !>(42)]
             ==
             :*  duct=~[/live]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -1222,7 +1222,7 @@
                 [%scry %noun !>(43)]
             ==
             :*  duct=~[/live]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.8] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -1236,7 +1236,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/live]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -1266,7 +1266,7 @@
       ^=  moves
         :~  :*  duct=~[/live]  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
     ==  ==  ==
   ::
@@ -1301,7 +1301,7 @@
                 [%success [%scry %noun !>(42)]]
             ==
             :*  duct=~[/live]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar]~)]
             ==
             :*  duct=~[/once]  %give  %made  ~1234.5.7  %complete
@@ -1318,7 +1318,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/live]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -1351,7 +1351,7 @@
             ==
             :*  duct=~[/two-deep-4u]  %pass
                 wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -1373,7 +1373,7 @@
             ==
             :*  duct=~[/two-deep-4u]  %pass
                 wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -1388,7 +1388,7 @@
       ^=  moves
         :~  :*  duct=~[/two-deep-4u]  %pass
                 wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -1433,7 +1433,7 @@
                 [%success [%ride scry-type %constant]]
             ==
             :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -1451,7 +1451,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -1465,7 +1465,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -1510,7 +1510,7 @@
                 [%success [%scry %noun !>(%it-does-in-fact-matter)]]
             ==
             :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -1532,7 +1532,7 @@
                 [%success [%scry %noun !>(%changed)]]
             ==
             :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -1546,7 +1546,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -1612,7 +1612,7 @@
                 [%success [%scry %noun scry-type %it-does-in-fact-matter]]
             ==
             :*  duct=~[/autocons]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.7
-                %c  %warp  [~nul ~nul]  %home
+                %c  %warp  ~nul  %home
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -1637,7 +1637,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/autocons]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.7
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -1814,7 +1814,7 @@
       ^=  moves
         :~  :*  duct=~[/live]  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
     ==  ==  ==
   ::
@@ -1918,7 +1918,7 @@
         ::
         %+  expect-eq
           !>  :*  duct=~[/call]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                  %c  %warp  [~nul ~nul]  %desk
+                  %c  %warp  ~nul  %desk
                   `[%mult [%da ~1234.5.6] (sy [%x /timer] ~)]
               ==
           !>  i.t.moves
@@ -1951,7 +1951,7 @@
         ::
         %+  expect-eq
           !>  :*  duct=~[/call]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                  %c  %warp  [~nul ~nul]  %desk
+                  %c  %warp  ~nul  %desk
                   `[%mult [%da ~1234.5.7] (sy [%x /timer] ~)]
               ==
           !>  i.t.moves
@@ -1967,7 +1967,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/call]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -2071,7 +2071,7 @@
                               (ream '|=(a=@ud +(a))')
             ==  ==    ==  ==
             :*  duct=~[/hood]  %pass  /~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar/hoon] ~)]
     ==  ==  ==
   ::
@@ -2085,7 +2085,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/hood]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -2392,7 +2392,7 @@
       ^=  moves
         :~  :*  duct=~[/live]  %pass
                 wire=/~nul/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
     ==  ==  ==
   ::
@@ -2472,7 +2472,7 @@
                 [%success [%ride scry-type %constant]]
             ==
             :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -2490,7 +2490,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -2504,7 +2504,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -2576,7 +2576,7 @@
         %+  expect-eq
           !>  :*  duct=~[/post-a]  %pass
                   wire=/~nul/clay-sub/~nul/desk/~1234.5.6  %c  %warp
-                  [~nul ~nul]  %desk
+                  ~nul  %desk
                   `[%mult [%da ~1234.5.6] (sy [%x /posts/a] [%x /posts/b] ~)]
               ==
           !>  i.t.moves
@@ -2607,7 +2607,7 @@
         %+  expect-eq
           !>  :*  duct=~[/post-b]  %pass
                   wire=/~nul/clay-sub/~nul/desk/~1234.5.7  %c  %warp
-                  [~nul ~nul]  %desk
+                  ~nul  %desk
                   `[%mult [%da ~1234.5.7] (sy [%x /posts/a] [%x /posts/b] ~)]
               ==
           !>  i.t.moves
@@ -2642,7 +2642,7 @@
         %+  expect-eq
           !>  :*  duct=~[/post-a]  %pass
                   wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                  %c  %warp  [~nul ~nul]  %desk
+                  %c  %warp  ~nul  %desk
                   `[%mult [%da ~1234.5.8] (sy [%x /posts/a] [%x /posts/b] ~)]
               ==
           !>  i.t.moves
@@ -2684,7 +2684,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/post-a]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -2748,7 +2748,7 @@
                     ==
             ==  ==
             :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.6
-                %c  %warp  [~nul ~nul]  %home
+                %c  %warp  ~nul  %home
                 `[%mult [%da ~1234.5.6] (sy [%x /scry/two] [%x /scry/one] ~)]
     ==  ==  ==
   ::
@@ -2769,7 +2769,7 @@
                 %success  %alts  %success  %scry  %noun  scry-type  'scry-two'
             ==
             :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.7
-                %c  %warp  [~nul ~nul]  %home
+                %c  %warp  ~nul  %home
                 `[%mult [%da ~1234.5.7] (sy [%x /scry/two] [%x /scry/one] ~)]
     ==  ==  ==
   ::
@@ -2790,7 +2790,7 @@
                 %success  %alts  %success  %scry  %noun  scry-type  'scry-one'
             ==
             :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.8
-                %c  %warp  [~nul ~nul]  %home
+                %c  %warp  ~nul  %home
                 `[%mult [%da ~1234.5.8] (sy [%x /scry/one] ~)]
     ==  ==  ==
   ::
@@ -2804,7 +2804,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.8
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -2856,7 +2856,7 @@
                 %success  %scry  %noun  scry-type  'scry-two'
             ==
             :*  duct=~[/same]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /scry/two] ~)]
     ==  ==  ==
   ::
@@ -2880,7 +2880,7 @@
                 %success  %alts  %success  %scry  %noun  scry-type  'scry-two'
             ==
             :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /scry/two] [%x /scry/one] ~)]
     ==  ==  ==
   ::
@@ -2905,7 +2905,7 @@
             ::  we subscribe to both paths because /same still exists.
             ::
             :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.8] (sy [%x /scry/one] ~)]
     ==  ==  ==
   ::
@@ -2924,7 +2924,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/same]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   =^  results5  ford-gate
@@ -2937,7 +2937,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/alts]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -3006,7 +3006,7 @@
                 %success  %alts  %success  %scry  %noun  scry-type  'scry-two'
             ==
             :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.6
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /scry/one] [%x /scry/two] ~)]
     ==  ==  ==
   ::  alts2 will depend on both scry3 and scry2
@@ -3024,7 +3024,7 @@
                 %success  %alts  %success  %scry  %noun  scry-type  'scry-two'
             ==
             :*  duct=~[/second]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.7
-                %c  %warp  [~nul ~nul]  %desk  ~  %mult  [%da ~1234.5.7]
+                %c  %warp  ~nul  %desk  ~  %mult  [%da ~1234.5.7]
                 (sy [%x /scry/two] [%x /scry/three] ~)
     ==  ==  ==
   ::
@@ -3047,7 +3047,7 @@
                 %success  %alts  %success  %scry  %noun  scry-type  'scry-three'
             ==
             :*  duct=~[/second]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                %c  %warp  [~nul ~nul]  %desk  ~  %mult  [%da ~1234.5.8]
+                %c  %warp  ~nul  %desk  ~  %mult  [%da ~1234.5.8]
                 (sy [%x /scry/three] ~)
     ==  ==  ==
   ::
@@ -3068,7 +3068,7 @@
                 %success  %alts  %success  %scry  %noun  scry-type  'scry-one'
             ==
             :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.9
-                %c  %warp  [~nul ~nul]  %desk  ~  %mult  [%da ~1234.5.9]
+                %c  %warp  ~nul  %desk  ~  %mult  [%da ~1234.5.9]
                 (sy [%x /scry/one] ~)
     ==  ==  ==
   ::
@@ -3082,7 +3082,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/first]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.9
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   =^  results6  ford-gate
@@ -3095,7 +3095,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/second]  %pass  wire=/~nul/clay-sub/~nul/desk/~1234.5.8
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -3164,7 +3164,7 @@
                 [%scry %noun !>(42)]
             ==
             :*  duct=~[/build]  %pass  wire=/~nul/clay-sub/~nul/desk
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -3198,7 +3198,7 @@
                 [%scry %noun !>(43)]
             ==
             :*  duct=~[/build]  %pass  wire=/~nul/clay-sub/~nul/desk
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar]~)]
     ==  ==  ==
   ::
@@ -3212,7 +3212,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/build]  %pass  wire=/~nul/clay-sub/~nul/desk
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -3258,7 +3258,7 @@
                 [%success [%ride scry-type %constant]]
             ==
             :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.6] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -3289,7 +3289,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk
-                %c  %warp  [~nul ~nul]  %desk
+                %c  %warp  ~nul  %desk
                 `[%mult [%da ~1234.5.7] (sy [%x /foo/bar] ~)]
     ==  ==  ==
   ::
@@ -3303,7 +3303,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/ride]  %pass  wire=/~nul/clay-sub/~nul/desk
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -3375,7 +3375,7 @@
           ==
         %+  expect-eq
           !>  :*  duct=~[/post-a]  %pass  wire=/~nul/clay-sub/~nul/desk
-                  %c  %warp  [~nul ~nul]  %desk
+                  %c  %warp  ~nul  %desk
                   `[%mult [%da ~1234.5.6] (sy [%x /posts/a] [%x /posts/b] ~)]
               ==
           !>  i.t.moves
@@ -3523,7 +3523,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/post-a]  %pass  wire=/~nul/clay-sub/~nul/desk
-                %c  %warp  [~nul ~nul]  %desk  ~
+                %c  %warp  ~nul  %desk  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -5890,7 +5890,7 @@
         %+  expect-eq
           !>  ^-  move:ford-gate
               :*  duct=~[/gh]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.6
-                  %c  %warp  [~nul ~nul]  %home
+                  %c  %warp  ~nul  %home
                   `[%mult [%da ~1234.5.6] files]
               ==
           !>  i.t.moves
@@ -6022,7 +6022,7 @@
         %+  expect-eq
           !>  ^-  move:ford-gate
               :*  duct=~[/gh2]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.7
-                  %c  %warp  [~nul ~nul]  %home
+                  %c  %warp  ~nul  %home
                   `[%mult [%da ~1234.5.7] files]
               ==
           !>  i.t.moves
@@ -6167,7 +6167,7 @@
         %+  expect-eq
           !>  ^-  move:ford-gate
               :*  duct=~[/gh3]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.8
-                  %c  %warp  [~nul ~nul]  %home
+                  %c  %warp  ~nul  %home
                   `[%mult [%da ~1234.5.8] files]
               ==
           !>  i.t.moves
@@ -6313,7 +6313,7 @@
           %+  expect-eq
             !>  ^-  move:ford-gate
                 :*  duct=~[/gh]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.9
-                    %c  %warp  [~nul ~nul]  %home
+                    %c  %warp  ~nul  %home
                     `[%mult [%da ~1234.5.9] files]
                 ==
             !>  i.t.moves
@@ -6363,7 +6363,7 @@
           %+  expect-eq
             !>  ^-  move:ford-gate
                 :*  duct=~[/gh2]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.9
-                    %c  %warp  [~nul ~nul]  %home
+                    %c  %warp  ~nul  %home
                     `[%mult [%da ~1234.5.9] files]
                 ==
             !>  i.t.moves
@@ -6413,7 +6413,7 @@
           %+  expect-eq
             !>  ^-  move:ford-gate
                 :*  duct=~[/gh3]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.9
-                    %c  %warp  [~nul ~nul]  %home
+                    %c  %warp  ~nul  %home
                     `[%mult [%da ~1234.5.9] files]
                 ==
             !>  i.t.moves
@@ -6429,7 +6429,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/gh]  %pass  /~nul/clay-sub/~nul/home/~1234.5.9
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   =^  results8  ford-gate
@@ -6442,7 +6442,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/gh2]  %pass  /~nul/clay-sub/~nul/home/~1234.5.9
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   =^  results9  ford-gate
@@ -6455,7 +6455,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/gh3]  %pass  /~nul/clay-sub/~nul/home/~1234.5.9
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -6535,7 +6535,7 @@
             ==
             ^-  move:ford-gate
             :*  duct=~[/walk]  %pass  /~nul/clay-sub/~nul/home/~1234.5.6
-                %c  %warp  [~nul ~nul]  %home  ~  %mult  [%da ~1234.5.6]
+                %c  %warp  ~nul  %home  ~  %mult  [%da ~1234.5.6]
                 %-  sy  :~
                   [%x /mar/two/hoon]
                   [%x /mar/one/hoon]
@@ -6554,7 +6554,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/walk]  %pass  /~nul/clay-sub/~nul/home/~1234.5.6
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -6584,7 +6584,7 @@
             ==
             ^-  move:ford-gate
             :*  duct=~[/walk]  %pass  /~nul/clay-sub/~nul/home/~1234.5.6
-                %c  %warp  [~nul ~nul]  %home  ~  %mult  [%da ~1234.5.6]
+                %c  %warp  ~nul  %home  ~  %mult  [%da ~1234.5.6]
                 %-  sy  :~
                   [%x /mar/one/hoon]
                   [%x /mar/two/hoon]
@@ -6605,7 +6605,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/walk]  %pass  /~nul/clay-sub/~nul/home/~1234.5.6
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   ;:  weld
@@ -6988,7 +6988,7 @@
       ::
       ^=  moves
         :~  :*  duct=~[/app]  %pass  wire=/~nul/clay-sub/~nul/home/~1234.5.8
-                %c  %warp  [~nul ~nul]  %home  ~
+                %c  %warp  ~nul  %home  ~
     ==  ==  ==
   ::
   ;:  weld

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -7261,7 +7261,7 @@
       ==
   ^-  [tang _ford-gate]
   ::
-  =/  ford  (ford-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  ford  (ford-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  ford-gate
     %-  call:ford  call-args
@@ -7282,7 +7282,7 @@
       ==
   ^-  [tang _ford-gate]
   ::
-  =/  ford  (ford-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  ford  (ford-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  ford-gate
     %-  take:ford  take-args
@@ -7307,7 +7307,7 @@
       ==
   ^-  [tang _ford-gate]
   ::
-  =/  ford  (ford-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  ford  (ford-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  ford-gate
     %-  call:ford  call-args
@@ -7326,7 +7326,7 @@
       ==
   ^-  [tang _ford-gate]
   ::
-  =/  ford  (ford-gate our=~zod now=now eny=`@`0xdead.beef scry=scry)
+  =/  ford  (ford-gate our=~nul now=now eny=`@`0xdead.beef scry=scry)
   ::
   =^  moves  ford-gate
     %-  take:ford  take-args
@@ -7363,7 +7363,7 @@
     ==
   ::
   =/  ford  *ford-gate
-  =/  state  (~(got by state-by-ship.ax.+>+<.ford) ship)
+  =/  state  state.ax.+>+<.ford
   ::
   =/  default-state  *ford-state:ford
   ::

--- a/tests/sys/vane/jael.hoon
+++ b/tests/sys/vane/jael.hoon
@@ -41,7 +41,7 @@
     %-  jael-call-with-comparator  :*
       jael-gate
       now=(add ~s1 ~1234.5.6)
-      call-args=[duct=[/ /term/1 wir ~] type=*type %vein ~nul]
+      call-args=[duct=[/ /term/1 wir ~] type=*type %vein ~]
       ^=  comparator
         |=  moves=(list move:jael-gate)
         ;:  weld
@@ -89,7 +89,7 @@
       ==
   ^-  [tang _jael-gate]
   ::
-  =/  jael  (jael-gate our=~zod now=now eny=`@`0xdead.beef scry=*sley)
+  =/  jael  (jael-gate our=~nul now=now eny=`@`0xdead.beef scry=*sley)
   ::
   =^  moves  jael-gate
     %-  call:jael  call-args
@@ -109,7 +109,7 @@
       ==
   ^-  [tang _jael-gate]
   ::
-  =/  jael  (jael-gate our=~zod now=now eny=`@`0xdead.beef scry=*sley)
+  =/  jael  (jael-gate our=~nul now=now eny=`@`0xdead.beef scry=*sley)
   ::
   =^  moves  jael-gate
     %-  call:jael  call-args
@@ -126,7 +126,7 @@
       ==
   ^-  [tang _jael-gate]
   ::
-  =/  jael  (jael-gate our=~zod now=now eny=`@`0xdead.beef scry=*sley)
+  =/  jael  (jael-gate our=~nul now=now eny=`@`0xdead.beef scry=*sley)
   ::
   =^  moves  jael-gate
     %-  take:jael  take-args
@@ -146,7 +146,7 @@
       ==
   ^-  [tang _jael-gate]
   ::
-  =/  jael  (jael-gate our=~zod now=now eny=`@`0xdead.beef scry=*sley)
+  =/  jael  (jael-gate our=~nul now=now eny=`@`0xdead.beef scry=*sley)
   ::
   =^  moves  jael-gate
     %-  take:jael  take-args


### PR DESCRIPTION
The Costello to #915's Abbott. This removes all the multi-homing indirection in the state, state-machines, and moves of all the vanes. The closes thing to an exception is `%gall`'s `%deal` task, which takes a pair of ships, but uses them alternatively for bidirectional communication.

I've tested networking, syncing/merging, and cross-ship app pokes in a number of scenarios, but there's obviously still risk involved in making this many changes across this many places. Drive-by reviews of the area one knows best would be greatly appreciated.