### PR TITLE
removes !: from vanes

### DIFF
--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -1,4 +1,3 @@
-!:
 ::  ford: build system vane
 ::
 ::    Ford is a functional reactive build system.

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1,4 +1,4 @@
-!:                                                      ::  /van/jael
+::                                                      ::  /van/jael
 ::                                                      ::  %reference/0
 !?  150
 ::


### PR DESCRIPTION
I think it was already in %jael, but I mistakenly added `!:` to %ford in #941.