### PR TITLE
Fix arvo ova order

### DIFF
--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -550,9 +550,10 @@
     |=  {lac/? mor/(list muse)}
     =|  ova/(list ovum)
     |-  ^-  {p/(list ovum) q=(list [label=@tas =vane])}
-    ?~  mor  [(flop ova) vanes]
+    ?~  mor
+      [ova vanes]
     =^  nyx  vanes  (jack lac i.mor)
-    $(ova (weld p.nyx ova), mor (weld q.nyx t.mor))
+    $(ova (weld ova p.nyx), mor (weld t.mor q.nyx))
   --
 --
 =<  ::  Arvo larval stage

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -553,6 +553,8 @@
     ?~  mor
       [ova vanes]
     =^  nyx  vanes  (jack lac i.mor)
+    ::  we emit ova to unix in fifo order, but emit internal moves depth-first
+    ::
     $(ova (weld ova p.nyx), mor (weld q.nyx t.mor))
   --
 --

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -553,7 +553,7 @@
     ?~  mor
       [ova vanes]
     =^  nyx  vanes  (jack lac i.mor)
-    $(ova (weld ova p.nyx), mor (weld t.mor q.nyx))
+    $(ova (weld ova p.nyx), mor (weld q.nyx t.mor))
   --
 --
 =<  ::  Arvo larval stage


### PR DESCRIPTION
Behn is sensitive to the order in which ova are emitted, which was not
correct. Previously, ova emitted first within a single vane activation
were processed as effects last.