### PR TITLE
fixes %clay sync merges for planets

### DIFF
--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -388,19 +388,25 @@
       ~
     =.  let  ?.  ?=($w p.p.u.rot)  let  ud:((hard cass:clay) q.q.r.u.rot)
     =/  =wire  /kiln/sync/[syd]/(scot %p her)/[sud]
-    =/  =cass  .^(cass:clay %cw /(scot %p our)/[syd]/(scot %da now))
+    ::  germ: merge mode for sync merges
     ::
-    ::    If we will be syncing in remote changes, we need all our sync merges
-    ::    up to and including the first remote sync to use the %init germ.
-    ::    Otherwise we won't have a merge-base with our sponsor.
+    ::    Initial merges from any source must use the %init germ.
+    ::    Subsequent merges may use any germ, but if the source is
+    ::    a remote ship with which we have not yet merged, we won't
+    ::    share a merge-base commit and all germs but %that will fail.
     ::
-    =/  bar=@ud
-      ?:  ?|  ?=(?($czar $pawn) (clan:title our))
-              !?=(%home syd)
-          ==
-        2
-      3
-    =/  =germ  ?:((gte bar ud.cass) %init %mate)
+    ::    We want to always use %that for the first remote merge.
+    ::    But we also want local syncs (%base to %home or %kids)
+    ::    to succeed after that first remote sync. To accomplish both
+    ::    we simply use %that for the first three sync merges.
+    ::    (The first two are from the pill.)
+    ::
+    =/  =germ
+      =/  =cass
+        .^(cass:clay %cw /(scot %p our)/[syd]/(scot %da now))
+      ?:  =(0 ud.cass)
+        %init
+      ?:((gth 3 ud.cass) %that %mate)
     =<  %-  spam
         ?:  =(our her)  ~
         [(render "beginning sync" sud her syd) ~]

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1805,49 +1805,52 @@
         ==
     ^+  +>
     =<  wake
-    =+  ^-  nut/(map tako yaki)
-        %-  molt  ^-  (list (pair tako yaki))
-        %+  turn  ~(tap in lar)
-        |=  yak/yaki
-        [r.yak yak]
-    =+  ^-  nat/(map lobe blob)
-        %-  molt  ^-  (list (pair lobe blob))
-        %+  turn  ~(tap in bar)
-        |=  bol/blob
-        [p.bol bol]
-    ~|  :*  %bad-foreign-update
-            :*  gar=gar
-                let=let
-                nut=(~(run by nut) ,~)
-                nat=(~(run by nat) ,~)
+    ::  hit: updated commit-hashes by @ud case
+    ::
+    =/  hit  (~(uni by hit.dom) gar)
+    ::  nut: new commit-hash/commit pairs
+    ::
+    =/  nut
+      (turn ~(tap in lar) |=(=yaki [r.yaki yaki]))
+    ::  hut: updated commits by hash
+    ::
+    =/  hut  (~(gas by hut.ran) nut)
+    ::  nat: new blob-hash/blob pairs
+    ::
+    =/  nat
+      (turn ~(tap in bar) |=(=blob [p.blob blob]))
+    ::  lat: updated blobs by hash
+    ::
+    =/  lat  (~(gas by lat.ran) nat)
+    ::  traverse updated state and sanity check
+    ::
+    =+  ~|  :*  %bad-foreign-update
+                [gar=gar let=let nut=(turn nut head) nat=(turn nat head)]
+                [hitdom=hit.dom letdom=let.dom]
             ==
-            :*  hitdom=hit.dom
-                letdom=let.dom
-                hutran=(~(run by hut.ran) ,~)
-                latran=(~(run by lat.ran) ,~)
-            ==
-        ==
-    =+  hit=(~(uni by hit.dom) gar)
-    =+  let=let
-    =+  hut=(~(uni by hut.ran) nut)
-    =+  lat=(~(uni by lat.ran) nat)
-    =+  ?:  =(0 let)  ~
-        =+  yon=`aeon`1                                 ::  sanity check
-        |-
-        ~|  yon=yon
-        =+  tak=(~(got by hit) yon)
-        =+  yak=(~(got by hut) tak)
-        =+  %-  ~(urn by q.yak)
-            |=  {pax/path lob/lobe}
-            ~|  [pax=path lob=lobe]
-            (~(got by lat) lob)
-        ?:  =(let yon)
+      ?:  =(0 let)
+        ~
+      =/  =aeon  1
+      |-  ^-  ~
+      =/  =tako
+        ~|  [%missing-aeon aeon]  (~(got by hit) aeon)
+      =/  =yaki
+        ~|  [%missing-tako tako]  (~(got by hut) tako)
+      =+  %+  turn
+            ~(tap by q.yaki)
+          |=  [=path =lobe]
+          ~|  [%missing-blob path lobe]
+          ?>  (~(has by lat) lobe)
           ~
-        $(yon +(yon))
+      ?:  =(let aeon)
+        ~
+      $(aeon +(aeon))
+    ::  persist updated state
+    ::
     %=  +>.$
+      let.dom   (max let let.dom)
       lim       (max (fall lem lim) lim)
       hit.dom   hit
-      let.dom   (max let let.dom)
       hut.ran   hut
       lat.ran   lat
     ==


### PR DESCRIPTION
by using `%that` instead of %init for sync merges into desks at cases 1-3. This fixes broken planet clay syncs on boot, a bug which was introduced with the new pill format in #909.

The error messages in `+apply-foreign-update` were broken, this also fixes them and refactors the function.
