### PR TITLE
drop fewer packets

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -515,8 +515,10 @@
     ++  deed
       ~/  %deed
       |=  [who=ship lyf=life]
-      ;;  ^deed
-      %-  need  %-  need
+      ^-  (unit ^deed)
+      =;  ded
+        ?~(ded ~ u.ded)
+      ;;  (unit (unit ^deed))
       %-  (sloy-light ski)
       =/  pur=spur
         /(scot %ud lyf)/(scot %p who)
@@ -564,7 +566,7 @@
           law.ton
         ::  save our deed (for comet/moon communication)
         ::
-        (deed our life)
+        (need (deed our life))
       ::
           val.ton
         ::  save our secrets, ready for action

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -811,38 +811,53 @@
           ++  chew                                      ::    chew:la:ho:um:am
             |=  [sin=skin msg=@]                        ::  receive
             ^+  +>
-            =<  apse
+            =<  abed
             |%
-            ++  apse
+            ::  +abed: check that we have the keys to communicate with :her
+            ::
+            ++  abed
               ^+  +>.$
-              ::  bos: our sponsor
-              ::
-              =/  bos  (sein our)
-              ::  seg:  her sponsor
-              ::
-              =/  seg  (sein her)
-              ::  rac:  her rank
-              ::
-              =/  rac  (clan:title her)
-              ::  request keys and continue processing packet if
-              ::  :her is our initial sponsor (TOFU)
+              ::  if we don't have a deed, subscribe for public key updates
               ::
               ::    XX update state so we only ask once?
               ::
-              =?  +>.$  &(=(~ lew.wod.dur.diz) =(her bos))
+              =?  +>.$  ?=(~ lew.wod.dur.diz)
                 (emit %beer her)
-              ::  request keys and drop packet if :her is (or is a moon of)
-              ::  an unfamilar on-chain ship (and not our sponsor)
+              ::  if we don't have a deed, scry for it
+              ::  (to avoid dropping the packet, if possible).
               ::
-              ?:  ?&  =(~ lew.wod.dur.diz)
-                      !=(her bos)
-                      ?|  !?=(?(%earl %pawn) rac)
-                          ?&  ?=(%earl rac)
-                              =/  fod  (~(get by hoc.ton.fox) seg)
-                              ?|  ?=(~ fod)
-                                  ?=(~ lew.wod.u.fod)
-                  ==  ==  ==  ==
-                (emit %beer ?:(?=(%earl rac) seg her))
+              =?  lew.wod.dur.diz  ?=(~ lew.wod.dur.diz)
+                ::  we could get the life from the packet if %open
+                ::  for now, we guess 1 for the life
+                ::  XX revise
+                ::
+                (deed her 1)
+              ::  if we have a deed, proceed
+              ::
+              ?^  lew.wod.dur.diz
+                apse
+              ::  if :her is our initial sponsor, proceed (TOFU)
+              ::
+              ::    XX TOFU is unnecessary if we include keys
+              ::    for the full sponsorship chain in the boot event
+              ::
+              ?:  =(her (sein our))
+                apse
+              ::  if :her is a comet, or a moon of a known ship, proceed
+              ::
+              =/  =rank:title  (clan:title her)
+              ?:  ?|  ?=(%pawn rank)
+                      ?&  ?=(%earl rank)
+                          !=(~ lew.wod.dur:(myx:gus (sein her)))
+                  ==  ==
+                apse
+              ::  otherwise, drop the packet
+              ::
+              +>.$
+            ::  +apse: process the packet, notify if :her status changed
+            ::
+            ++  apse
+              ^+  +>.$
               =/  oub  bust:puz
               =/  neg  =(~ yed.caq.dur.diz)
               =.  +>.$  east

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -2298,12 +2298,15 @@
       [u.lyf pub:ex:cub sig.own.sub.lex]
     ::
     =/  pub  (~(get by kyz.puk.sub.lex) u.who)
-    ?~  pub  ~
-    :: XX check lyf
-    ::
+    ?~  pub
+      ~
+    ?:  (gth u.lyf life.u.pub)
+      ~
+    =/  pas  (~(get by pubs.u.pub) u.lyf)
+    ?~  pas
+      ~
     :^  ~  ~  %noun
-    !>  ^-  deed:ames
-    [life.u.pub (~(got by pubs.u.pub) life.u.pub) ~]
+    !>  `deed:ames`[u.lyf u.pas ~]
   ::
       %earl
     ?.  ?=([@ @ @ ~] tyl)  [~ ~]


### PR DESCRIPTION
by scrying into `%jael` for public keys when meeting new ships. Also cleans up `%ames` packet acceptance.