### PR TITLE
Eyre clean up outgoing requests on restart

### DIFF
--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -762,11 +762,31 @@
         $them                                           ::  outbound request
       ?~  p.kyz
         =+  sud=(need (~(get by kes) hen))
-        %=  +>.$
-          mow    :_(mow [ged [%give %thus sud ~]])
-          q.ask  (~(del by q.ask) sud)
-          kes    (~(del by kes) hen)
-        ==
+        =.  +>.$
+          %_  +>.$
+            mow    :_(mow [ged [%give %thus sud ~]])
+            q.ask  (~(del by q.ask) sud)
+            kes    (~(del by kes) hen)
+          ==
+        ::
+        =/  driver=(unit [key=[user (list @t)] val=driv])
+          =/  drivers  ~(tap by sec)
+          |-  ^-  (unit [key=[user (list @t)] val=driv])
+          ?~  drivers  ~
+          ::
+          ?~  q=req.q.q.i.drivers
+            $(drivers t.drivers)
+          ::
+          ?~  tip=~(top to q)
+            $(drivers t.drivers)
+          ::
+          ?:  =(hen p.u.tip)
+            `i.drivers
+          $(drivers t.drivers)
+        ::
+        ?~  driver
+          +>.$
+        ~(cancel-request vi u.driver)
       ::  ~&  eyre-them+(en-purl p.u.p.kyz)
       %=  +>.$
         mow    :_(mow [ged [%give %thus p.ask p.kyz]])
@@ -2193,6 +2213,9 @@
       |=  res/vase
       =.  liv  |  :: block requests until a reponse is given
       (eyre-them wir (slam !>(|=({$send a/hiss} a)) res))
+    ::
+    ++  cancel-request  ~&  %cancel-request
+                        (dead-hiss(liv &) [leaf+"canceled"]~)
     ::
     ++  handle-moves
       |=  a/(list {p/term q/$-(vase _abet)})


### PR DESCRIPTION
Eyre used to reach an inconsistent state if it received the %born event on Vere restart. This PR makes sure we properly unqueue each request from the security driver that emitted it, if there was one.

This work was done with @joemfb