### PR TITLE
removes the last of old %ames ack move %went

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3901,10 +3901,6 @@
       (start-request:den for u.q.rif)
     [mos ..^$]
   ::
-      $went
-    ::  this won't happen until we send responses.
-    !!
-  ::
       $west
     =*  wer  wer.req
     =*  pax  pax.req

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -39,8 +39,7 @@
           ==  ==  ==                                    ::
 ++  sign                                                ::  in result $<-
           $%  $:  $a                                    ::  by %ames
-          $%  {$woot p/ship q/coop}              ::  acknowledgment
-              {$went ship cape:ames}                   ::  XX ignore
+          $%  {$woot p/ship q/coop}                     ::  acknowledgment
           ==  ==                                        ::
               $:  $b                                    ::  by %behn
           $%  {$wake ~}                                ::  timer activate
@@ -840,10 +839,6 @@
         $well
       +>.$(wel (dank wel p.kyz q.kyz))
     ::
-        $went
-      ::  this won't happen until we send responses.
-      !!
-    ::
         $west                                           ::  remote request
       =.  mow  :_(mow [hen %give %mack ~])
       ::  TODO: make +gram and %west play nicely together
@@ -943,11 +938,6 @@
     ::    (emule |.(~|(gall-dumb+tee !!)))
     ::
         $woot  +>.$
-        $went
-          :: XX eyre sends no wests, so should get no wents
-          ::~&  e+unexpected+sih
-          +>.$
-    ::
     ::
         $thou
       ?+    -.tee  !!

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1069,8 +1069,6 @@
         (ap-lame %pour (ap-suck "pour: malformed card"))
       =^  cug  +>.$  (ap-find [-.q.vax pax])
       ?~  cug
-        ?:  =(-.q.vax %went)
-          +>.$
         (ap-lame -.q.vax (ap-suck "pour: no {(trip -.q.vax)}: {<pax>}"))
       =^  tel  vel  (~(slot wa vel) 3 vax)
       =^  cam  +>.$
@@ -1342,8 +1340,6 @@
       ==
     =/  =move  [hen %give %mass %gall %| [mass ~]]
     [[move ~] ..^$]
-  ::  
-      $went  !!   ::  XX fixme
   ==
 ::
 ++  load                                                ::  recreate vane

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -484,8 +484,7 @@
           {$sunk p=ship q=life}                         ::  report death
           {$warp wer/ship rif/riff}                     ::  internal file req
           {$werp who/ship wer/ship rif/riff}            ::  external file req
-          {$wegh ~}                                    ::  report memory
-          {$went wer/ship pax/path num/@ud ack/coop}    ::  response confirm
+          {$wegh ~}                                     ::  report memory
           {$west wer/ship pax/path res/*}               ::  network request
       ==                                                ::
     --  ::able
@@ -751,7 +750,6 @@
           [%thud ~]                                     ::  inbound cancel
           [%wegh ~]                                     ::  report memory
           [%well p=path q=(unit mime)]                  ::  put/del .well-known
-          [%went p=ship q=path r=@ud s=coop]            ::  response confirm
           [%west p=ship q=[path *]]                     ::  network request
           [%wise p=ship q=prox]                         ::  proxy notification
       ==                                                ::
@@ -1677,9 +1675,8 @@
           {$init p/ship}                                ::  set owner
           {$deal p/sock q/cush}                         ::  full transmission
           {$sunk p=ship q/life}                         ::  report death
-          {$went p/ship q/path r/@ud s/coop}            ::  response confirm
           {$west p/ship q/path r/*}                     ::  network request
-          {$wegh ~}                                    ::  report memory
+          {$wegh ~}                                     ::  report memory
       ==                                                ::
     --  ::able
   ++  bitt  (map bone (pair ship path))                 ::  incoming subs


### PR DESCRIPTION
%ames no longer sends %went, but %clay, %gall, and %eyre still had (stubbed out) handlers for it. Closes #47.