### PR TITLE
Update Azimuth event handling to account for updated indexing

### DIFF
--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7323,8 +7323,8 @@
       `[who %activated who]
     ::
     ?:  =(event.log spawned)
-      =/  pre=@  (decode-topics topics.log ~[%uint])
-      =/  who=@  (decode-results data.log ~[%uint])
+      =+  ^-  [pre=@ who=@]
+          (decode-topics topics.log ~[%uint %uint])
       `[pre %spawned who]
     ::
     ?:  =(event.log escape-requested)
@@ -7342,7 +7342,8 @@
       `[who %sponsor `wer]
     ::
     ?:  =(event.log lost-sponsor)
-      =/  who=@  (decode-topics topics.log ~[%uint])
+      =+  ^-  [who=@ pos=@]
+          (decode-topics topics.log ~[%uint %uint])
       `[who %sponsor ~]
     ::
     ?:  =(event.log changed-keys)


### PR DESCRIPTION
Event signatures hadn't changed, but some arguments had become indexed. This affects event parsing.