### PR TITLE
Treat sponsorship like it's treated on-chain

### DIFF
--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -69,7 +69,7 @@
 ++  note-jael                                           ::
   $%  $:  %dawn                                         ::  boot from keys
           =seed:able:jael                               ::    identity params
-          spon=(unit ship)                              ::    sponsor
+          spon=ship                                     ::    sponsor
           czar=(map ship [=life =pass])                 ::    galaxy table
           turf=(list turf)                              ::    domains
           bloq=@ud                                      ::    block number

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -637,11 +637,8 @@
     =/  pot  (~(get by pos.eth.sub) who)
     ?:  ?&  ?=(^ pot)
             ?=(^ net.u.pot)
-            ?=(^ sponsor.u.net.u.pot)
         ==
-      u.sponsor.u.net.u.pot
-    ::  XX fall back to most recent sponsor instead?
-    ::
+      who.sponsor.u.net.u.pot
     (^sein:title who)
   ::                                                    ::  ++saxo:of
   ++  saxo                                              ::  sponsorship chain
@@ -670,7 +667,7 @@
     ::  boot from keys
     ::    $:  $dawn
     ::        =seed
-    ::        spon=(unit ship)
+    ::        spon=ship
     ::        czar=(map ship [=life =pass])
     ::        turf=(list turf)}
     ::        bloq=@ud

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -8447,7 +8447,7 @@
       ::
       ?.  ?=(%1 lyf.seed)
         [%| %invalid-life]
-      [%& ~marzod]  ::TODO  how to do comet sponsorship?
+      [%& (^sein:title who.seed)]
     ::
         %earl
       ::  a moon must be signed by the parent

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7323,8 +7323,8 @@
       `[who %activated who]
     ::
     ?:  =(event.log spawned)
-      =/  pre=@  (decode-topics topics.log ~[%uint])
-      =/  who=@  (decode-results data.log ~[%uint])
+      =+  ^-  [pre=@ who=@]
+          (decode-topics topics.log ~[%uint %uint])
       `[pre %spawned who]
     ::
     ?:  =(event.log escape-requested)
@@ -7342,7 +7342,8 @@
       `[who %sponsor `wer]
     ::
     ?:  =(event.log lost-sponsor)
-      =/  who=@  (decode-topics topics.log ~[%uint])
+      =+  ^-  [who=@ pos=@]
+          (decode-topics topics.log ~[%uint %uint])
       `[who %sponsor ~]
     ::
     ?:  =(event.log changed-keys)

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -148,7 +148,7 @@
         $:  =life
             =pass
             continuity-number=@ud
-            sponsor=(unit @p)  ::TODO  doesn't 100% reflect chain state
+            sponsor=[has=? who=@p]
             escape=(unit @p)
         ==
       ::
@@ -175,7 +175,7 @@
         [%spawned who=@p]                           ::  Spawned
         [%keys =life =pass]                         ::  ChangedKeys
         [%continuity new=@ud]                       ::  BrokeContinuity
-        [%sponsor new=(unit @p)]                    ::  EscapeAcc/LostSpons
+        [%sponsor new=[has=? who=@p]]               ::  EscapeAcc/LostSpons
         [%escape new=(unit @p)]                     ::  EscapeReq/Can
         [%management-proxy new=address]             ::  ChangedManagementPro
         [%voting-proxy new=address]                 ::  ChangedVotingProxy
@@ -1848,7 +1848,7 @@
           [%hail p=ship q=remote]                       ::  remote update
           $:  %dawn                                     ::  boot from keys
               =seed:able:jael                           ::    identity params
-              spon=(unit ship)                          ::    sponsor
+              spon=ship                                 ::    sponsor
               czar=(map ship [=life =pass])             ::    galaxy table
               turf=(list turf)                          ::    domains
               bloq=@ud                                  ::    block number
@@ -7290,8 +7290,7 @@
         ::
           continuity-number
         ::
-          ?.  has-sponsor  ~
-          ``@p`sponsor
+          [has-sponsor `@p`sponsor]
         ::
           ?.  escape-requested  ~
           ``@p`escape-to
@@ -7339,12 +7338,12 @@
     ?:  =(event.log escape-accepted)
       =+  ^-  [who=@ wer=@]
           (decode-topics topics.log ~[%uint %uint])
-      `[who %sponsor `wer]
+      `[who %sponsor & wer]
     ::
     ?:  =(event.log lost-sponsor)
       =+  ^-  [who=@ pos=@]
           (decode-topics topics.log ~[%uint %uint])
-      `[who %sponsor ~]
+      `[who %sponsor | pos]
     ::
     ?:  =(event.log changed-keys)
       =/  who=@  (decode-topics topics.log ~[%uint])
@@ -7395,7 +7394,7 @@
     ::
         %activated
       %_  pot
-        net  `[0 0 0 `(^sein:title who.dif) ~]
+        net  `[0 0 0 &^(^sein:title who.dif) ~]
         kid  ?.  ?=(?(%czar %king) (clan:title who.dif))  ~
              `[0x0 ~]
       ==
@@ -7416,8 +7415,10 @@
         pot(life.u.net life.dif, pass.u.net pass.dif)
       ::
           %sponsor
-        ?~  new.dif  pot(sponsor.u.net ~)
-        pot(sponsor.u.net new.dif, escape.u.net ~)
+        %=  pot
+          sponsor.u.net  new.dif
+          escape.u.net   ?:(has.new.dif ~ escape.u.net.pot)
+        ==
       ::
         %continuity  pot(continuity-number.u.net new.dif)
         %escape      pot(escape.u.net new.dif)
@@ -8429,7 +8430,7 @@
   ::
   ++  veri
     |=  [=seed:able:jael =point:azimuth =live]
-    ^-  (each sponsor=(unit ship) error=term)
+    ^-  (each sponsor=ship error=term)
     =/  rac  (clan:title who.seed)
     =/  cub  (nol:nu:crub:crypto key.seed)
     ?-  rac
@@ -8446,7 +8447,7 @@
       ::
       ?.  ?=(%1 lyf.seed)
         [%| %invalid-life]
-      [%& ~]
+      [%& ~marzod]  ::TODO  how to do comet sponsorship?
     ::
         %earl
       ::  a moon must be signed by the parent
@@ -8471,7 +8472,7 @@
       ::
       ?^  live
         [%| %already-booted]
-      [%& ~]
+      [%& (^sein:title who.seed)]
     ::
         *
       ::  on-chain ships must be launched
@@ -8496,7 +8497,9 @@
         [%| %already-booted]
       ::  produce the sponsor for vere
       ::
-      [%& sponsor.u.net.point]
+      ~?  !has.sponsor.u.net.point
+        [%no-sponsorship-guarantees-from who.sponsor.u.net.point]
+      [%& who.sponsor.u.net.point]
     ==
   --
 --  ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -8479,27 +8479,28 @@
       ::
       ?~  net.point
         [%| %not-keyed]
+      =*  net  u.net.point
       ::  boot keys must match the contract
       ::
-      ?.  =(pub:ex:cub pass.u.net.point)
+      ?.  =(pub:ex:cub pass.net)
         [%| %key-mismatch]
       ::  life must match the contract
       ::
-      ?.  =(lyf.seed life.u.net.point)
+      ?.  =(lyf.seed life.net)
         [%| %life-mismatch]
       ::  the boot life must be greater than and discontinuous with
       ::  the last seen life (per the sponsor)
       ::
       ?:  ?&  ?=(^ live)
               ?|  ?=(%| breach.u.live)
-                  (lte life.u.net.point life.u.live)
+                  (lte life.net life.u.live)
           ==  ==
         [%| %already-booted]
       ::  produce the sponsor for vere
       ::
-      ~?  !has.sponsor.u.net.point
-        [%no-sponsorship-guarantees-from who.sponsor.u.net.point]
-      [%& who.sponsor.u.net.point]
+      ~?  !has.sponsor.net
+        [%no-sponsorship-guarantees-from who.sponsor.net]
+      [%& who.sponsor.net]
     ==
   --
 --  ::

--- a/tests/sys/vane/jael.hoon
+++ b/tests/sys/vane/jael.hoon
@@ -17,7 +17,7 @@
     -8~kX.3ALiG.rQjOi.HZ9hj.84b6G.P5pCZ.UtNtt.Lh9TE.2DQJ2
   =/  url  (de-purl:html 'http://localhost:8545')
   =/  dan
-    [`seed:able:jael`[~nul 1 key ~] ~ ~ [/org/urbit ~] 0 url ~]
+    [`seed:able:jael`[~nul 1 key ~] ~nul ~ [/org/urbit ~] 0 url ~]
   ::
   =^  results1  jael-gate
     =/  hen=duct

--- a/tests/sys/zuse/dawn.hoon
+++ b/tests/sys/zuse/dawn.hoon
@@ -12,7 +12,7 @@
         188.597.545.066.664.466.963.044.328.182.155.965.137.512.758.548.384.
         637.214.562
         continuity-number=0
-        sponsor=[~ u=~zod]
+        sponsor=[& ~zod]
         escape=~
     ==
   [~ u=[spawn-proxy=0x0 spawned=~]]
@@ -209,7 +209,7 @@
 ++  test-veri-good
   =/  sed  [~zod 1 sec ~]
   %+  expect-eq
-    !>  [%& `~zod]
+    !>  [%& ~zod]
     !>  (veri:dawn sed pot ~)
 ::
 ++  test-veri-not-spawned
@@ -251,7 +251,7 @@
       (shaf %earl (sham who 1 pub:ex:cub))
     [who 1 sec:ex:cub `sig]
   %+  expect-eq
-    !>  [%& ~]
+    !>  [%& (^sein:title who)]
     !>  (veri:dawn sed pot ~)
 ::
 ++  test-veri-earl-missing-sig
@@ -327,7 +327,7 @@
   =/  who=ship  `@`fig:ex:cub
   =/  sed  [who 1 sec:ex:cub ~]
   %+  expect-eq
-    !>  [%& ~]
+    !>  [%& ~mittun]
     !>  (veri:dawn sed *point:azimuth-types ~)
 ::
 ++  test-veri-pawn-key-mismatch


### PR DESCRIPTION
That is, sponsorship is no longer `(unit ship)`, but rather `[? ship]`, so that we retain knowledge of a ship's most recent sponsor even after it is kicked.

This allows us to do the simple-dumb solution to "what if no sponsor" by just relying on the "current/last known" sponsor always. In the case the ship itself isn't active or known, jael's `++sein` still falls back to the prefix.

Open question here is what sponsor to provide for comets. I've hardcoded ~marzod for now, but this should probably pull from the "comet stars" list. iirc that's the approach we settled on?

This doesn't *seem* to require any `dawn.c` changes, aside from some comments. @joemfb please confirm.

I tried booting a ~marzod off the Ropsten deploy, but couldn't get it to reach the ~zod, probably because of existing non-functional DNS dependency. (Ropsten contracts still have DNS set to example.com, not sure if/what to change this to. @ixv?)

Tests not updated yet, they'll probably fail because of the `(unit ship)` -> `[? ship]` change. Will get to those later today.

Depends on/includes #957, but submitting as separate PR for cleaner review. (So, ignore the first commit here.)