### PR TITLE
More eyre fixes

### DIFF
--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -5,16 +5,13 @@
 =,  behn
 |=  pit=vase
 =>  |%
-    +$  move  [p=duct q=(wind note:able gift:able)]
-    +$  sign  ~
-    ::
-    +$  behn-state
-      $:  timers=(list timer)
-          unix-duct=duct
-          next-wake=(unit @da)
-      ==
-    ::
-    +$  timer  [date=@da =duct]
+    +$  move        [p=duct q=(wind note:able gift:able)]
+    +$  sign        ~
+    +$  behn-state  $:  timers=(list timer)
+                        unix-duct=duct
+                        next-wake=(unit @da)
+                    ==
+    +$  timer       [date=@da =duct]
     --
 ::
 =|  behn-state

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -2050,7 +2050,14 @@
       (execute-turbo:abet se+[wir usr dom] live schematic)
     ++  dead-this  |=(a/tang (fail:abet 500 0v0 a))
     ++  dead-hiss  |=(a/tang pump(req ~(nap to req), ..vi (give-sigh %| a)))
-    ++  eyre-them  |=({a/whir-se b/vase} (eyre-them:abet se+[a usr dom] b))
+    ::
+    ++  eyre-them
+      |=  [a=whir-se b=vase]
+      ::  block requests until we get a response to this request
+      ::
+      =.  liv  |
+      (eyre-them:abet se+[a usr dom] b)
+    ::
     ++  pass-note  |=({a/whir-se b/note} (pass-note:abet se+[a usr dom] b))
     ::  XX block reqs until correct core checked in?
     ++  warn  |=(a/tang ((slog (flop a)) abet))
@@ -2213,7 +2220,6 @@
     ++  do-send
       |=  wir/whir-se  ^-  $-(vase _abet)
       |=  res/vase
-      =.  liv  |  :: block requests until a reponse is given
       (eyre-them wir (slam !>(|=({$send a/hiss} a)) res))
     ::
     ++  cancel-request  ~&  %cancel-request

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -779,9 +779,9 @@
             `i.drivers
           $(drivers t.drivers)
         ::
-        ?~  driver
-          +>.$
-        ~(cancel-request vi u.driver)
+        ?^  driver
+          ~(cancel-request vi u.driver)
+        (give-sigh(hen (tail hen)) %| [leaf+"canceled on %born"]~)
       ::  ~&  eyre-them+(en-purl p.u.p.kyz)
       %=  +>.$
         mow    :_(mow [ged [%give %thus p.ask p.kyz]])
@@ -815,6 +815,7 @@
         ~&  dead-request+hen
         +>.$(ded (~(put in ded) hen))                   ::  uncaught requests
       =+  lid=(~(got by lyv) hen)
+      =.  lyv  (~(del by lyv) hen)
       :: ~&  did-thud+[-.lid hen]
       ?-  -.lid
           $exec
@@ -2105,7 +2106,7 @@
     ::
     ++  fin-httr
       |=  vax/vase
-      =^  ole  req  ~(get to req)
+      =^  ole  req  ~|  %eyre-no-queue  ~(get to req)
       =>  .(ole `{p/duct q/mark *}`ole)             :: XX types
       =.  ..vi  (cast-thou(hen p.ole) q.ole httr+vax)    :: error?
       pump

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -1,4 +1,4 @@
-::  ::  %eyre, http servant
+!:  ::  %eyre, http servant
 !?  164
 ::::
 |=  pit/vase
@@ -638,6 +638,7 @@
     |=  kyz/task:able
     ^+  +>
     =.  p.top  our              ::  XX necessary?
+    ~&  %eyre-apex^-.kyz^hen
     ?-    -.kyz
         ::  new unix process - learn of first boot or a restart.
         ::
@@ -758,6 +759,7 @@
       ?~  p.kyz
         =+  sud=(need (~(get by kes) hen))
         =.  +>.$
+          ~&  %give-thus
           %_  +>.$
             mow    :_(mow [ged [%give %thus sud ~]])
             q.ask  (~(del by q.ask) sud)
@@ -782,7 +784,8 @@
         ?^  driver
           ~(cancel-request vi u.driver)
         (give-sigh(hen (tail hen)) %| [leaf+"canceled on %born"]~)
-      ::  ~&  eyre-them+(en-purl p.u.p.kyz)
+      ::
+      ~&  %give-thus
       %=  +>.$
         mow    :_(mow [ged [%give %thus p.ask p.kyz]])
         p.ask  +(p.ask)
@@ -932,6 +935,7 @@
     ^+  +>
     ?:  &(?=({?($of $ow) ^} tee) !(~(has by wix) p.tee))
       ~&(dead-ire+[`whir`tee] +>)
+    ~&  %eyre-axon^&2.sih^hen
     ?-    &2.sih
         $crud  +>.$(mow [[hen %slip %d %flog +.sih] mow])
     ::  $dumb
@@ -941,6 +945,7 @@
         $woot  +>.$
     ::
         $thou
+      ~&  %eyre-axon-thou^-.tee
       ?+    -.tee  !!
         $ay  (ames-gram (slav %p p.tee) %got (slav %uv q.tee) |2.sih)
         $hi  (cast-thou q.tee httr+!>(p.sih))
@@ -1088,6 +1093,7 @@
   ::
   ++  eyre-them
     |=  {tea/whir vax/vase}
+    ~&  %eyre-them
     (pass-note tea [%e %meta :(slop !>(%them) !>(~) vax)])
   ::
   ++  ames-gram
@@ -2033,7 +2039,12 @@
             {liv/? req/(qeu {p/duct q/mark r/vase:hiss})}
         ==
     ++  self  .
-    ++  abet  +>(sec (~(put by sec) +<- +<+))
+    ++  abet
+      ~&  :*  %eyre-vi-abet
+              usr=usr  dom=dom  liv=liv  cor=?~(cor ~ ?@(u.cor [~ ~] %ok))
+              req=~(dep to req)
+          ==
+      +>(sec (~(put by sec) +<- +<+))
     ++  execute-turbo
       |=  [wir=whir-se live=? schematic=schematic:ford]
       (execute-turbo:abet se+[wir usr dom] live schematic)
@@ -2092,6 +2103,7 @@
     ::
     ++  pump
       ^+  abet
+      ~&  %eyre-vi-pump
       ?~  cor
         build
       ?.  liv
@@ -2114,9 +2126,13 @@
     ::  Interfaces
     ::
     ++  get-quay  |=(quy/quay (call %receive-auth-query-string quay+!>(quy)))
-    ++  get-req   |=(a/{mark vase:hiss} pump(req (~(put to req) hen a)))
+    ++  get-req
+      |=  a/{mark vase:hiss}
+      ~&  %eyre-get-req^req=~(dep to req)^new-req=+(~(dep to req))
+      pump(req (~(put to req) hen a))
     ++  get-thou
       |=  {wir/whir-se hit/httr}
+      ~&  %eyre-get-thou^liv=liv
       =.  liv  &
       ?+  wir  !!
         ?($receive-auth-query-string $in)  (call %receive-auth-response httr+!>(hit))

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -5703,6 +5703,13 @@
     ::  make sure we have something to send
     ::
     ?>  ?=([%complete %value *] state.build-status)
+    ~?  .=  duct
+        :~  /g/use/dojo/~zod/inn/hand
+            /g/use/hood/~zod/out/dojo/drum/phat/~zod/dojo
+            /d
+            //term/1
+        ==
+      %ford-finished^duct
     ::  send a %made move unless it's an unchanged live build
     ::
     =?    moves


### PR DESCRIPTION
- Remove dead requests from `lyv`
- Notify client when we cancel a request by calling `+give-sigh`
- Added a `~|` when Eyre crashes due to trying to access an empty security driver request queue.

I'm still working on understanding that crash, but we should now at least be able to know where the crash occurred.