### PR TITLE
Adds utf-8 rendering

### DIFF
--- a/mar/urb.hoon
+++ b/mar/urb.hoon
@@ -8,7 +8,11 @@
 ::
 ++  grow                                                ::  convert to
   |%
-  ++  hymn  ;html:(head body:"+{own}")                  ::  convert to %hymn
+  ++  hymn  ;html
+              ;head;
+              ;meta(charset "utf-8");
+              ;body:"+{own}"                  ::  convert to %hymn
+            ==
   ++  html  (crip (en-xml hymn))                        ::  convert to %html
   ++  mime  [/text/html (as-octs html)]                 ::  convert to %mime
   --


### PR DESCRIPTION
I found an issue where `"` would render as `â€` in markdown. I asked @ixv for help and he fixed it so it has the utf-8 charset. Interesting, `master` does not have this problem.