### PR TITLE
adds explicit types to the sample of +uno:by

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1692,7 +1692,7 @@
     =+  b=a
     |@
     ++  $
-      |*  meg/$-({* * *} *)
+      |=  meg/$-({_p:node _q:node _q:node} _q:node)
       |-  ^+  a
       ?~  b
         a


### PR DESCRIPTION
This PR extracts the type-safety change to `+uno:by` from #785.