### PR TITLE
Reduce ++hard usage in jael for speed

### DIFF
--- a/mar/json/rpc/response.hoon
+++ b/mar/json/rpc/response.hoon
@@ -2,14 +2,15 @@
 /-  json-rpc
 =,  json-rpc
 ::
-|_  res=response
+!:
+|_  res=raw-response
 ::
 ++  grab                                                ::  convert from
   |%
-  ++  noun  response                                    ::  from noun
+  ++  noun  raw-response                                    ::  from noun
   ++  httr                                              ::  from httr
     |=  hit/httr:eyre
-    ^-  response
+    ^-  raw-response
     ~|  hit
     ?:  ?=($2 (div p.hit 100))
       =,  html
@@ -18,6 +19,16 @@
   ++  json                                              ::  from json
     =,  dejs-soft:format
     |=  a=json
+    ^-  raw-response
+    =;  resp
+      ?-    -.resp
+          %error   resp
+          %fail    resp
+          %batch   resp
+          %result
+        ~|  resp
+        [%result id.resp (crip (en-json:html res.resp))]
+      ==
     ^-  response
     =;  dere
       =+  res=((ar dere) a)

--- a/sur/json/rpc.hoon
+++ b/sur/json/rpc.hoon
@@ -1,5 +1,14 @@
 |%
+++  raw-response
+  $~  [%fail *httr:eyre]
+  $%  [%result id=@t res=@t]
+      [%error id=@t code=@t message=@t]  ::TODO  data?
+      [%fail hit=httr:eyre]
+      [%batch bas=(list response)]
+  ==
+::
 ++  response  ::TODO  id should be optional
+  $~  [%fail *httr:eyre]
   $%  [%result id=@t res=json]
       [%error id=@t code=@t message=@t]  ::TODO  data?
       [%fail hit=httr:eyre]

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1906,7 +1906,16 @@
       ~&  [%yikes cuz]
       +>.$
     ?>  ?=(%json-rpc-response mar)
-    =+  rep=~|(res ((hard response:rpc:jstd) q.res))
+    =+  raw-rep=~|(res ((hard raw-response:rpc:jstd) q.res))
+    =/  rep=response:rpc:jstd
+      ?-    -.raw-rep
+          %error   raw-rep
+          %fail    raw-rep
+          %batch   raw-rep
+          %result
+        ~|  raw-rep
+        [%result id.raw-rep (need (de-json:html res.raw-rep))]
+      ==
     ?:  ?=(%fail -.rep)
       ?:  =(405 p.hit.rep)
         ~&  'HTTP 405 error (expected if using infura)'

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -103,7 +103,20 @@
   |%
   ++  rpc
     |%
+    ::  The json-rpc-response mark doesn't parse the json for `res`
+    ::  so that we can efficiently ++hard the value in %jael.  It's
+    ::  much slower to ++hard json than to simply re-parse it.
+    ::
+    ++  raw-response
+      $~  [%fail *httr:eyre]
+      $%  [%result id=@t res=@t]
+          [%error id=@t code=@t message=@t]  ::TODO  data?
+          [%fail hit=httr:eyre]
+          [%batch bas=(list response)]
+      ==
+    ::
     ++  response  ::TODO  id should be optional
+      $~  [%fail *httr:eyre]
       $%  [%result id=@t res=json]
           [%error id=@t code=@t message=@t]  ::TODO  data?
           [%fail hit=httr:eyre]
@@ -7174,11 +7187,12 @@
         |%
         ::  azimuth: data contract
         ::
-        ++  azimuth  0x308a.b6a6.024c.f198.b57e.008d.0ac9.ad02.1988.6579
+        ::  ++  azimuth  0x308a.b6a6.024c.f198.b57e.008d.0ac9.ad02.1988.6579  ::  ropsten
+        ++  azimuth  0x223c.067f.8cf2.8ae1.73ee.5caf.ea60.ca44.c335.fecb  ::  mainnet
         ::
         ::  launch: block number of azimuth deploy
         ::
-        ++  launch  4.601.630
+        ++  launch  6.784.800
         --
       ::
       ::  hashes of ship event signatures
@@ -8483,6 +8497,7 @@
       ::  boot keys must match the contract
       ::
       ?.  =(pub:ex:cub pass.net)
+        ~&  [%key-mismatch pub:ex:cub pass.net]
         [%| %key-mismatch]
       ::  life must match the contract
       ::


### PR DESCRIPTION
How do you get typed responses from eyre without running into issues around ++hard?  I've got a poor solution working, but I'm interested in the general solution.

Up untill now, Jael makes HTTP requests to an Ethereum node, and Eyre parses the response through the %json-rpc-response mark, which parses the httr to json and a couple more things.  Eyre gives a %sigh back to Jael, which includes the json response as a vase.  However, Jael needs to use that result as typed data, so it ++hard's it to the appropriate type (mostly a bunch of json).

This basically works on testnet, but it fails on mainnet because we have much more data, and ++hard is superlinear in the amount of json, so it crashes.  We can get around this by splitting the requests into really small batches (so the superlinearity doesn't kill us), but that's not a real solution.

What I've done for now is stored the JSON part as simply text in the mark translation, then parsed it in Jael, because parsing JSON is much faster than +hard'ing json.  This splits the parsing weirdly across the two locations, though.  I suppose one solution would be to forget the mark and just parse the whole httr in Jael.  Another solution would be to parse out the json into a more specific type in the mark, but I'm not sure if we can actually give it a sufficiently specific type that the ++hard is fast.  Plus, that leaves in the ++hard, which is a code smell.

Are there other solutions to get typed to a vane from eyre?