### PR TITLE
removes +life from %bond +meal (to fix nacks)

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -984,9 +984,8 @@
               +>(..la (tock p.fud q.fud r.fud))
             ::
                 %bond
-              ::  ~&  [%bond q.fud r.fud]
-              ?>  =(lyf:sen:gus p.fud)
-              (deer q.fud r.fud ?-(kay %dead ~, %good [~ s.fud]))
+              ::  ~&  [%bond p.fud q.fud]
+              (deer p.fud q.fud ?-(kay %dead ~, %good [~ r.fud]))
             ::
                 %carp
               ::  =+  zol=(~(get by olz.weg) s.fud)
@@ -1115,7 +1114,7 @@
                 san  (~(put by san.rol) sex hen)
               ==
           %+  wind  [cha sex]
-          [%bond clon:diz cha sex val]
+          [%bond cha sex val]
         ::
         ++  zest                                        ::    zest:ho:um:am
           :~  :~  :*  [%rtt rtt.sop.bah]

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -338,7 +338,7 @@
     ==                                                  ::
   ++  meal                                              ::  payload
     $%  {$back p/coop q/flap r/@dr}                     ::  ack
-        {$bond p/life q/path r/@ud s/*}                 ::  message
+        {$bond p/path q/@ud r/*}                        ::  message
         {$carp p/@ q/@ud r/@ud s/flap t/@}              ::  skin+inx+cnt+hash
         {$fore p/ship q/(unit lane) r/@}                ::  forwarded packet
     ==                                                  ::


### PR DESCRIPTION
This field is obsolete, the +life is passed in the outer packet wrapper and validated therein. It's presence was preventing the sending of negative acks.