### PR TITLE
% means path-to-render in renderers

### DIFF
--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -4344,10 +4344,10 @@
           |=  [=truss sub-crane=^crane]
           ^-  compose-cranes
           ::
-          =/  =beam
-            =,  source-rail.scaffold
-            [[ship.disc desk.disc [%ud 0]] spur]
-          =/  hoon-parser  (vang & (en-beam beam))
+          =/  beam-to-render=beam
+            [[ship.disc desk.disc %ud 0] spur]:path-to-render
+          ::
+          =/  hoon-parser  (vang & (en-beam beam-to-render))
           ::
           =+  tuz=(posh:hoon-parser truss)
           ?~  tuz


### PR DESCRIPTION
Note that this doesn't apply to the `/~` rune, which parses its input into Hoon more greedily. For all other Ford runes, though, this should parse late-bound paths using :path-to-render instead of the path of the renderer file itself.

@vvisigoth you might want to test this before merging; this compiles, but I didn't have a renderer at hand to throw at it.

@eglaysher I'd appreciate a quick sanity check from you, since you wrote most of this part of Ford.