### PR TITLE
remove %eyre auth redirect printfs

### DIFF
--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -1168,8 +1168,6 @@
   ++  render-tang                                         ::  tanks to manx
     ~/  %render-tang
     |=  {dep/@uvH tan/tang}
-    ~&  [%render-tang dep]
-    %-  (slog tan)
     ;html
       ;head
         ;link(rel "stylesheet", href "/lib/base.css");

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -1314,8 +1314,13 @@
           $red
         =+  url=(en-purl hat pok(p [~ %html]) quy)
         ?+    p.pok  ~|(bad-redirect+[p.pok url] !!)
+            ::  ignore css
+            ::
+            {~ $css}  !!
+        ::
             {~ $js}
           $(pez [%js auth-redir:js])
+        ::
             {~ $json}
           =/  red
             (pairs:enjs ok+b+| red+(tape:enjs url) ~)


### PR DESCRIPTION
This PR suppresses a couple printfs that were always being triggered on authentication redirects.

/cc @ixv