### PR TITLE
use foreign aeon for foreign mark definitions

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -631,6 +631,7 @@
     ::  translate other cases to dates
     ::
     =/  aey  (case-to-aeon:ze case)
+    ::  ~&  [%case-to-date aey let.dom our her syd case]
     ?~  aey  `@da`0
     ?:  =(0 u.aey)  `@da`0
     t:(aeon-to-yaki:ze u.aey)
@@ -3170,7 +3171,9 @@
         :*  hen  %pass
             =+  (cat 3 %diff- nam)
             [%merge (scot %p p.bob) q.bob (scot %p p.ali) q.ali - ~]
-            %f  %build  live=%.n  %pin  (case-to-date r.oth)  %list
+            %f  %build  live=%.n  %pin
+            (case-to-date:((de our now hen ruf) p.oth q.oth) r.oth)
+            %list
             ^-  (list schematic:ford)
             %+  murn  ~(tap by q.bas.dat)
             |=  {pax/path lob/lobe}

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -13,7 +13,7 @@
 ::
 ::    We call the date in the definition of a build the "formal date" to
 ::    distinguish it from the time at which the build was performed.
-
+::
 ::    Each build is referentially transparent with respect to its formal date:
 ::    ask to run that function on the namespace and a particular formal date,
 ::    and Ford will always produce the same result.


### PR DESCRIPTION
When getting mark definitions to compare a foreign commit against its merge base, we need to use `case-to-aeon` of the foreign desk, not our local one.

I've tested that this fixes the issue locally, but I haven't tested it with multiple ships.