### PR TITLE
add eth-manage app

### DIFF
--- a/app/eth-manage.hoon
+++ b/app/eth-manage.hoon
@@ -1,3 +1,8 @@
+::  usage:
+::    :eth-manage %look
+::      kick polling from eth mainnet node
+::    :eth-manage [%wind 1.000.000]
+::      rewind to block 1.000.000
 =>  $~  |%
     ++  move  (pair bone card)
     ++  card
@@ -17,20 +22,16 @@
 ++  poke
   |=  [mar=@tas val=*]
   ^-  (quip move _+>)
-  ~&  %ouch
   :_  +>.$
-  ?+  val
-        ~&(%oops ~)
-    %turf  [ost.hid %turf /hi ~]~                       ::  +
-    %vein  [ost.hid %vein /hi]~                 ::  +
-    %look  :_  ~                                        ::  +
-           =/  pul  |+(need (de-purl:html 'http://eth-mainnet.urbit.org:8545'))
-           [ost.hid %look /hi pul]
-    %wind  :_  ~                                        ::  -
-           :*  ost.hid  %wind  /hi
-               ::  0
-               4.280.000
-           ==
+  ?+  val  ~&(%oops ~)
+      %turf         [ost.hid %turf /hi ~]~
+      %vein         [ost.hid %vein /hi]~
+      [%wind @ud]   [ost.hid %wind /hi +.val]~
+      %look
+    :_  ~
+    =/  pul
+      (need (de-purl:html 'http://eth-mainnet.urbit.org:8545'))
+    [ost.hid %look /hi |+pul]
   ==
 ::
 ++  vein

--- a/app/eth-manage.hoon
+++ b/app/eth-manage.hoon
@@ -1,0 +1,57 @@
+=>  $~  |%
+    ++  move  (pair bone card)
+    ++  card
+      $%  [%turf wire ~]
+          [%vein wire]
+          [%look wire src=(each ship purl:eyre)]
+          [%wind wire p=@ud]
+      ==
+    ++  state
+      $:  a/@
+      ==
+    --
+=,  gall
+|_  $:  hid/bowl
+        state
+    ==
+++  poke
+  |=  [mar=@tas val=*]
+  ^-  (quip move _+>)
+  ~&  %ouch
+  :_  +>.$
+  ?+  val
+        ~&(%oops ~)
+    %turf  [ost.hid %turf /hi ~]~                       ::  +
+    %vein  [ost.hid %vein /hi]~                 ::  +
+    %look  :_  ~                                        ::  +
+           =/  pul  |+(need (de-purl:html 'http://eth-mainnet.urbit.org:8545'))
+           [ost.hid %look /hi pul]
+    %wind  :_  ~                                        ::  -
+           :*  ost.hid  %wind  /hi
+               ::  0
+               4.280.000
+           ==
+  ==
+::
+++  vein
+  |=  [wir/wire =life ven=(map life ring)]
+  ^-  (quip move _+>)
+  ~&  [%pierc life ven]
+  `+>.$
+::
+++  turf
+  |=  [wir/wire pax=(list path)]
+  ^-  (quip move _+>)
+  ~&  [%slurp pax]
+  `+>.$
+::
+++  prep
+  |=  old/(unit noun)
+  ^-  [(list move) _+>.$]
+  ?~  old
+    `+>.$
+  =+  new=((soft state) u.old)
+  ?~  new
+    `+>.$
+  `+>.$(+<+ u.new)
+--


### PR DESCRIPTION
We need to be able to kick jael if it stops listening to the ethereum node.  This app does that with `:eth %look`.

This should probably be cleaned up, but it's vital functionality for now.