### PR TITLE
Quality-of-life improvements for %jael

### DIFF
--- a/mar/snap.hoon
+++ b/mar/snap.hoon
@@ -1,0 +1,16 @@
+::
+::::  /hoon/snap/mar
+  ::
+=,  mimes:html
+|_  snap/snapshot:jael
+++  grow
+  |%
+  ++  mime  [/application/octet-stream (jam snap)]
+  --
+++  grab
+  |%
+  ++  noun  snapshot:jael
+  ++  mime  |=([p=mite:eyre q=octs:eyre] (cue q.q))
+  --
+++  grad  %mime
+--

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1281,6 +1281,7 @@
         $perm  `%c
         $rule  `%e
         $serv  `%e
+        $snap  `%j
         $them  `%e
         $wait  `%b
         $want  `%a

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -2378,6 +2378,12 @@
     !>  ^-  (list ship)
     (~(saxo of [our now eny] lex) u.who)
   ::
+      %eth-status
+    ?.  ?=(~ tyl)  [~ ~]
+    :^  ~  ~  %noun  !>
+    ^-  [latest-block=@ud source=(each ship node-src)]
+    [latest-block.etn.lex source.etn.lex]
+  ::
       %snap
     ?.  ?=(~ tyl)  [~ ~]
     ?:  =(~ snaps.sap.lex)

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -848,6 +848,11 @@
       %+  cure  hen
       [[%meet ship.tac life.tac pass.tac]~ urb]
     ::
+    ::  restore snapshot
+    ::    [%snap snap=snapshot kick=?]
+        %snap
+      (restore-snap hen snap.tac kick.tac)
+    ::
     ::  XX should be a subscription
     ::  XX reconcile with .dns.eth
     ::  request domains

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1856,6 +1856,7 @@
           [%nuke ~]                                     ::  cancel tracker from
           [%pubs =ship]                                 ::  view public keys
           [%meet =ship =life =pass]                     ::  met after breach
+          [%snap snap=snapshot kick=?]                  ::  load snapshot
           [%turf ~]                                     ::  view domains
           [%vein ~]                                     ::  view signing keys
           [%vent ~]                                     ::  view ethereum events


### PR DESCRIPTION
`.^([latest-block=@ud source=(each ship node-src:jael) %j /=eth-status=)` now gives you some useful information about your current jael state.

I also added a `snap` mark so we can load these snaps into clay and inspect them.

Finally, I added a `%snap` option to `%jael` and `%eth-manage` so that we can restore a snapshot that we put in clay on-demand.