### PR TITLE
always use our reef for clay

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -838,7 +838,7 @@
         %+  turn  `(list path)`mus
         |=  a/path
         :-  [%$ %path !>(a)]
-        :^  %cast  [her syd]  %mime
+        :^  %cast  [our %home]  %mime
         =+  (need (need (read-x:ze cas a)))
         ?:  ?=(%& -<)
           [%$ p.-]
@@ -1211,7 +1211,7 @@
               ?>  ?=($ins -.mis)
               :-  [%$ %path -:!>(*path) pax]
               =+  =>((flop pax) ?~(. %$ i))
-              [%cast [her syd] - [%$ p.mis]]
+              [%cast [our %home] - [%$ p.mis]]
           ==
           :*  hen  %pass
               [%diffing (scot %p her) syd (scot %da wen) ~]
@@ -1223,7 +1223,7 @@
               =+  (need (need (read-x:ze let.dom pax)))
               ?>  ?=(%& -<)
               :-  [%$ %path -:!>(*path) pax]
-              [%pact [her syd] [%$ p.-] [%$ p.mis]]
+              [%pact [our %home] [%$ p.-] [%$ p.mis]]
           ==
           :*  hen  %pass
               [%castifying (scot %p her) syd (scot %da wen) ~]
@@ -1235,7 +1235,7 @@
               ?>  ?=($mut -.mis)
               :-  [%$ %path -:!>(*path) pax]
               =+  (lobe-to-mark:ze (~(got by q:(aeon-to-yaki:ze let.dom)) pax))
-              [%cast [her syd] - [%$ p.mis]]
+              [%cast [our %home] - [%$ p.mis]]
           ==
       ==
     %_    +>.$
@@ -1404,7 +1404,7 @@
         |=  {pax/path cay/cage}
         :-  [%$ %path -:!>(*path) pax]
         =+  (lobe-to-schematic:ze [her syd] pax (~(got by q:(aeon-to-yaki:ze let.dom)) pax))
-        [%diff [her syd] - [%$ cay]]
+        [%diff [our %home] - [%$ cay]]
     ==
   ::
   ::  Handle result of diffing mutations.
@@ -1593,7 +1593,7 @@
           [%$ %null !>(~)]
         =+  (~(get by mim.dom) a)
         ?^  -  [%$ %mime !>(u.-)]
-        :^  %cast  [her syd]  %mime
+        :^  %cast  [our %home]  %mime
         =+  (need (need (read-x:ze let.dom a)))
         ?:  ?=(%& -<)
           [%$ p.-]
@@ -1769,7 +1769,7 @@
   ++  vale-page
     |=  [disc=disc:ford a=page]
     ^-  schematic:ford
-    ?.  ?=($hoon p.a)  [%vale disc a]
+    ?.  ?=($hoon p.a)  [%vale [our %home] a]
     ?.  ?=(@t q.a)  [%dude |.(>%weird-hoon<) %ride [%zpzp ~] %$ *cage]
     [%$ p.a [%atom %t ~] q.a]
   ::
@@ -2167,7 +2167,7 @@
       |=  [disc=disc:ford a=page]
       ^-  schematic:ford
       ::
-      ?.  ?=($hoon p.a)  [%volt disc a]
+      ?.  ?=($hoon p.a)  [%volt [our %home] a]
       ::  %hoon bootstrapping
       [%$ p.a [%atom %t ~] q.a]
     ::
@@ -2191,7 +2191,7 @@
       ?-  -.bol
         $direct     (page-to-schematic disc q.bol)
         $delta      ~|  delta+q.q.bol
-                    [%pact disc $(lob q.q.bol) (page-to-schematic disc r.bol)]
+                    [%pact [our %home] $(lob q.q.bol) (page-to-schematic disc r.bol)]
       ==
     ::
     ::  Hashes a page to get a lobe.
@@ -3191,7 +3191,9 @@
             :-  ~
             =/  disc  [p.oth q.oth]
             :-  [%$ %path !>(pax)]
-            [%diff disc (lobe-to-schematic disc pax lob) (lobe-to-schematic disc pax u.a)]
+            :^  %diff  [our %home]
+              (lobe-to-schematic disc pax lob)
+            (lobe-to-schematic disc pax u.a)
         ==
       ::
       ::  Diff ali's commit against the mergebase.
@@ -3556,7 +3558,7 @@
             ?.  b
               [%$ %null !>(~)]
             =/  disc  [p q]:val
-            :^  %cast  disc  %mime
+            :^  %cast  [our %home]  %mime
             (lobe-to-schematic:zez disc a (~(got by q.new.dat) a))
         ==
       ::
@@ -3641,7 +3643,7 @@
           =+  bol=(~(got by lat.ran) lob)
           ?-  -.bol
             $direct     (page-to-schematic disc q.bol)
-            $delta      [%pact disc $(lob q.q.bol) (page-to-schematic disc r.bol)]
+            $delta      [%pact [our %home] $(lob q.q.bol) (page-to-schematic disc r.bol)]
           ==
         ::
         ::  Find the most recent common ancestor(s).


### PR DESCRIPTION
fixes #1008 

I'm not sure this is the right solution, but if we run into issues with clay being rickety, this is a solid hotfix that makes sense to me, at least while we're regularly breaching (so we can expect peoples' hoon/zuse/arvo/marks to be pretty compatible).

I suspect we'll eventually want to revert this and instead compile the foreign marks with the foreign kernel, but it has to be done at the new revision, and I don't know how to tell ford about the new kernel for that desk before the revision is even complete.