### PR TITLE
slum in Arvo scry

### DIFF
--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -191,10 +191,7 @@
         (~(slym wa *worm) vase.vane *vane-sample)
       ::  cache the access of the %scry arm
       ::
-      =^  fun  worm.vane  (~(slap wa worm.vane) rig [%limb %scry])
-      ::  cache the call to +mint that the +slym in +scry will do
-      ::
-      +:(~(mint wa worm.vane) p.fun [%limb %$])
+      +:(~(slap wa worm.vane) rig [%limb %scry])
     ==
   ::
   ++  wink                                              ::  deploy
@@ -356,11 +353,9 @@
         ==
       ^-  (unit (unit (cask)))
       =+  fun=-:(~(slap wa worm.vane) rig [%limb %scry])
-      =+  pro=-:(~(slym wa worm.vane) fun old)
-      ?~  q.pro  ~
-      ?~  +.q.pro  [~ ~]
-      =/  dat  +>.q.pro
-      [~ ~ (mark -.dat) +.dat]
+      ::
+      %-  (unit (unit (cask)))
+      (slum q.fun old)
     ::
     ++  soar                                            ::  scrub vane
       |=  sev/vase


### PR DESCRIPTION
@eglaysher's recent profile shows a significant percentage of Ames processing time inside Arvo's +scry function, almost all of which happens on +slym:wa cache misses. Since we don't actually use the type from the result of the +slym call, there's no reason to call the compiler. Just run the function untyped using +slum and clam the output to `(unit (unit (cask)))`.