### PR TITLE
+has:in typecheck hack

### DIFF
--- a/app/hall.hoon
+++ b/app/hall.hoon
@@ -498,7 +498,7 @@
       ~/  %hall-action-create
       |=  {nom/name des/cord typ/security}
       ^+  ..ta-action
-      ?.  (~(has in stories) nom)
+      ?.  (~(has by stories) nom)
         %^  impact  nom  %new
         :*  [[[our.bol nom] ~] ~ ~]
             des
@@ -516,7 +516,7 @@
       ::
       ~/  %hall-action-design
       |=  {nom/name cof/config}
-      ?.  (~(has in stories) nom)
+      ?.  (~(has by stories) nom)
         (impact nom %new cof)
       (ta-evil (crip "{(trip nom)}: already exists"))
     ::
@@ -2654,15 +2654,16 @@
     ==
   ::
     ?:  =(wat ~)  &
-    %-  ~(has in wat)
-    ?+  -.det  %hasnot
-      $gram     %grams
-      $new      %config-l
-      $remove   %config-l
+    ?+  -.det   |
+      $gram     (~(has in wat) %grams)
+      $new      (~(has in wat) %config-l)
+      $remove   (~(has in wat) %config-l)
       $config   ?:  =(cir.det [our.bol nom])
-                %config-l  %config-r
+                  (~(has in wat) %config-l)
+                (~(has in wat) %config-r)
       $status   ?:  =(cir.det [our.bol nom])
-                %group-l  %group-r
+                  (~(has in wat) %group-l)
+                (~(has in wat) %group-r)
     ==
   ==
 ::

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -12130,7 +12130,7 @@
       |=  [acc=_map [ty=type k=xkey]]
       =/  dest  (~(get by refs.tbl) k)
       ?^  dest  (~(put by acc) ty u.dest)
-      ?.  (~(has in live.tbl))  acc
+      ?.  (~(has in live.tbl) k)  acc
       (~(put in acc) ty k)
     ::
     ::  Rebuild the `xrays` table.

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -1335,10 +1335,26 @@
     ?~  b
       a
     $(b t.b, a (put i.b))
+  ::  +has: does :b exist in :a?
   ::
-  ++  has                                               ::  b exists in a check
+  ++  has
     ~/  %has
-    |*  b/*
+    |*  b=*
+    ^-  ?
+    ::  wrap extracted item type in a unit because bunting fails
+    ::
+    ::    If we used the real item type of _?^(a n.a !!) as the sample type,
+    ::    then hoon would bunt it to create the default sample for the gate.
+    ::
+    ::    However, bunting that expression fails if :a is ~. If we wrap it
+    ::    in a unit, the bunted unit doesn't include the bunted item type.
+    ::
+    ::    This way we can ensure type safety of :b without needing to perform
+    ::    this failing bunt. It's a hack.
+    ::
+    %.  [~ b]
+    |=  b=(unit _?>(?=(^ a) n.a))
+    =>  .(b ?>(?=(^ b) u.b))
     |-  ^-  ?
     ?~  a
       |

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -5932,7 +5932,7 @@
       %+  welp  tam
       =-  ?~(att rez [' ' (attr att rez)])
       ^-  rez/tape
-      ?:  &(?=(~ c.mex) |(cot (clot man)))
+      ?:  &(?=(~ c.mex) |(cot ?^(man | (clot man))))
         [' ' '/' '>' rez]
       :-  '>'
       (many c.mex :(weld "</" tam ">" rez))


### PR DESCRIPTION
`+has:in` now ensures type safety on the element. It ain't pretty, but it works. Also keep in mind that this function is jetted, so its internal mischief won't cause performance issues.

cc @eglaysher 