### PR TITLE
Handle |mass in Jael

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1530,8 +1530,7 @@
   ::
   ++  wegh
     ^-  mass
-    :-  %ames
-    :-  %|
-    :~  fox+[%& fox]
+    :+  %ames  %|
+    :~  dot+&+fox
     ==
   --

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -81,9 +81,9 @@
             %wegh
           :_  state  :_  ~
           :^  hen  %give  %mass
-          :-  %behn
-          :-  %|
-          :~  timers+[%& timers]
+          :+  %behn  %|
+          :~  timers+&+timers
+              dot+&+state
           ==
         ==
       ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3928,14 +3928,14 @@
       $wegh
     :_  ..^$  :_  ~
     :^  hen  %give  %mass
-    :-  %clay
-    :-  %|
-    :~  domestic+[%& rom.ruf]
-        foreign+[%& hoy.ruf]
-        :-  %object-store  :-  %|
-        :~  commits+[%& hut.ran.ruf]
-            blobs+[%& lat.ran.ruf]
+    :+  %clay  %|
+    :~  domestic+&+rom.ruf
+        foreign+&+hoy.ruf
+        :+  %object-store  %|
+        :~  commits+&+hut.ran.ruf
+            blobs+&+lat.ran.ruf
         ==
+        dot+&+ruf
     ==
   ==
 ::

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -431,9 +431,10 @@
       ::
       ++  wegh
         ^-  mass
-        :-  %dill
-        :-  %|
-        :~  all+[%& [hey dug]:all]
+        :+  %dill  %|
+        :~  hey+&+hey.all
+            dug+&+dug.all
+            dot+&+all
         ==
       ::
       ++  wegt

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -1,4 +1,4 @@
-::
+!:
 ::  dill (4d), terminal handling
 ::
 |=  pit/vase
@@ -19,6 +19,7 @@
           e/(unit mass)                                 ::
           f/(unit mass)                                 ::
           g/(unit mass)                                 ::
+          j/(unit mass)                                 ::
       ==                                                ::
   ==                                                    ::
 ++  axon                                                ::  dill per duct
@@ -77,7 +78,7 @@
           snap=(unit snapshot:jael)                     ::    head start
       ==                                                ::
       [%fake our=ship]                                  ::  boot fake
-      :: XX wegh                                        ::
+      [%wegh ~]
   ==                                                    ::
 ++  note                                                ::  out request $->
   $%  {$a note-ames}                                    ::
@@ -120,6 +121,7 @@
   ==                                                    ::
 ++  sign-jael                                           ::
   $%  [%init p=ship]                                    ::
+      [%mass p=mass]
   ==                                                    ::
 ++  sign                                                ::  in result $<-
   $%  {$a sign-ames}                                    ::
@@ -280,6 +282,7 @@
               [hen %pass /heft/eyre %e %wegh ~]
               [hen %pass /heft/ford %f %wegh ~]
               [hen %pass /heft/gall %g %wegh ~]
+              [hen %pass /heft/jael %j %wegh ~]
               moz
           ==
         ==
@@ -374,7 +377,7 @@
         |=  sih/sign
         ^+  +>
         ?-    sih
-            {?($a $b $c $e $f $g) $mass *}
+            {?($a $b $c $e $f $g $j) $mass *}
           (wegt -.sih p.sih)
         ::
             {$a $nice *}
@@ -434,7 +437,7 @@
         ==
       ::
       ++  wegt
-        |=  {lal/?($a $b $c $e $f $g) mas/mass}
+        |=  {lal/?($a $b $c $e $f $g $j) mas/mass}
         ^+  +>
         =.  hef.all
           ?-  lal
@@ -444,6 +447,7 @@
             $e  ~?(?=(^ e.hef.all) %double-mass-e hef.all(e `mas))
             $f  ~?(?=(^ f.hef.all) %double-mass-f hef.all(f `mas))
             $g  ~?(?=(^ g.hef.all) %double-mass-g hef.all(g `mas))
+            $j  ~?(?=(^ j.hef.all) %double-mass-j hef.all(j `mas))
           ==
         ?.  ?&  ?=(^ a.hef.all)
                 ?=(^ b.hef.all)
@@ -451,12 +455,13 @@
                 ?=(^ e.hef.all)
                 ?=(^ f.hef.all)
                 ?=(^ g.hef.all)
+                ?=(^ j.hef.all)
             ==
           +>.$
-        %+  done(hef.all [~ ~ ~ ~ ~ ~])
+        %+  done(hef.all [~ ~ ~ ~ ~ ~ ~])
           %mass
         =>  [hef.all d=wegh]
-        [%vanes %| ~[u.a u.c d u.e u.f u.g u.b]]
+        [%vanes %| ~[u.a u.b u.c d u.e u.g u.f u.j]]
       --
     ::
     ++  ax                                              ::  make ++as

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -2296,12 +2296,13 @@
   ?:  ?=($wegh -.task)
     :_  ..^$  :_  ~
     :^  hen  %give  %mass
-    :-  %eyre
-    :-  %|
-    :~  dependencies+[%& liz]  sessions+[%& wup]  views+[%& wix]
-        ducts+[%| ~[dead+[%& ded] proxy+[%& pox] outgoing+[%& ask]]]
-        hosts+[%& dop]
-        misc+[%& bol]
+    :+  %eyre  %|
+    :~  dependencies+&+liz
+        sessions+&+wup
+        views+&+wix
+        ducts+[%| ~[dead+&+ded proxy+&+pox outgoing+&+ask]]
+        hosts+&+dop
+        dot+&+bol
     ==
   =+  ska=(sloy ski)
   =+  sky=|=({* *} `(unit)`=+(a=(ska +<) ?~(a ~ ?~(u.a ~ [~ u.u.a]))))

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -6196,14 +6196,11 @@
     :_  ~
     :^  duct  %give  %mass
     ^-  mass
-    :-  %ford
-    :-  %|
-    :~  ^-  mass
-        :+  (scot %p our)  %|
-        ::
-        :~  [%builds [%& builds.state.ax]]
-            [%compiler-cache [%& compiler-cache.state.ax]]
-    ==  ==
+    :+  %ford  %|
+    :~  builds+&+builds.state.ax
+        compiler-cache+&+compiler-cache.state.ax
+        dot+&+ax
+    ==
   ==
 ::  +take: receive a response from another vane
 ::

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1330,15 +1330,15 @@
   ::
       $wegh
     =/  =mass
-      =*  mas  mast.all
-      :+  (scot %p our)  %|
-      :~  [%foreign [%& sap.mast.all]]
+      :+  %gall  %|
+      :~  foreign+&+sap.mast.all
           :+  %blocked  %|
           (sort ~(tap by (~(run by wub.mast.all) |=(sofa [%& +<]))) aor)
           :+  %active   %|
           (sort ~(tap by (~(run by bum.mast.all) |=(seat [%& +<]))) aor)
+          dot+&+all
       ==
-    =/  =move  [hen %give %mass %gall %| [mass ~]]
+    =/  =move  [hen %give %mass mass]
     [[move ~] ..^$]
   ==
 ::

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -890,6 +890,22 @@
         $vine
       +>(yen (~(put in yen) hen))
     ::
+        %wegh
+      %_    +>
+          moz
+        :_  moz
+        ^-  move
+        :^  hen  %give  %mass
+        ^-  mass
+        :+  %jael  %|
+        :~  yen+&+yen
+            urb+&+urb
+            sub+&+sub
+            etn+&+etn
+            sap+&+sap
+        ==
+      ==
+    ::
     ::  authenticated remote request
     ::    {$west p/ship q/path r/*}
     ::

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -903,6 +903,7 @@
             sub+&+sub
             etn+&+etn
             sap+&+sap
+            dot+&+lex
         ==
       ==
     ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1786,6 +1786,7 @@
       ==  ==                                            ::
     ++  gift                                            ::  out result <-$
       $%  [%init p=ship]                                ::  report install unix
+          [%mass p=mass]                                ::  memory usage report
           [%mack p=(unit tang)]                         ::  message n/ack
           [%pubs public]                                ::  public keys
           [%turf turf=(list turf)]                      ::  domains
@@ -1862,6 +1863,7 @@
           [%vent ~]                                     ::  view ethereum events
           [%vest ~]                                     ::  view public balance
           [%vine ~]                                     ::  view secret history
+          [%wegh ~]                                     ::  memory usage request
           [%west p=ship q=path r=*]                     ::  remote request
           [%wind p=@ud]                                 ::  rewind before block
       ==                                                ::


### PR DESCRIPTION
Dill wasn't asking, and Jael didn't know how to answer. Now Jael's memory is reported in a format like this:
```
    %jael:
      %yen: B/0
      %urb: B/264
      %sub: B/744
      %etn: B/0
      %sap: B/48
    --KB/1.056
```

If we want more detail, we could probably take the list of snapshots in `sap` and print out their sizes one by one, turning their event number into a `@tas` to identify them. Seemed like overkill for now, though.