### PR TITLE
added look-kick functionality to eth-node

### DIFF
--- a/app/eth-manage.hoon
+++ b/app/eth-manage.hoon
@@ -31,11 +31,15 @@
       [%snap * ?]
     [ost.hid %snap /hi (snapshot:jael +<.val) +>.val]~
   ::
-      %look
+      %look-ethnode
     :_  ~
     =/  pul
       (need (de-purl:html 'http://eth-mainnet.urbit.org:8545'))
     [ost.hid %look /hi |+pul]
+  ::
+      [%look-kick who=@p]
+    :_  ~
+    [ost.hid %look /hi %& who.val]
   ==
 ::
 ++  vein


### PR DESCRIPTION
Adds %look-kick functionality to the eth-manage app, which allows you to change what source you are downloading snapshots from.

Changing this source seems to fix the problem of stars getting stuck on an old block number.