### PR TITLE
build tank outside of |.

### DIFF
--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -1158,9 +1158,10 @@
   ++  execute-turbo
     ~/  %execute-turbo
     |=  [tea=whir live=? request=schematic:ford]
+    =/  tan=tank  [%leaf "eyre: execute {(spud tea)}"]
     %+  pass-note  tea
     :*  %f  %build  live
-        [%dude |.([%leaf "eyre: execute {<tea>}"]) request]
+        [%dude =>(a=tan |.(a)) request]
     ==
   ::
   ++  add-links                                           :: x-urbit:// urls


### PR DESCRIPTION
Inside +execute-turbo in eyre, we moved the tank outside of the |. so that it's not held as a thunk. This stops ford from holding onto an 80MB error message in one of its caches.