### PR TITLE
notify vanes of kernel upgrades

### DIFF
--- a/lib/hood/helm.hoon
+++ b/lib/hood/helm.hoon
@@ -176,9 +176,9 @@
   =+  way=?:(zus (welp top /sys/[nam]) (welp top /sys/vane/[nam]))
   =+  fil=.^(@ %cx (welp way /hoon))
   [%flog /reload [%veer ?:(=('z' tip) %$ tip) way fil]]
-::  +poke-reset:  send %vega to reboot kernel
+::  +poke-reset:  send %lyra to initiate kernel upgrade
 ::
-::    And reinstall %zuse and the vanes.
+::    And reinstall %zuse and the vanes with %veer.
 ::    Trigger with |reset.
 ::
 ++  poke-reset
@@ -189,7 +189,7 @@
   =/  top=path  /(scot %p our)/home/(scot %da now)/sys
   =/  hun  .^(@ %cx (welp top /hoon/hoon))
   =/  arv  .^(@ %cx (welp top /arvo/hoon))
-  :-  [%flog /reset [%vega `@t`hun `@t`arv]]
+  :-  [%flog /reset [%lyra `@t`hun `@t`arv]]
   %+  turn
     (module-ova:pill top)
   |=(a=[wire flog:dill] [%flog a])

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -663,9 +663,10 @@
               ^-  [(list ovum) *]
               =>  .(+< ((hard ,[now=@da ovo=ovum]) +<))
               =^  ova  +>+.$  (^poke now ovo)
+              =|  out=(list ovum)
               |-  ^-  [(list ovum) *]
               ?~  ova
-                [~ +>.^$]
+                [(flop out) +>.^$]
               ::  upgrade the kernel -- %vega here is an effect from a vane
               ::
               ?:  ?=(%vega -.q.i.ova)
@@ -676,10 +677,8 @@
               ::  and passing the rest through as output
               ::
               =^  vov  +>+.^$  (feck now i.ova)
-              ?~  vov
-                $(ova t.ova)
-              =/  avo  $(ova t.ova)
-              [[+.vov -.avo] +.avo]
+              =?  out  ?=(^ vov)  [+.vov out]
+              $(ova t.ova)
     ::
     ++  wish  |=(* (^wish ((hard @ta) +<)))             ::  22
     --

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -540,9 +540,9 @@
     ::  we emit ova to unix in fifo order, but emit internal moves depth-first
     ::
     $(ova (weld ova p.nyx), mor (weld q.nyx t.mor))
-  ::  +kick-all: kick every vane with :ovum
+  ::  +spam: kick every vane with :ovum
   ::
-  ++  kick-all
+  ++  spam
     |=  [lac=? ovo=ovum]
     ^-  [(list ovum) (list [label=@tas =vane])]
     =/  card
@@ -551,7 +551,7 @@
       [%soft q.ovo]
     %+  kick  lac
     %+  turn  vanes
-    |=([label=@tas *] [label ~ [%pass / label card]])
+    |=([label=@tas *] [label ~ [%pass p.ovo label card]])
   --
 --
 =<  ::  Arvo larval stage
@@ -715,7 +715,7 @@
   ::
   ?:  ?=(%vega -.q.i.ova)
     =^  zef  vanes
-      (~(kick-all (is our vil eny bud vanes) now) lac i.ova)
+      (~(spam (is our vil eny bud vanes) now) lac i.ova)
     $(out [i.ova out], ova (weld t.ova zef))
   ::
   =^  vov  +>.^$  (feck now i.ova)

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -540,6 +540,18 @@
     ::  we emit ova to unix in fifo order, but emit internal moves depth-first
     ::
     $(ova (weld ova p.nyx), mor (weld q.nyx t.mor))
+  ::  +kick-all: kick every vane with :ovum
+  ::
+  ++  kick-all
+    |=  [lac=? ovo=ovum]
+    ^-  [(list ovum) (list [label=@tas =vane])]
+    =/  card
+      :+  %&
+        [%cell [%atom %tas `%soft] %noun]
+      [%soft q.ovo]
+    %+  kick  lac
+    %+  turn  vanes
+    |=([label=@tas *] [label ~ [%pass / label card]])
   --
 --
 =<  ::  Arvo larval stage
@@ -654,7 +666,7 @@
               |-  ^-  [(list ovum) *]
               ?~  ova
                 [~ +>.^$]
-              ::  upgrade the kernel
+              ::  upgrade the kernel -- %vega here is an effect from a vane
               ::
               ?:  ?=(%vega -.q.i.ova)
                 %+  fall
@@ -688,20 +700,28 @@
       bud  dub
       vanes  (turn nyf |=({a/@tas b/vise} [a [b *worm]]))
     ==
+  =|  out=(list ovum)
   |-  ^-  [(list ovum) _+>.^$]
   ?~  ova
-    [~ +>.^$]
+    [(flop out) +>.^$]
   ::  iterate over effects, handling those on arvo proper
   ::  and passing the rest through as output
   ::
   ::    In practice, the pending effects after an upgrade
-  ::    are the %veer moves to install %zuse and the vanes.
+  ::    are the %veer moves to install %zuse and the vanes,
+  ::    plus a %vega notification that the upgrade is complete.
+  ::
+  ::    N.B. this implementation assumes that %vega will be
+  ::    at the end of :ova.
+  ::
+  ?:  ?=(%vega -.q.i.ova)
+    =^  zef  vanes
+      (~(kick-all (is our vil eny bud vanes) now) lac i.ova)
+    $(out [i.ova out], ova (weld t.ova zef))
   ::
   =^  vov  +>.^$  (feck now i.ova)
-  ?~  vov
-    $(ova t.ova)
-  =/  avo  $(ova t.ova)
-  [[+.vov -.avo] +.avo]
+  =?  out  ?=(^ vov)  [+.vov out]
+  $(ova t.ova)
 ::
 ++  peek                                                ::  external inspect
   |=  {now/@da hap/path}
@@ -840,16 +860,18 @@
     :*  our
         now
         eny
-        ova
+        ::  tack a notification onto the pending effects
+        ::
+        (weld ova [`ovum`[/ %vega ~] ~])
         bud
         (turn vanes |=([label=@tas =vane] [label vase.vane]))
     ==
   ::  call into the new kernel
   ::
   =/  out  (slum gat sam)
-  ::  tack a reset notification onto the product
+  ::  add types to the product
   ::
-  [[[/ %vega ~] ((list ovum) -.out)] +.out]
+  [((list ovum) -.out) +.out]
 ::  +veer: install %zuse or a vane
 ::
 ::    Identity is in the sample so the larval stage

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -667,9 +667,9 @@
               |-  ^-  [(list ovum) *]
               ?~  ova
                 [(flop out) +>.^$]
-              ::  upgrade the kernel -- %vega here is an effect from a vane
+              ::  upgrade the kernel
               ::
-              ?:  ?=(%vega -.q.i.ova)
+              ?:  ?=(%lyra -.q.i.ova)
                 %+  fall
                   (vega now t.ova ({@ @} +.q.i.ova))
                 [~ +>.^$]

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1507,6 +1507,9 @@
             ==
           [[%wine who " has sunk"]~ fox]
         ::
+            %vega
+          [~ fox]
+        ::
             %wake
           (~(wake am [our now fox ski]) hen)
         ::

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -59,6 +59,11 @@
           =.  timers  (unset-timer [p.task hen])
           (set-wake ~)
         ::
+            ::  %vega: learn of a kernel upgrade
+            ::
+            %vega
+          [~ state]
+        ::
             ::  %wait: set a new timer
             ::
             %wait

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -3886,6 +3886,8 @@
   ::
       $sunk  [~ ..^$]
   ::
+      $vega  [~ ..^$]
+  ::
       ?($warp $werp)
     ::  capture whether this read is on behalf of another ship
     ::  for permissions enforcement

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -159,7 +159,7 @@
           $blew  (send %rez p.p.kyz q.p.kyz)
           $heft  heft
           $veer  (dump kyz)
-          $vega  (dump kyz)
+          $vega  ?>(?=(^ p.kyz) (dump kyz))
           $verb  (dump kyz)
         ==
       ::
@@ -530,6 +530,14 @@
   ::  a %sunk notification from %jail comes in on an unfamiliar duct
   ::
   ?:  ?=(%sunk -.task)
+    [~ ..^$]
+  ::  a %vega notification on kernel upgrade comes in on an unfamiliar duct
+  ::
+  ::    XX note that this is different from the %vega that triggers
+  ::    a kernel upgrade (from lib/hood/helm)
+  ::    XX do something about this naming collision
+  ::
+  ?:  ?=([%vega ~] task)
     [~ ..^$]
   ::
   =/  nus  (ax hen)

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -51,9 +51,9 @@
   $%  {$crud p/@tas q/(list tank)}                      ::
       {$heft $~}                                        ::
       {$init p/ship}                                    ::
+      {$lyra p/@t q/@t}                                 ::  upgrade kernel
       {$text p/tape}                                    ::
       {$veer p/@ta q/path r/@t}                         ::  install vane
-      {$vega p/@t q/@t}                                 ::  reboot by path
       {$verb $~}                                        ::  verbose mode
   ==                                                    ::
 ++  note-eyre                                           ::
@@ -158,8 +158,8 @@
                  (crud p.kyz q.kyz)
           $blew  (send %rez p.p.kyz q.p.kyz)
           $heft  heft
+          $lyra  (dump kyz)
           $veer  (dump kyz)
-          $vega  ?>(?=(^ p.kyz) (dump kyz))
           $verb  (dump kyz)
         ==
       ::
@@ -533,11 +533,7 @@
     [~ ..^$]
   ::  a %vega notification on kernel upgrade comes in on an unfamiliar duct
   ::
-  ::    XX note that this is different from the %vega that triggers
-  ::    a kernel upgrade (from lib/hood/helm)
-  ::    XX do something about this naming collision
-  ::
-  ?:  ?=([%vega ~] task)
+  ?:  ?=(%vega -.task)
     [~ ..^$]
   ::
   =/  nus  (ax hen)

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -729,6 +729,8 @@
     ::
         $sunk  +>
     ::
+        $vega  +>
+    ::
         ?($chis $this)                                  ::  inbound request
       %-  emule  |.  ^+  ..apex
       =*  sec  p.kyz    ::  ?                           ::  https bit

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -6183,6 +6183,14 @@
     ::
     [~ ford-gate]
   ::
+      ::  %vega: learn of kernel upgrade
+      ::
+      ::    XX clear cache, rebuild live builds
+      ::
+      %vega
+    ::
+    [~ ford-gate]
+  ::
       ::  %wipe: wipe stored builds, clearing :percent-to-remove of the entries
       ::
       %wipe

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1317,6 +1317,8 @@
   ::
       $sunk  [~ ..^$]
   ::
+      $vega  [~ ..^$]
+  ::
       $west
     ?>  ?=({?($ge $gh) @ ~} q.q.hic)
     =*  dap  i.t.q.q.hic

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -865,6 +865,12 @@
       ?<  =(fak.own.sub ?=(^ tuf.own.sub))
       +>.$(moz [[hen %give %turf tuf.own.sub] moz])
     ::
+    ::  learn of kernel upgrade
+    ::    [%vega ~]
+    ::
+        %vega
+      +>.$
+    ::
     ::  watch private keys
     ::    {$vein $~}
     ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -622,10 +622,10 @@
           {$burl p/@t}                                  ::  activate url
           {$init p/@p}                                  ::  set owner
           {$logo ~}                                    ::  logout
+          {$lyra p/@t q/@t}                             ::  upgrade kernel
           {$mass p/mass}                                ::  memory usage
           {$send p/lane:ames q/@}                       ::  transmit packet
           {$veer p/@ta q/path r/@t}                     ::  install vane
-          {$vega p/@t q/@t}                             ::  reboot
           {$verb ~}                                    ::  verbose mode
       ==                                                ::
     ++  task                                            ::  in request ->$
@@ -640,14 +640,13 @@
           {$hook ~}                                    ::  this term hung up
           {$harm ~}                                    ::  all terms hung up
           {$init p/ship}                                ::  after gall ready
+          {$lyra p/@t q/@t}                             ::  upgrade kernel
           {$noop ~}                                    ::  no operation
           {$sunk p=ship q=life}                         ::  report death
           {$talk p/tank}                                ::
           {$text p/tape}                                ::
           {$veer p/@ta q/path r/@t}                     ::  install vane
-          ::  XX gross hack to trigger or report upgrade
-          ::
-          {$vega p/?(~ {p/@t q/@t})}                    ::  reboot
+          {$vega ~}                                     ::  report upgrade
           {$verb ~}                                     ::  verbose mode
       ==                                                ::
     --  ::able
@@ -705,9 +704,9 @@
   ++  flog                                              ::  sent to %dill
     $%  {$crud p/@tas q/(list tank)}                    ::
         {$heft ~}                                      ::
+        {$lyra p/@t q/@t}                               ::  upgrade kernel
         {$text p/tape}                                  ::
         {$veer p/@ta q/path r/@t}                       ::  install vane
-        {$vega p/@t q/@t}                               ::  reboot
         {$verb ~}                                      ::  verbose mode
     ==                                                  ::
   --  ::dill

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -617,16 +617,16 @@
   ++  able  ^?
     |%
     ++  gift                                            ::  out result <-$
-      $%  {$bbye ~}                                    ::  reset prompt
+      $%  {$bbye ~}                                     ::  reset prompt
           {$blit p/(list blit)}                         ::  terminal output
           {$burl p/@t}                                  ::  activate url
           {$init p/@p}                                  ::  set owner
-          {$logo ~}                                    ::  logout
+          {$logo ~}                                     ::  logout
           {$lyra p/@t q/@t}                             ::  upgrade kernel
           {$mass p/mass}                                ::  memory usage
           {$send p/lane:ames q/@}                       ::  transmit packet
           {$veer p/@ta q/path r/@t}                     ::  install vane
-          {$verb ~}                                    ::  verbose mode
+          {$verb ~}                                     ::  verbose mode
       ==                                                ::
     ++  task                                            ::  in request ->$
       $%  {$belt p/belt}                                ::  terminal input
@@ -635,13 +635,13 @@
           {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$flog p/flog}                                ::  wrapped error
           {$flow p/@tas q/(list gill:gall)}             ::  terminal config
-          {$hail ~}                                    ::  terminal refresh
-          {$heft ~}                                    ::  memory report
-          {$hook ~}                                    ::  this term hung up
-          {$harm ~}                                    ::  all terms hung up
+          {$hail ~}                                     ::  terminal refresh
+          {$heft ~}                                     ::  memory report
+          {$hook ~}                                     ::  this term hung up
+          {$harm ~}                                     ::  all terms hung up
           {$init p/ship}                                ::  after gall ready
           {$lyra p/@t q/@t}                             ::  upgrade kernel
-          {$noop ~}                                    ::  no operation
+          {$noop ~}                                     ::  no operation
           {$sunk p=ship q=life}                         ::  report death
           {$talk p/tank}                                ::
           {$text p/tape}                                ::
@@ -656,46 +656,46 @@
   ++  blew  {p/@ud q/@ud}                               ::  columns rows
   ++  belt                                              ::  old belt
     $%  {$aro p/?($d $l $r $u)}                         ::  arrow key
-        {$bac ~}                                       ::  true backspace
+        {$bac ~}                                        ::  true backspace
         {$ctl p/@c}                                     ::  control-key
-        {$del ~}                                       ::  true delete
+        {$del ~}                                        ::  true delete
         {$met p/@c}                                     ::  meta-key
-        {$ret ~}                                       ::  return
+        {$ret ~}                                        ::  return
         {$txt p/(list @c)}                              ::  utf32 text
     ==                                                  ::
   ++  blit                                              ::  old blit
-    $%  {$bel ~}                                       ::  make a noise
-        {$clr ~}                                       ::  clear the screen
+    $%  {$bel ~}                                        ::  make a noise
+        {$clr ~}                                        ::  clear the screen
         {$hop p/@ud}                                    ::  set cursor position
         {$lin p/(list @c)}                              ::  set current line
-        {$mor ~}                                       ::  newline
+        {$mor ~}                                        ::  newline
         {$sag p/path q/*}                               ::  save to jamfile
         {$sav p/path q/@}                               ::  save to file
         {$url p/@t}                                     ::  activate url
     ==                                                  ::
-  ++  deco  ?(~ $bl $br $un)                           ::  text decoration
+  ++  deco  ?(~ $bl $br $un)                            ::  text decoration
   ++  dill-belt                                         ::  new belt
     $%  {$aro p/?($d $l $r $u)}                         ::  arrow key
-        {$bac ~}                                       ::  true backspace
+        {$bac ~}                                        ::  true backspace
         {$cru p/@tas q/(list tank)}                     ::  echo error
         {$ctl p/@}                                      ::  control-key
-        {$del ~}                                       ::  true delete
-        {$hey ~}                                       ::  refresh
+        {$del ~}                                        ::  true delete
+        {$hey ~}                                        ::  refresh
         {$met p/@}                                      ::  meta-key
-        {$ret ~}                                       ::  return
+        {$ret ~}                                        ::  return
         {$rez p/@ud q/@ud}                              ::  resize, cols, rows
         {$txt p/(list @c)}                              ::  utf32 text
         {$yow p/gill:gall}                              ::  connect to app
     ==                                                  ::
   ++  dill-blit                                         ::  new blit
-    $%  {$bel ~}                                       ::  make a noise
-        {$clr ~}                                       ::  clear the screen
+    $%  {$bel ~}                                        ::  make a noise
+        {$clr ~}                                        ::  clear the screen
         {$hop p/@ud}                                    ::  set cursor position
         {$klr p/stub}                                   ::  styled text
         {$mor p/(list dill-blit)}                       ::  multiple blits
         {$pom p/stub}                                   ::  styled prompt
         {$pro p/(list @c)}                              ::  show as cursor+line
-        {$qit ~}                                       ::  close console
+        {$qit ~}                                        ::  close console
         {$out p/(list @c)}                              ::  send output line
         {$sag p/path q/*}                               ::  save to jamfile
         {$sav p/path q/@}                               ::  save to file
@@ -703,11 +703,11 @@
     ==                                                  ::
   ++  flog                                              ::  sent to %dill
     $%  {$crud p/@tas q/(list tank)}                    ::
-        {$heft ~}                                      ::
+        {$heft ~}                                       ::
         {$lyra p/@t q/@t}                               ::  upgrade kernel
         {$text p/tape}                                  ::
         {$veer p/@ta q/path r/@t}                       ::  install vane
-        {$verb ~}                                      ::  verbose mode
+        {$verb ~}                                       ::  verbose mode
     ==                                                  ::
   --  ::dill
 ::                                                      ::::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -242,6 +242,7 @@
           {$kick p/@da}                                 ::  wake up
           {$nuke p/@p}                                  ::  toggle auto-block
           {$sunk p=ship q=life}                         ::  report death
+          {$vega ~}                                     ::  report upgrade
           {$wake ~}                                     ::  timer activate
           {$wegh ~}                                     ::  report memory
           {$west p/ship q/path r/*}                     ::  network request
@@ -423,6 +424,7 @@
       $%  {$born ~}                                     ::  new unix process
           {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$rest p/@da}                                 ::  cancel alarm
+          {$vega ~}                                     ::  report upgrade
           {$wait p/@da}                                 ::  set alarm
           {$wake ~}                                    ::  timer activate
           {$wegh ~}                                    ::  report memory
@@ -475,6 +477,7 @@
           {$ogre pot/$@(desk beam)}                     ::  delete mount point
           {$perm des/desk pax/path rit/rite}            ::  change permissions
           {$sunk p=ship q=life}                         ::  report death
+          {$vega ~}                                     ::  report upgrade
           {$warp wer/ship rif/riff}                     ::  internal file req
           {$werp who/ship wer/ship rif/riff}            ::  external file req
           {$wegh ~}                                     ::  report memory
@@ -642,8 +645,10 @@
           {$talk p/tank}                                ::
           {$text p/tape}                                ::
           {$veer p/@ta q/path r/@t}                     ::  install vane
-          {$vega p/@t q/@t}                             ::  reboot
-          {$verb ~}                                    ::  verbose mode
+          ::  XX gross hack to trigger or report upgrade
+          ::
+          {$vega p/?(~ {p/@t q/@t})}                    ::  reboot
+          {$verb ~}                                     ::  verbose mode
       ==                                                ::
     --  ::able
   ::
@@ -741,6 +746,7 @@
           [%chis p=? q=clip r=httq]                     ::  IPC inbound request
           [%this p=? q=clip r=httq]                     ::  inbound request
           [%thud ~]                                     ::  inbound cancel
+          [%vega ~]                                     ::  report upgrade
           [%wegh ~]                                     ::  report memory
           [%well p=path q=(unit mime)]                  ::  put/del .well-known
           [%west p=ship q=[path *]]                     ::  network request
@@ -977,6 +983,9 @@
           ::  %sunk: receive a report that a foreign ship has lost continuity
           ::
           [%sunk =ship =life]
+          ::  %vega: report kernel upgrade
+          ::
+          [%vega ~]
           ::  %wegh: produce memory usage information
           ::
           [%wegh ~]
@@ -1668,6 +1677,7 @@
           {$init p/ship}                                ::  set owner
           {$deal p/sock q/cush}                         ::  full transmission
           {$sunk p=ship q/life}                         ::  report death
+          {$vega ~}                                     ::  report upgrade
           {$west p/ship q/path r/*}                     ::  network request
           {$wegh ~}                                     ::  report memory
       ==                                                ::
@@ -1859,6 +1869,7 @@
           [%meet =ship =life =pass]                     ::  met after breach
           [%snap snap=snapshot kick=?]                  ::  load snapshot
           [%turf ~]                                     ::  view domains
+          [%vega ~]                                     ::  report upgrade
           [%vein ~]                                     ::  view signing keys
           [%vent ~]                                     ::  view ethereum events
           [%vest ~]                                     ::  view public balance


### PR DESCRIPTION
This PR updates arvo to send a `[%vega ~]` task to every vane after a kernel upgrade (and after the %zuse and the vanes have been recompiled as well).

Right now, the task handlers in each vane are just stubs. I think the most pressing feature is to make %ford clear it's cache and rebuild all live builds. This PR could go in as is, or it could be held open until the task handlers themselves are also implemented.

Note that this change creates an awkward naming collision in %dill, which already handles a %vega task (to trigger the kernel upgrade). I've handled this for now with an ugly type fork. Eventually, the different moves that together make up the kernel upgrade procedure should probably have different names.