### PR TITLE
ensures  defaults in $~ specs nest in the actual structure

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -7830,7 +7830,7 @@
                  ::
                  [%tsld [%$ 6] p.mod]
       {$bspd *}  $(mod p.mod)
-      {$bssg *}  p.mod
+      {$bssg *}  [%kthp q.mod p.mod]
       {$bsts *}  [%ktts p.mod $(mod q.mod)]
       {$bsvt *}  $(mod p.mod)
       {$bswt *}  ::  use last entry
@@ -7891,7 +7891,7 @@
     ::  process annotations outside construct, to catch default
     ::
     ?:  ?=($dbug -.mod)  factory(mod q.mod, bug [p.mod bug])
-    ?:  ?=($bssg -.mod)  factory(mod q.mod, def `p.mod)
+    ?:  ?=($bssg -.mod)  factory(mod q.mod, def `[%kthp q.mod p.mod])
     ^-  hoon
     ::  if we recognize an indirection
     ::
@@ -8212,7 +8212,7 @@
       ::  default
       ::
           {$bssg *}
-        relative(mod q.mod, def `p.mod)
+        relative(mod q.mod, def `[%kthp q.mod p.mod])
       ::
       ::  choice, $?
       ::


### PR DESCRIPTION
A fix for #1045