### PR TITLE
Minimum viable Bitcoin RPC support

### DIFF
--- a/app/bitcoin-cli.hoon
+++ b/app/bitcoin-cli.hoon
@@ -1,0 +1,103 @@
+::  minimum viable bitcoin app
+::
+::    first, run |init-auth-basic with bitcoin-rpc as the domain (no .tld)
+::    to configure your rpc username and password.
+::    then, poke this app with either an %app command or %rpc request.
+::
+/+  *bitcoin, basic-auth
+::
+|%
+++  task
+  $%  [%rpc req=request:rpc]
+      [%app cmd=command]
+  ==
+::
+++  command
+  $%  [%select-wallet name=(unit @tas)]
+  ==
+::
+++  state
+  $:  wallet=(unit @tas)
+  ==
+::
+++  move  (pair bone card)
+++  card
+  $%  [%hiss wire (unit user:eyre) mark %hiss hiss:eyre]
+  ==
+::
+--
+::
+|_  [=bowl:gall state]
+++  prep
+  |=  (unit *)
+  ^-  (quip move _+>)
+  [~ ..prep]
+::
+++  poke-noun
+  |=  =task
+  ^-  (quip move _+>)
+  ?:  ?=(%app -.task)
+    ?-  -.cmd.task
+      %select-wallet  [~ +>.$(wallet name.cmd.task)]
+    ==
+  :_  +>.$
+  :_  ~
+  ^-  move
+  :-  ost.bowl
+  ^-  card
+  :*  %hiss
+      /some/wire
+      [~ '']
+      %json-rpc-response
+      %hiss
+      (auth-request /sec/bitcoin-rpc/atom req.task)
+  ==
+::
+++  sigh-json-rpc-response
+  |=  [wir=wire res=response:rpc:jstd]
+  ^-  (quip move _+>)
+  ~|  res
+  ~&  (parse-response:rpc res)
+  [~ +>.$]
+::
+++  request-to-hiss
+  |=  req=request:rpc
+  %+  request-to-hiss:rpc:jstd
+    =-  (need (de-purl:html (crip -)))
+    =+  url="http://localhost:18443/"
+    ?.  ?=(?(%generate) -.req)  url
+    ?~  wallet  url
+    (weld url "wallet/{(trip u.wallet)}")
+  (request-to-rpc:rpc req)
+::
+++  auth-request
+  |=  [key=path req=request:rpc]
+  ^-  hiss:eyre
+  %.  (request-to-hiss req)
+  ~(add-auth-header basic-auth (bale-from-path key) ~)
+::
+::TODO  into /lib/sec?
+::
+++  get-code
+  ^-  @t
+  =-  (crip +:(scow %p .^(@p %j -)))
+  %-  en-beam:format
+  =,  bowl
+  [[our %code da+now] /(scot %p our)]
+::
+++  bale-from-path
+  |=  =path
+  ^-  (bale:eyre @t)
+  :+  [our now eny byk]:bowl
+    [*user:eyre domain=*(list @t)]
+  ^-  @t
+  %-  decode-atom
+  %+  slav  %uw
+  .^(@ %cx (weld =,(bowl /(scot %p our)/[q.byk]/(scot %da now)) path))
+::
+++  decode-atom
+  |=  dat=@
+  ^-  @
+  %-  need
+  (de:crub:crypto get-code dat)
+--

--- a/lib/bitcoin.hoon
+++ b/lib/bitcoin.hoon
@@ -1,0 +1,66 @@
+/-  *bitcoin
+|%
+++  rpc
+  =,  ^rpc
+  |%
+  ++  request-to-rpc
+    =,  enjs:format
+    |=  req=request
+    ^-  request:rpc:jstd
+    :-  -.req
+    ?-  -.req
+        %generate
+      :-  'generate'
+      :-  %list
+      ^-  (list json)
+      :-  (numb blocks.req)
+      ?~  max-tries.req  ~
+      [(numb u.max-tries.req) ~]
+    ::
+        %get-block-count
+      :-  'getblockcount'
+      list+~
+    ::
+        %list-wallets
+      :-  'listwallets'
+      list+~
+    ::
+        %create-wallet
+      :-  'createwallet'
+      :-  %list
+      :~  s+name.req
+          b+disable-private-keys.req
+      ==
+    ==
+  ::
+  ++  parse-response
+    =,  dejs:format
+    |=  res=response:rpc:jstd
+    ^-  response
+    ~|  -.res
+    ?>  ?=(%result -.res)
+    ?+  id.res
+      ~|  [%unsupported-response id.res]
+      !!
+    ::
+        %generate
+      :-  id.res
+      %.  res.res
+      (ar (su hex))
+    ::
+        %get-block-count
+      :-  id.res
+      (ni res.res)
+    ::
+        %list-wallets
+      :-  id.res
+      %.  res.res
+      (ar so)
+    ::
+        %create-wallet
+      :-  id.res
+      %.  res.res
+      (ot name+so warning+so ~)
+    ==
+  --
+--

--- a/mar/json/rpc/response.hoon
+++ b/mar/json/rpc/response.hoon
@@ -1,6 +1,5 @@
 ::
-/-  json-rpc
-=,  json-rpc
+=,  rpc:jstd
 ::
 |_  res=response
 ::

--- a/sur/bitcoin.hoon
+++ b/sur/bitcoin.hoon
@@ -1,0 +1,27 @@
+|%
+++  address  @  ::TODO  did an aura exist for this? we need a to-string arm
+++  blockhash  @ux
+::
+++  rpc
+  |%
+  +$  request
+    $%  ::  node management
+        ::
+        [%generate blocks=@ud max-tries=(unit @ud)]
+        ::  chain state
+        ::
+        [%get-block-count ~]
+        ::  wallet management
+        ::
+        [%list-wallets ~]
+        [%create-wallet name=@t disable-private-keys=_|]
+    ==
+  ::
+  +$  response
+    $%  [%generate blocks=(list blockhash)]
+        [%get-block-count count=@ud]
+        [%list-wallets wallets=(list @t)]
+        [%create-wallet name=@t warning=@t]
+    ==
+  --
+--

--- a/sur/json/rpc.hoon
+++ b/sur/json/rpc.hoon
@@ -1,8 +1,0 @@
-|%
-++  response  ::TODO  id should be optional
-  $%  [%result id=@t res=json]
-      [%error id=@t code=@t message=@t]  ::TODO  data?
-      [%fail hit=httr:eyre]
-      [%batch bas=(list response)]
-  ==
---

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -95,7 +95,17 @@
   |%
   ++  rpc
     |%
-    ++  response  ::TODO  id should be optional
+    +$  request
+      $:  id=@t
+          method=@t
+          params=request-params
+      ==
+    ::
+    +$  request-params
+      $%  [%list (list json)]
+          [%object (list (pair @t json))]
+      ==
+    +$  response
       $~  [%fail *httr:eyre]
       $%  [%result id=@t res=json]
           [%error id=@t code=@t message=@t]  ::TODO  data?
@@ -7971,6 +7981,8 @@
       ^-  json
       %-  pairs
       =;  r=[met=@t pas=(list json)]
+        ::TODO  should use request-to-json:rpc:jstd,
+        ::      and probably (fall riq -.req)
         :*  jsonrpc+s+'2.0'
             method+s+met.r
             params+a+pas.r
@@ -8165,6 +8177,43 @@
   ++  hex-to-num
     |=  a=@t
     (rash (rsh 3 2 a) hex)
+  --
+::
+::  |jstd: json standard library
+::
+++  jstd
+  =,  ^jstd
+  |%
+  ++  rpc
+    =,  ^rpc
+    |%
+    ++  request-to-hiss
+      |=  [url=purl:eyre req=request]
+      ^-  hiss:eyre
+      :-  url
+      :+  %post
+        %-  ~(gas in *math:eyre)
+        ~['Content-Type'^['application/json']~]
+      %-  some
+      %-  as-octt:mimes:html
+      (en-json:html (request-to-json req))
+    ::
+    ++  request-to-json
+      |=  request
+      ^-  json
+      %-  pairs:enjs:format
+      :~  jsonrpc+s+'0.2'
+          id+s+id
+          method+s+method
+        ::
+          :-  %params
+          ^-  json
+          ?-  -.params
+            %list     [%a +.params]
+            %object   [%o (~(gas by *(map @t json)) +.params)]
+          ==
+      ==
+    --
   --
 ::
 ::  |dawn: pre-boot request/response de/serialization and validation


### PR DESCRIPTION
This includes a `bitcoin` `sur` and `lib` for dealing with Bitcoin RPC requests and responses.  
I've included a simple `/app/bitcoin-cli` that uses the lib to forward RPC call nouns to an actual node. Very bare-bones, with hard-coded URL and all... [but it works!](https://twitter.com/mdfang/status/1092171862178701313)

This PR is easily considered incomplete, but I'm opening it for discussion to support further development. Maybe we're fine merging this as-is though? It works, and "support additional Bitcoin RPC calls" might be a good contributor issue.

It'd be cool if we could send transactions in whatever way. I think my best bet it to talk to @loganallenc about what the deal is with the accounts/wallets and transactions interfaces.  
I vaguely remember there being auras for bitcoin addresses, does anyone know what they are?

The request-tag-as-json-id pattern here feels pretty nice. We might want to consider using that for Ethereum RPC integration as well, as a default, but I haven't thought it over much yet.

Includes/depends on #1051.