### PR TITLE
adds some details to |mass, plug a leak in %ames

### DIFF
--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -917,4 +917,3 @@
   |=  txt/@
   q:(slap bud (ream txt))
 --
-

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -770,11 +770,20 @@
     =.  q.q.ovo
       :-  %userspace
       :-  %|
-      :~  hoon+`pit
-          zuse+`bud
-          ::  hoon-cache+`p.niz
+      :~  hoon+&+pit
+          zuse+&+bud
+          :+  %caches  %|
+          %+  turn
+            %+  sort  vanes
+            |=([a=[lab=@tas *] b=[lab=@tas *]] (aor lab.a lab.b))
+          |=([label=@tas =vane] [(cat 3 %vane- label) %& worm.vane])
           q.q.ovo
-          dot+`.
+          :+  %vases  %|
+          %+  turn
+            %+  sort  vanes
+            |=([a=[lab=@tas *] b=[lab=@tas *]] (aor lab.a lab.b))
+          |=([label=@tas =vane] [(cat 3 %vane- label) %& vase.vane])
+          dot+&+.
       ==
     [[~ ovo] +>.$]
   ::  add entropy

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1508,7 +1508,14 @@
           [[%wine who " has sunk"]~ fox]
         ::
             %vega
-          [~ fox]
+          ::  re-initialize our cryptosuite B cores
+          ::
+          =/  =wund
+            %+  turn
+              val.ton.fox
+            |=  [=life =ring *]
+            [life ring (nol:nu:crub:crypto ring)]
+          [~ fox(val.ton wund)]
         ::
             %wake
           (~(wake am [our now fox ski]) hen)
@@ -1541,6 +1548,19 @@
   ++  wegh
     ^-  mass
     :+  %ames  %|
-    :~  dot+&+fox
+    :~  :+  %town  %|
+        =>  ton.fox
+        :~  wund+&+val
+            deed+&+law
+            fast+&+seh
+            them+&+hoc
+        ==
+        :+  %corn  %|
+        =>  zac.fox
+        :~  incoming+&+nys
+            complete+&+olz
+            neighbor+&+wab
+        ==
+        dot+&+fox
     ==
   --


### PR DESCRIPTION
%ames keeps a `+crub` core with its keys already installed. I don't know if this was a performance optimization, or just an artifact of an earlier time. In any case, we now re-establish that core after a kernel reset.