### PR TITLE
Make a new ship launch into dojo

### DIFF
--- a/.travis/test.js
+++ b/.travis/test.js
@@ -83,16 +83,6 @@ function barMass(urb) {
 }
 
 Promise.resolve(urbit)
-//  XX temporary
-//  send ctrl-x to select dojo
-//
-.then(function(){
-  return urbit.expect(/talk\[\] /)
-  .then(function() {
-    return urbit.pty.write("\x18")
-  })
-  .then(function() { return urbit })
-})
 .then(actions.safeBoot)
 .then(function(){
   return barMass(urbit);

--- a/lib/hood/drum.hoon
+++ b/lib/hood/drum.hoon
@@ -99,12 +99,12 @@
   ^-  part
   :*  %drum
       %2
-      ~                                                 ::  sys
-      (deft-fish our)                                   ::  eel
-      (deft-apes our)                                   ::  ray
-      ~                                                 ::  fur
-      ~                                                 ::  bin
-  ==                                                    ::
+      sys=~
+      eel=(deft-fish our)
+      ray=(deft-apes our)
+      fur=~
+      bin=~
+  ==
 ::
 ::
 ++  en-gill                                           ::  gill to wire
@@ -245,7 +245,9 @@
 ::
 ++  se-adit                                           ::  update servers
   ^+  .
-  %+  roll  ~(tap in ray)
+  ::  ensure dojo connects after talk
+  =*  dojo-on-top  aor
+  %+  roll  (sort ~(tap in ray) dojo-on-top)
   =<  .(con +>)
   |:  $:{wel/well:gall con/_..se-adit}  ^+  con
   =.  +>.$  con


### PR DESCRIPTION
Currently, when you launch a new ship, after initialization, you are dumped into talk. This change makes it so you are dumped into dojo instead.

The thing you are dumped into is a consequence of sort order over the `ray` set defined in `lib/hood/drum.hoon`. Under the previous `mug` algorithm, it happened that `dojo` was first.

This fixes issue #1033.