### PR TITLE
Don't fire timer in the middle of another event and take one timer at a time

### DIFF
--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -59,9 +59,6 @@
   ++  wait
     |=  date=@da
     ^+  [moves state]
-    ::  process elapsed timers first to maintain sort order
-    ::
-    =.  event-core    notify-clients
     =.  timers.state  (set-timer [date duct])
     set-wake
   ::  +wake: unix says we should wake up; notify clients and set :next-wake
@@ -92,7 +89,7 @@
   ::
   ++  notify-clients
     =*  timers  timers.state
-    |-  ^+  event-core
+    ^+  event-core
     ::
     ?~  timers
       =.  moves  (flop moves)
@@ -102,10 +99,10 @@
       =.  moves  (flop moves)
       event-core
     ::
-    %_  $
-      timers  t.timers
-      moves   [[duct.i.timers %give %wake ~] moves]
-    ==
+    =.  moves  [[duct.i.timers %give %wake ~] moves]
+    =>  .(timers t.timers)
+    =.  moves  (flop moves)
+    event-core
   ::  +set-wake: set or unset a unix timer to wake us when next timer expires
   ::
   ::    We prepend the unix %doze event so that it is handled first. Arvo must


### PR DESCRIPTION
While debugging issues in aquarium, I changed these behaviors of behn.  With these changes, I think it's now true that we fire no more than one timer in an event, and only if this is a %wake event straight from unix.  This should make it much easier to reason about behn's behavior.

There was never any good reason to fire a timer while setting another timer, right?  I think I was running into a situation where I'd have one thing set a timer for `now` to try to wait for the next event, and then another would do the same thing in the same event, which would fire the first in the same event.

It's super weird, btw, that we `(flop moves)` in several places rather than once in a `++abet`-style function.  I *think* the flops are right, but I really can't tell.