### PR TITLE
Clear ford, send %incompletes on %vega

### DIFF
--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -1467,8 +1467,6 @@
       `move`[duct %give %made now %incomplete ~]
     ::
     =.  moves  (weld incompletes moves)
-    :: For some reason, setting it to *_state instead of *ford-state
-    :: doesn't work. TODO: understand this.
     =.  state  *ford-state
     ..execute
   ::  +cancel: cancel a build

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -7012,7 +7012,7 @@
       ::
       moves=~
     ==
-  (weld results (expect-ford-empty ford-gate ~nul))
+  (weld results (expect-ford-very-empty ford-gate ~nul))
 ::
 ++  test-vega-complete-once-build  ^-  tang
   ::
@@ -7044,7 +7044,7 @@
   ;:  weld
     results1
     results2
-    (expect-ford-empty ford-gate ~nul)
+    (expect-ford-very-empty ford-gate ~nul)
   ==
 ::
 ++  test-vega-live-build  ^-  tang
@@ -7077,7 +7077,7 @@
   ;:  weld
     results1
     results2
-    (expect-ford-empty ford-gate ~nul)
+    (expect-ford-very-empty ford-gate ~nul)
   ==
 ::
 ++  test-vega-many  ^-  tang
@@ -7148,7 +7148,7 @@
     results2
     results3
     results4
-    (expect-ford-empty ford-gate ~nul)
+    (expect-ford-very-empty ford-gate ~nul)
   ==
 ::
 ++  test-vega-in-progress-once-build  ^-  tang
@@ -7186,7 +7186,7 @@
   ;:  weld
     results1
     results2
-    (expect-ford-empty ford-gate ~nul)
+    (expect-ford-very-empty ford-gate ~nul)
   ==
 ::  |data: shared data between cases
 ::  +|  data
@@ -7536,12 +7536,13 @@
 ::  +expect-ford-empty: assert that ford's state is one empty ship
 ::
 ::    At the end of every test, we want to assert that we have cleaned up all
-::    state.
+::    state, modulo caching.
 ::
 ++  expect-ford-empty
   |=  [ford-gate=_ford-gate ship=@p]
   ^-  tang
   ::
+  :: clear all caches
   =^  results1  ford-gate
     %-  ford-call  :*
       ford-gate
@@ -7565,6 +7566,35 @@
   ?:  =(default-state state)
     ~
   ::
+  =/  build-state=(list tank)
+    %-  zing
+    %+  turn  ~(tap by builds.state)
+    |=  [build=build:ford build-status=build-status:ford]
+    :~  [%leaf (build-to-tape:ford build)]
+        [%leaf "requesters: {<requesters.build-status>}"]
+        [%leaf "clients: {<~(tap in ~(key by clients.build-status))>}"]
+    ==
+  ::
+  =/  braces  [[' ' ' ' ~] ['{' ~] ['}' ~]]
+  ::
+  :~  [%leaf "failed to cleanup"]
+      [%leaf "builds.state:"]
+      [%rose braces build-state]
+  ==
+:: +expect-ford-very-empty: assert that ford's state is a very empty ship
+::
+::   At the end of some tests, we want to assert that we have cleaned up all
+::   state, *including* the caches.
+++  expect-ford-very-empty
+  |=  [ford-gate=_ford-gate ship=@p]
+  ^-  tang
+  ::
+  =/  ford  *ford-gate
+  =/  state  state.ax.+>+<.ford
+  =/  default-state  *ford-state:ford
+  ::
+  ?:  =(default-state state)
+    ~
   =/  build-state=(list tank)
     %-  zing
     %+  turn  ~(tap by builds.state)

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -14,6 +14,7 @@
 ::
 =/  test-pit=vase  !>(..zuse)
 =/  ford-gate  (ford-vane test-pit)
+=/  ford-types  *ford-gate  :: use only for getting the defined types, please
 ~!  +6.ford-gate
 ::
 |%
@@ -7561,45 +7562,34 @@
   =.  max-size.queue.build-cache.state  max-size.queue.build-cache.default-state
   =.  next-anchor-id.build-cache.state  0
   ::
-  %+  welp  results1
-  ::
-  ?:  =(default-state state)
-    ~
-  ::
-  =/  build-state=(list tank)
-    %-  zing
-    %+  turn  ~(tap by builds.state)
-    |=  [build=build:ford build-status=build-status:ford]
-    :~  [%leaf (build-to-tape:ford build)]
-        [%leaf "requesters: {<requesters.build-status>}"]
-        [%leaf "clients: {<~(tap in ~(key by clients.build-status))>}"]
-    ==
-  ::
-  =/  braces  [[' ' ' ' ~] ['{' ~] ['}' ~]]
-  ::
-  :~  [%leaf "failed to cleanup"]
-      [%leaf "builds.state:"]
-      [%rose braces build-state]
-  ==
+  (welp results1 (expect-ford-state-zero state))
 :: +expect-ford-very-empty: assert that ford's state is a very empty ship
 ::
 ::   At the end of some tests, we want to assert that we have cleaned up all
 ::   state, *including* the caches.
+::
 ++  expect-ford-very-empty
   |=  [ford-gate=_ford-gate ship=@p]
   ^-  tang
   ::
   =/  ford  *ford-gate
   =/  state  state.ax.+>+<.ford
-  =/  default-state  *ford-state:ford
+  ::
+  (expect-ford-state-zero state)
+::
+++  expect-ford-state-zero
+  |=  state=ford-state:ford-types
+  ^-  tang
+  ::
+  =/  default-state  *ford-state:ford-types
   ::
   ?:  =(default-state state)
     ~
   =/  build-state=(list tank)
     %-  zing
     %+  turn  ~(tap by builds.state)
-    |=  [build=build:ford build-status=build-status:ford]
-    :~  [%leaf (build-to-tape:ford build)]
+    |=  [build=build:ford-types build-status=build-status:ford-types]
+    :~  [%leaf (build-to-tape:ford-types build)]
         [%leaf "requesters: {<requesters.build-status>}"]
         [%leaf "clients: {<~(tap in ~(key by clients.build-status))>}"]
     ==

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -7006,7 +7006,7 @@
   =^  results  ford-gate
     %-  ford-call  :*
       ford-gate
-      now=~1234.5.8
+      now=~1234.5.6
       scry=scry-is-forbidden
       ::
       call-args=[duct=~[/wherever] type=~ %vega ~]
@@ -7544,6 +7544,7 @@
   ^-  tang
   ::
   :: clear all caches
+  ::
   =^  results1  ford-gate
     %-  ford-call  :*
       ford-gate

--- a/tests/sys/vane/ford.hoon
+++ b/tests/sys/vane/ford.hoon
@@ -6999,6 +6999,195 @@
     results4
     (expect-ford-empty ford-gate ~nul)
   ==
+::
+++  test-vega-empty  ^-  tang
+  ::
+  =^  results  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.8
+      scry=scry-is-forbidden
+      ::
+      call-args=[duct=~[/wherever] type=~ %vega ~]
+      ::
+      moves=~
+    ==
+  (weld results (expect-ford-empty ford-gate ~nul))
+::
+++  test-vega-complete-once-build  ^-  tang
+  ::
+  =^  results1  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.6
+      scry=scry-is-forbidden
+      ::
+      ^=  call-args
+        [duct=~[/gimme] type=~ %build live=%.n [%$ %noun !>('result')]]
+      ::
+      ^=  moves
+        :~  :*  duct=~[/gimme]  %give  %made  ~1234.5.6
+                %complete  %success  %$  %noun  !>('result')
+    ==  ==  ==
+  ::
+  =^  results2  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.7
+      scry=scry-is-forbidden
+      ::
+      call-args=[duct=~[/wherever] type=~ %vega ~]
+      ::
+      moves=~
+    ==
+  ::
+  ;:  weld
+    results1
+    results2
+    (expect-ford-empty ford-gate ~nul)
+  ==
+::
+++  test-vega-live-build  ^-  tang
+  ::
+  =^  results1  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.6
+      scry=scry-is-forbidden
+      ::
+      ^=  call-args
+        [duct=~[/gimme] type=~ %build live=%.y [%$ %noun !>('result')]]
+      ::
+      ^=  moves
+        :~  :*  duct=~[/gimme]  %give  %made  ~1234.5.6
+                %complete  %success  %$  %noun  !>('result')
+    ==  ==  ==
+  ::
+  =^  results2  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.7
+      scry=scry-is-forbidden
+      ::
+      call-args=[duct=~[/wherever] type=~ %vega ~]
+      ::
+      moves=~[[duct=~[/gimme] %give %made ~1234.5.7 %incomplete ~]]
+    ==
+  ::
+  ;:  weld
+    results1
+    results2
+    (expect-ford-empty ford-gate ~nul)
+  ==
+::
+++  test-vega-many  ^-  tang
+  ::
+  =^  results1  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.6
+      scry=scry-is-forbidden
+      ::
+      ^=  call-args
+        [duct=~[/gimme] type=~ %build live=%.y [%$ %noun !>('anthony')]]
+      ::
+      ^=  moves
+        :~  :*  duct=~[/gimme]  %give  %made  ~1234.5.6
+                %complete  %success  %$  %noun  !>('anthony')
+    ==  ==  ==
+  ::
+  =^  results2  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.7
+      scry=scry-is-forbidden
+      ::
+      ^=  call-args
+        [duct=~[/gotcha] type=~ %build live=%.y [%$ %noun !>('galen')]]
+      ::
+      ^=  moves
+        :~  :*  duct=~[/gotcha]  %give  %made  ~1234.5.7
+                %complete  %success  %$  %noun  !>('galen')
+    ==  ==  ==
+  ::
+  =^  results3  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.8
+      scry=scry-is-forbidden
+      ::
+      ^=  call-args
+        [duct=~[/nah-bro] type=~ %build live=%.n [%$ %noun !>('curtis')]]
+      ::
+      ^=  moves
+        :~  :*  duct=~[/nah-bro]  %give  %made  ~1234.5.8
+                %complete  %success  %$  %noun  !>('curtis')
+    ==  ==  ==
+  ::
+  =^  results4  ford-gate
+    %-  ford-call-with-comparator  :*
+      ford-gate
+      now=~1234.5.9
+      scry=scry-is-forbidden
+      ::
+      call-args=[duct=~[/wherever] type=~ %vega ~]
+      ::
+      ^=  comparator
+        |=  moves=(list move:ford-gate)
+        ^-  tang
+        %+  expect-eq
+          !>  %-  sy
+              :~  [[duct=~[/gimme] %give %made ~1234.5.9 %incomplete ~]]
+                  [[duct=~[/gotcha] %give %made ~1234.5.9 %incomplete ~]]
+              ==
+          !>  (sy moves)
+    ==
+  ::
+  ;:  weld
+    results1
+    results2
+    results3
+    results4
+    (expect-ford-empty ford-gate ~nul)
+  ==
+::
+++  test-vega-in-progress-once-build  ^-  tang
+  ::
+  =^  results1  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.6
+      scry=(scry-block ~1234.5.6)
+      ::  when we scry on a blocked path, expect a subscription move
+      ::
+      ^=  call-args
+        :*  duct=~[/gimme]  type=~  %build  live=%.n
+            [%scry %c ren=%x rail=[[~nul %desk] /bar/foo]]
+        ==
+      ::
+      ^=  moves
+        :~  :*  duct=~[/gimme]  %pass
+                wire=/scry-request/cx/~nul/desk/~1234.5.6/foo/bar
+                %c  %warp  ~nul  %desk
+                ~  %sing  %x  [%da ~1234.5.6]  /foo/bar
+    ==  ==  ==
+  ::
+  =^  results2  ford-gate
+    %-  ford-call  :*
+      ford-gate
+      now=~1234.5.7
+      scry=scry-is-forbidden
+      ::
+      call-args=[duct=~[/whatever] type=~ %vega ~]
+      ::
+      moves=~[[duct=~[/gimme] %give %made ~1234.5.7 %incomplete ~]]
+    ==
+  ::
+  ;:  weld
+    results1
+    results2
+    (expect-ford-empty ford-gate ~nul)
+  ==
 ::  |data: shared data between cases
 ::  +|  data
 ++  large-mark-graph


### PR DESCRIPTION
Currently, when a kernel reset occurs, ford's state will find itself with copies of contents of the old kernel. To address this, on a %vega event, we purge all builds, and send %incomplete %made responses to all ducts who might expect another build result from us in the future (i.e. in-progress once builds and all live builds). Further commits will be added to this pull request to ensure that recipients perform the correct action (re-requesting the builds) on receiving such messages.

@belisarius222, could you please take a look at the `TODO: understand this` in my implementation of `++reset`? This point confused both Elliot and me. Thanks!