### PR TITLE
add |bonk and flop ames timer order

### DIFF
--- a/app/hood.hoon
+++ b/app/hood.hoon
@@ -169,6 +169,7 @@
 ++  poke-helm-tlon-init-stream  (wrap poke-tlon-init-stream):from-helm
 ++  poke-helm-automass        (wrap poke-automass):from-helm
 ++  poke-helm-cancel-automass  (wrap poke-cancel-automass):from-helm
+++  poke-helm-bonk            (wrap poke-bonk):from-helm
 ++  poke-hood-sync            (wrap poke-sync):from-kiln
 ++  poke-kiln-commit          (wrap poke-commit):from-kiln
 ++  poke-kiln-info            (wrap poke-info):from-kiln

--- a/gen/hood/bonk.hoon
+++ b/gen/hood/bonk.hoon
@@ -1,0 +1,7 @@
+::  Helm: bonk ames
+::
+::::  /hoon/bonk/hood/gen
+  ::
+/?    310
+:-  %say
+|=({^ ~ ~} helm-bonk+~)

--- a/lib/hood/helm.hoon
+++ b/lib/hood/helm.hoon
@@ -37,7 +37,8 @@
 =+  sez=(fall (~(get by hoc) ost) $:session)
 =>  |%                                                  ::  arvo structures
     ++  card                                            ::
-      $%  {$conf wire dock $load ship term}             ::
+      $%  [%bonk wire ~]                                ::
+          {$conf wire dock $load ship term}             ::
           {$flog wire flog:dill}                        ::
           [%mint wire our=ship p=ship q=safe:rights:jael]
           {$nuke wire ship}                             ::
@@ -105,6 +106,12 @@
 ++  poke-cancel-automass
   |=  ~
   abet:(emit %rest way.mass-timer.sez nex.mass-timer.sez)
+::
+++  poke-bonk
+  |=  ~
+  ~&  .^((unit @da) %a /(scot %p our)/time/(scot %da now)/(scot %p our))
+  %-  %-  slog  :_  ~  .^(tank %b /(scot %p our)/timers/(scot %da now))
+  abet:(emit %bonk /bonk ~)
 ::
 ++  take-wake-automass
   |=  [way=wire ~]

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1331,6 +1331,8 @@
     ::
         %pito
       :_  fox(tim `p.bon)
+      %-  flop
+      ^-  (list move)
       :-  [gad.fox %pass /ames %b %wait p.bon]
       ?~  tim.fox  ~
       [gad.fox %pass /ames %b %rest u.tim.fox]~
@@ -1462,6 +1464,13 @@
           :_  fox(gad hen)
           [%bock ~]~
         ::
+            %bonk
+          :_  fox
+          ?~  tim.fox
+            ~&  %ames-bonk-e
+            ~
+          [%pito u.tim.fox]~
+        ::
             %hear
           (~(gnaw am [our now fox ski]) %good p.kyz q.kyz)
         ::
@@ -1543,6 +1552,10 @@
       ?.  =(our his)
         ~
       ``[%noun !>(pals:~(um am [our now fox ski]))]
+    ?:  ?=([%time ~] tyl)
+      ?.  =(our his)
+        ~
+      ``[%noun !>(tim.fox)]
     ~
   ::
   ++  wegh

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1258,6 +1258,7 @@
       ^-  (unit @tas)
       ?+  sep  ~&  [%ap-vain sep]
                ~
+        $bonk  `%a
         $build  `%f
         $cash  `%a
         $conf  `%g

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -244,6 +244,7 @@
       ==  ==  ==                                        ::
     ++  task                                            ::  in request ->$
       $%  {$barn ~}                                    ::  new unix process
+          {$bonk ~}                                     ::  reset the timer
           {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$hear p/lane q/@}                            ::  receive packet
           {$halo p/lane q/@ r/ares}                     ::  hole with trace


### PR DESCRIPTION
I got annoyed by not being able to talk to ~dopzod or anyone that I hadn't already interacted with, and since we weren't getting even "not responding still trying" messages I figured the timers were borked.  If we haven't interacted with someone, we currently wait for the first message to timeout to retry which is necessary for properly setting up the symmetric key (that's a whole 'nother issue, and not urgent).

Anyhow, this does three things:  (1) put a scry in ames to check whether we think we have an outstanding timer in behn.  With this, you can check these two scrys:

```
.^((unit @da) %a /=time=/(scot %p our))
%.  ~  %-  slog  :_  ~  .^(tank %b /=timers=)
```

If the first gives non-null, but here's no corresponding timer in the second, then ames is frozen (i.e. it will never retry a message).  I can imagine two instances, where that could happen:  if we crash in the middle of a %wake event to ames (although maybe that just goes through anyway when the next timer fires?  Not sure how that works) or if ames tries to set a timer for the same time as the current time, because we currently send the `%wait` followed by the `%rest`, which is clearly backwards.  Maybe there are other instances where we could freeze up.

(2) Flop the order of `%wait` and `%rest` when handling the `%pito` boon to fix the above.  It's too late at night for me to figure out if there's a deeper flopping issue in this section of the code.  Basically, they get flopped at the end of `++knap`, so in `++clop` we're in the mode of "left-most move is executed last", which is the mode we usually want when we have a state variable push onto, but not when we're just producing lists of moves.  So maybe that flop should be removed, but I'm not going to touch that right now.

(3) Add a `|bonk` generator that sends a `%bonk` card to ames, which makes it try to reset its timer.  We should, of course, find out why ames is freezing, but in the meantime this will print out the `.^`s above and get us going again.