### PR TITLE
Implement +from-unix for turning Unix timestamps into @da

### DIFF
--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -6735,6 +6735,13 @@
     ::                                                  ::::
   ++  chrono  ^?
     |%
+    ::  +from-unix: unix timestamp to @da
+    ::
+    ++  from-unix
+      |=  timestamp=@ud
+      ^-  @da
+      %+  add  ~1970.1.1
+      (mul timestamp ~s1)
     ::                                                  ::  ++dawn:chrono:
     ++  dawn                                            ::  Jan 1 weekday
       |=  yer/@ud


### PR DESCRIPTION
Does what it says on the can. This is useful for dealing with external services that give you dates in the form of Unix timestamps.