### PR TITLE
Fix topics decoding to work with zero values

### DIFF
--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7758,10 +7758,9 @@
       ::  tox:  list of hex words
       |*  [tox=(lest @ux) tys=(list etyp)]
       =-  (decode-arguments (crip -) tys)
-      %+  render-hex-bytes  (mul 32 (lent tox))
       %+  roll  `(list @ux)`tox
-      |=  [top=@ux tos=@]
-      (cat 8 top tos)
+      |=  [top=@ tos=tape]
+      (weld tos (render-hex-bytes 32 top))
     ::
     ++  decode-results
       ::  rex:  string of hex bytes with leading 0x.

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7755,23 +7755,19 @@
     ::
     ::  decoding
     ::
-    ++  decode-topics
-      ::  tox:  list of hex words
-      |*  [tox=(lest @ux) tys=(list etyp)]
-      =-  (decode-arguments (crip -) tys)
-      %+  roll  `(list @ux)`tox
-      |=  [top=@ tos=tape]
-      (weld tos (render-hex-bytes 32 top))
+    ++  decode-topics  decode-arguments
     ::
     ++  decode-results
       ::  rex:  string of hex bytes with leading 0x.
       |*  [rex=@t tys=(list etyp)]
-      (decode-arguments (rsh 3 2 rex) tys)
+      =-  (decode-arguments - tys)
+      %+  turn  (rip 9 (rsh 3 2 rex))
+      (curr rash hex)
     ::
     ++  decode-arguments
-      |*  [res=@t tys=(list etyp)]
+      |*  [wos=(list @) tys=(list etyp)]
+      =/  wos=(list @)  wos  ::  get rid of tmi
       =|  win=@ud
-      =/  wos=(list @t)  (rip 9 res)
       =<  (decode-from 0 tys)
       |%
       ++  decode-from
@@ -7796,22 +7792,21 @@
             ?(%address %bool %uint)  ::  %int %real %ureal
           :-  +(win)
           ?-  typ
-            %address  `@ux`(rash wor hex)
-            %uint     `@ud`(rash wor hex)
-            %bool     =(1 (rash wor hex))
+            %address  `@ux`wor
+            %uint     `@ud`wor
+            %bool     =(1 wor)
           ==
         ::
             %string
           =+  $(tys ~[%bytes])
-          ~!  -
           [nin (trip (swp 3 q.dat))]
         ::
             %bytes
           :-  +(win)
           ::  find the word index of the actual data.
-          =/  lic=@ud  (div (rash wor hex) 32)
+          =/  lic=@ud  (div wor 32)
           ::  learn the bytelength of the data.
-          =/  len=@ud  (rash (snag lic wos) hex)
+          =/  len=@ud  (snag lic wos)
           (decode-bytes-n +(lic) len)
         ::
             [%bytes-n *]
@@ -7821,11 +7816,11 @@
             [%array *]
           :-  +(win)
           ::  find the word index of the actual data.
-          =.  win  (div (rash wor hex) 32)
+          =.  win  (div wor 32)
           ::  read the elements from their location.
           %-  tail
           %^  decode-array-n  ~[t.typ]  +(win)
-          (rash (snag win wos) hex)
+          (snag win wos)
         ::
             [%array-n *]
           (decode-array-n ~[t.typ] win n.typ)
@@ -7835,18 +7830,16 @@
         |=  [fro=@ud bys=@ud]
         ^-  octs
         ::  parse {bys} bytes from {fro}.
-        =-  [bys (rash - hex)]
-        %^  end  3  (mul 2 bys)
-        %+  can  9
-        %+  turn
-          (swag [fro +((div (dec bys) 32))] wos)
-        |=(a=@t [1 a])
+        :-  bys
+        %^  rsh  3  (sub 32 (mod bys 33))
+        %+  rep  8
+        (flop (swag [fro +((div (dec bys) 32))] wos))
       ::
       ++  decode-array-n
         ::NOTE  we take (list etyp) even though we only operate on
         ::      a single etyp as a workaround for urbit/arvo#673
+        ::NOTE  careful! produces lists without type info
         =|  res=(list)
-        ~&  %watch-out--arrays-without-typeinfo
         |*  [tys=(list etyp) fro=@ud len=@ud]
         ^-  [@ud (list)]
         ?~  tys  !!

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7831,9 +7831,13 @@
         ^-  octs
         ::  parse {bys} bytes from {fro}.
         :-  bys
-        %^  rsh  3  (sub 32 (mod bys 33))
+        %^  rsh  3
+          =+  (mod bys 32)
+          ?:(=(0 -) - (sub 32 -))
         %+  rep  8
-        (flop (swag [fro +((div (dec bys) 32))] wos))
+        %-  flop
+        =-  (swag [fro -] wos)
+        +((div (dec bys) 32))
       ::
       ++  decode-array-n
         ::NOTE  we take (list etyp) even though we only operate on
@@ -8214,8 +8218,10 @@
     |=  [wat=tape mof=@ud wer=?(%left %right)]
     ^-  tape
     =+  len=(lent wat)
-    ?:  =(len mof)  wat
-    =+  tad=(reap (sub mof (mod len mof)) '0')
+    ?:  =(0 len)  (reap mof '0')
+    =+  mad=(mod len mof)
+    ?:  =(0 mad)  wat
+    =+  tad=(reap (sub mof mad) '0')
     %-  weld
     ?:(?=(%left wer) [tad wat] [wat tad])
   ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7713,6 +7713,7 @@
         ::  enc(X) is the sequence of bytes in X padded with zero-bytes to a
         ::  length of 32.
         ::  Note that for any X, len(enc(X)) is a multiple of 32.
+        ~|  [%bytes-n-too-long max=32 actual=p.p.dat]
         ?>  (lte p.p.dat 32)
         (pad-to-multiple (render-hex-bytes p.dat) 64 %right)
       ::
@@ -7722,7 +7723,7 @@
         ::  by the minimum number of zero-bytes such that len(enc(X)) is a
         ::  multiple of 32.
         %+  weld  $(dat [%uint p.p.dat])
-        $(dat [%bytes-n p.dat])
+        (pad-to-multiple (render-hex-bytes p.dat) 64 %right)
       ::
           %string
         ::  enc(X) = enc(enc_utf8(X)), i.e. X is utf-8 encoded and this value is


### PR DESCRIPTION
Because `+cat` doesn't care to left-shift if you append a zero value.

Previously:

```hoon
> (decode-topics:rpc:ethereum ~[0x0 0x1] ~[%uint %uint])
[0 1]
> (decode-topics:rpc:ethereum ~[0x1 0x0] ~[%uint %uint])
[0 1]
```

Now:

```hoon
> (decode-topics:rpc:ethereum ~[0x0 0x1] ~[%uint %uint])
[0 1]
> (decode-topics:rpc:ethereum ~[0x1 0x0] ~[%uint %uint])
[1 0]
```