### PR TITLE
+ob overhaul

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3865,9 +3865,9 @@
     =/  f  (prf (sub j 1) arr)
     ::
     =/  tmp
-    ?.  =((mod j 2) 0)
-      (mod (add f ell) a)
-    (mod (add f ell) b)
+      ?.  =((mod j 2) 0)
+        (mod (add f ell) a)
+      (mod (add f ell) b)
     ::
     $(j +(j), ell arr, arr tmp)
   ::
@@ -3882,14 +3882,14 @@
     =/  j  r
     ::
     =/  ahh
-    ?.  =((mod r 2) 0)
-      (div m a)
-    (mod m a)
+      ?.  =((mod r 2) 0)
+        (div m a)
+      (mod m a)
     ::
     =/  ale
-    ?.  =((mod r 2) 0)
-      (mod m a)
-    (div m a)
+      ?.  =((mod r 2) 0)
+        (mod m a)
+      (div m a)
     ::
     :: Similar to the comment in +fe, +fen differs from B&R (2002)'s "fe^-1"
     :: here in order to preserve the legacy cipher's behaviour on most inputs.
@@ -3898,14 +3898,14 @@
     :: correct those cases by swapping the values of 'ahh' and 'ale'.
     ::
     =/  ell
-    ?:  =(ale a)
-      ahh
-    ale
+      ?:  =(ale a)
+        ahh
+      ale
     ::
     =/  arr
-    ?:  =(ale a)
-      ale
-    ahh
+      ?:  =(ale a)
+        ale
+      ahh
     ::
     |-
     ?:  (lth j 1)
@@ -3917,9 +3917,9 @@
     ::  'f' modulo the same number before performing subtraction.
     ::
     =/  tmp
-    ?.  =((mod j 2) 0)
-      (mod (sub (add arr a) (mod f a)) a)
-    (mod (sub (add arr b) (mod f b)) b)
+      ?.  =((mod j 2) 0)
+        (mod (sub (add arr a) (mod f a)) a)
+      (mod (sub (add arr b) (mod f b)) b)
     ::
     $(j (sub j 1), ell tmp, arr ell)
   ::

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3788,34 +3788,34 @@
   ++  feis
     |=  m=@
     ^-  @
-    (fee 4 65.535 65.536 (mul 65.535 65.536) m)
+    (fee 4 65.535 65.536 (mul 65.535 65.536) eff m)
   ::
   ::  +tail: reverse +feis.
   ::
   ++  tail
     |=  m=@
     ^-  @
-    (feen 4 65.535 65.536 (mul 65.535 65.536) m)
+    (feen 4 65.535 65.536 (mul 65.535 65.536) eff m)
   ::
   ::  +fee: "Fe" in B&R (2002).
   ::
   ++  fee
-    |=  [r=@ a=@ b=@ k=@ m=@]
+    |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
-    =+  c=(fe r a b m)
+    =+  c=(fe r a b prf m)
     ?:  (lth c k)
       c
-    (fe r a b c)
+    (fe r a b prf c)
   ::
   ::  +feen: "Fe^-1" in B&R (2002).
   ::
   ++  feen
-    |=  [r=@ a=@ b=@ k=@ m=@]
+    |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
-    =+  c=(fen r a b m)
+    =+  c=(fen r a b prf m)
     ?:  (lth c k)
       c
-    (fen r a b c)
+    (fen r a b prf c)
   ::
   ::  +fe:  "fe" in B&R (2002).
   ::
@@ -3823,7 +3823,7 @@
   ::    to support some legacy behaviour.  See urbit/arvo#1105.
   ::
   ++  fe
-    |=  [r=@ a=@ b=@ m=@]
+    |=  [r=@ a=@ b=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
     =+  j=1
     =+  ell=(mod m a)
@@ -3837,7 +3837,7 @@
         (add (mul arr a) ell)
       (add (mul ell a) arr)
     ::
-    =/  f  (eff (sub j 1) arr)
+    =/  f  (prf (sub j 1) arr)
     ::
     =/  tmp
     ?.  =((mod j 2) 0)
@@ -3852,7 +3852,7 @@
   ::    to support some legacy behaviour.  See urbit/arvo#1105.
   ::
   ++  fen
-    |=  [r=@ a=@ b=@ m=@]
+    |=  [r=@ a=@ b=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
     =+  j=r
     ::
@@ -3879,7 +3879,7 @@
     |-
     ?:  (lth j 1)
       (add (mul arr a) ell)
-    =/  f  (eff (sub j 1) ell)
+    =/  f  (prf (sub j 1) ell)
     ::
     ::  Note that there is a slight deviation here to avoid dealing with
     ::  negative values.  We add 'a' or 'b' to arr as appropriate and reduce

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3760,8 +3760,8 @@
     ?:  &((gte pyn 0x1.0000) (lte pyn 0xffff.ffff))
       (add 0x1.0000 (feis (sub pyn 0x1.0000)))
     ?:  &((gte pyn 0x1.0000.0000) (lte pyn 0xffff.ffff.ffff.ffff))
-      =+  lo=(dis pyn 0xffff.ffff)
-      =+  hi=(dis pyn 0xffff.ffff.0000.0000)
+      =/  lo  (dis pyn 0xffff.ffff)
+      =/  hi  (dis pyn 0xffff.ffff.0000.0000)
       %+  con  hi
       $(pyn lo)
     pyn
@@ -3775,8 +3775,8 @@
     ?:  &((gte cry 0x1.0000) (lte cry 0xffff.ffff))
       (add 0x1.0000 (tail (sub cry 0x1.0000)))
     ?:  &((gte cry 0x1.0000.0000) (lte cry 0xffff.ffff.ffff.ffff))
-      =+  lo=(dis cry 0xffff.ffff)
-      =+  hi=(dis cry 0xffff.ffff.0000.0000)
+      =/  lo  (dis cry 0xffff.ffff)
+      =/  hi  (dis cry 0xffff.ffff.0000.0000)
       %+  con  hi
       $(cry lo)
     cry
@@ -3812,10 +3812,10 @@
   ++  fee
     |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
-    =+  c=(fe r a b prf m)
-    ?:  (lth c k)
-      c
-    (fe r a b prf c)
+    =/  c  (fe r a b prf m)
+      ?:  (lth c k)
+        c
+      (fe r a b prf c)
   ::
   ::  +feen: "Fe^-1" in B&R (2002).
   ::
@@ -3825,10 +3825,10 @@
   ++  feen
     |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
-    =+  c=(fen r a b prf m)
-    ?:  (lth c k)
-      c
-    (fen r a b prf c)
+    =/  c  (fen r a b prf m)
+      ?:  (lth c k)
+        c
+      (fen r a b prf c)
   ::
   ::  +fe:  "fe" in B&R (2002).
   ::
@@ -3840,9 +3840,9 @@
   ++  fe
     |=  [r=@ a=@ b=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
-    =+  j=1
-    =+  ell=(mod m a)
-    =+  arr=(div m a)
+    =/  j  1
+    =/  ell  (mod m a)
+    =/  arr  (div m a)
     |-
     ::
     ?:  (gth j r)
@@ -3879,7 +3879,7 @@
   ++  fen
     |=  [r=@ a=@ b=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
-    =+  j=r
+    =/  j  r
     ::
     =/  ahh
     ?.  =((mod r 2) 0)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3747,13 +3747,17 @@
           df4d.225e.2d56.7fd6.1395.a3f8.c582
     (cut 3 [a 1] b)
   --
-::
 ++  ob
   |%
-  ++  feen                                              ::  conceal structure v2
+  ::  +fein: conceal structure, v3.
+  ::
+  ::    +fein conceals planet-sized atoms.  The idea is that it should not be
+  ::    trivial to tell which planet a star has spawned under.
+  ::
+  ++  fein
     |=  pyn/@  ^-  @
     ?:  &((gte pyn 0x1.0000) (lte pyn 0xffff.ffff))
-      (add 0x1.0000 (fice (sub pyn 0x1.0000)))
+      (add 0x1.0000 (feis (sub pyn 0x1.0000)))
     ?:  &((gte pyn 0x1.0000.0000) (lte pyn 0xffff.ffff.ffff.ffff))
       =+  lo=(dis pyn 0xffff.ffff)
       =+  hi=(dis pyn 0xffff.ffff.0000.0000)
@@ -3761,10 +3765,14 @@
       $(pyn lo)
     pyn
   ::
-  ++  fend                                              ::  restore structure v2
+  ::  +fynd: restore structure, v3.
+  ::
+  ::    Restores obfuscated values that have been enciphered with +fein.
+  ::
+  ++  fynd
     |=  cry/@  ^-  @
     ?:  &((gte cry 0x1.0000) (lte cry 0xffff.ffff))
-      (add 0x1.0000 (teil (sub cry 0x1.0000)))
+      (add 0x1.0000 (tail (sub cry 0x1.0000)))
     ?:  &((gte cry 0x1.0000.0000) (lte cry 0xffff.ffff.ffff.ffff))
       =+  lo=(dis cry 0xffff.ffff)
       =+  hi=(dis cry 0xffff.ffff.0000.0000)
@@ -3772,43 +3780,126 @@
       $(cry lo)
     cry
   ::
-  ++  fice                                              ::  adapted from
-    |=  nor/@                                           ::  black and rogaway
-    ^-  @                                               ::  "ciphers with
-    =+  ^=  sel                                         ::   arbitrary finite
-    %+  rynd  3                                         ::   domains", 2002
-    %+  rynd  2
-    %+  rynd  1
-    %+  rynd  0
-    [(mod nor 65.535) (div nor 65.535)]
-    (add (mul 65.535 -.sel) +.sel)
+  ::  +feis: a four-round generalised Feistel cipher over the domain
+  ::         [2^16, 2^32 - 1].
   ::
-  ++  teil                                              ::  reverse ++fice
-    |=  vip/@
+  ::    See: Black & Rogaway (2002), Ciphers for arbitrary finite domains.
+  ::
+  ++  feis
+    |=  m=@
     ^-  @
-    =+  ^=  sel
-    %+  rund  0
-    %+  rund  1
-    %+  rund  2
-    %+  rund  3
-    [(mod vip 65.535) (div vip 65.535)]
-    (add (mul 65.535 -.sel) +.sel)
+    (fee 4 65.535 65.536 (mul 65.535 65.536) m)
   ::
-  ++  rynd                                              ::  feistel round
-    |=  {n/@ l/@ r/@}
-    ^-  {@ @}
-    :-  r
-    ?~  (mod n 2)
-      (~(sum fo 65.535) l (muk (snag n raku) 2 r))
-    (~(sum fo 65.536) l (muk (snag n raku) 2 r))
+  ::  +tail: reverse +feis.
   ::
-  ++  rund                                              ::  reverse round
-    |=  {n/@ l/@ r/@}
-    ^-  {@ @}
-    :-  r
-    ?~  (mod n 2)
-      (~(dif fo 65.535) l (muk (snag n raku) 2 r))
-    (~(dif fo 65.536) l (muk (snag n raku) 2 r))
+  ++  tail
+    |=  m=@
+    ^-  @
+    (feen 4 65.535 65.536 (mul 65.535 65.536) m)
+  ::
+  ::  +fee: "Fe" in B&R (2002).
+  ::
+  ++  fee
+    |=  [r=@ a=@ b=@ k=@ m=@]
+    ^-  @
+    =+  c=(fe r a b m)
+    ?:  (lth c k)
+      c
+    (fe r a b c)
+  ::
+  ::  +feen: "Fe^-1" in B&R (2002).
+  ::
+  ++  feen
+    |=  [r=@ a=@ b=@ k=@ m=@]
+    ^-  @
+    =+  c=(fen r a b m)
+    ?:  (lth c k)
+      c
+    (fen r a b c)
+  ::
+  ::  +fe:  "fe" in B&R (2002).
+  ::
+  ::    Note that this implementation differs slightly from the reference paper
+  ::    to support some legacy behaviour.  See urbit/arvo#1105.
+  ::
+  ++  fe
+    |=  [r=@ a=@ b=@ m=@]
+    ^-  @
+    =+  j=1
+    =+  ell=(mod m a)
+    =+  arr=(div m a)
+    |-
+    ::
+    ?:  (gth j r)
+      ?.  =((mod r 2) 0)
+        (add (mul arr a) ell)
+      ?:  =(arr a)
+        (add (mul arr a) ell)
+      (add (mul ell a) arr)
+    ::
+    =/  f  (eff (sub j 1) arr)
+    ::
+    =/  tmp
+    ?.  =((mod j 2) 0)
+      (mod (add f ell) a)
+    (mod (add f ell) b)
+    ::
+    $(j +(j), ell arr, arr tmp)
+  ::
+  ::  +fen:  "fe^-1" in B&R (2002).
+  ::
+  ::    Note that this implementation differs slightly from the reference paper
+  ::    to support some legacy behaviour.  See urbit/arvo#1105.
+  ::
+  ++  fen
+    |=  [r=@ a=@ b=@ m=@]
+    ^-  @
+    =+  j=r
+    ::
+    =/  ahh
+    ?.  =((mod r 2) 0)
+      (div m a)
+    (mod m a)
+    ::
+    =/  ale
+    ?.  =((mod r 2) 0)
+      (mod m a)
+    (div m a)
+    ::
+    =/  ell
+    ?:  =(ale a)
+      ahh
+    ale
+    ::
+    =/  arr
+    ?:  =(ale a)
+      ale
+    ahh
+    ::
+    |-
+    ?:  (lth j 1)
+      (add (mul arr a) ell)
+    =/  f  (eff (sub j 1) ell)
+    ::
+    ::  Note that there is a slight deviation here to avoid dealing with
+    ::  negative values.  We add 'a' or 'b' to arr as appropriate and reduce
+    ::  'f' modulo the same number before performing subtraction.
+    ::
+    =/  tmp
+    ?.  =((mod j 2) 0)
+      (mod (sub (add arr a) (mod f a)) a)
+    (mod (sub (add arr b) (mod f b)) b)
+    ::
+    $(j (sub j 1), ell tmp, arr ell)
+  ::
+  ::  +eff: a murmur3-based pseudorandom function.  'F' in B&R (2002).
+  ::
+  ++  eff
+    |=  [j=@ r=@]
+    ^-  @
+    (muk (snag j raku) 2 r)
+  ::
+  ::  +raku: seeds for eff.
   ::
   ++  raku
     ^-  (list @ux)
@@ -3817,6 +3908,7 @@
         0x85bc.ae01
         0x4b38.7af7
     ==
+  ::
   --
 ::
 ::::  3g: molds and mold builders
@@ -5617,7 +5709,7 @@
   ++  dim  (ape dip)
   ++  dip  (bass 10 ;~(plug sed:ab (star sid:ab)))
   ++  dum  (bass 10 (plus sid:ab))
-  ++  fed  %+  cook  fend:ob
+  ++  fed  %+  cook  fynd:ob
            ;~  pose
              %+  bass  0x1.0000.0000.0000.0000          ::  oversized
                ;~  plug
@@ -5729,7 +5821,7 @@
           ==
         ::
             $p
-          =+  sxz=(feen:ob q.p.lot)
+          =+  sxz=(fein:ob q.p.lot)
           =+  dyx=(met 3 sxz)
           :-  '~'
           ?:  (lte dyx 1)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3813,9 +3813,9 @@
     |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
     =/  c  (fe r a b prf m)
-      ?:  (lth c k)
-        c
-      (fe r a b prf c)
+    ?:  (lth c k)
+      c
+    (fe r a b prf c)
   ::
   ::  +feen: "Fe^-1" in B&R (2002).
   ::
@@ -3826,9 +3826,9 @@
     |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
     =/  c  (fen r a b prf m)
-      ?:  (lth c k)
-        c
-      (fen r a b prf c)
+    ?:  (lth c k)
+      c
+    (fen r a b prf c)
   ::
   ::  +fe:  "fe" in B&R (2002).
   ::

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3788,14 +3788,14 @@
   ++  feis
     |=  m=@
     ^-  @
-    (fee 4 65.535 65.536 (mul 65.535 65.536) eff m)
+    (fee 4 0xffff 0x1.0000 (mul 0xffff 0x1.0000) eff m)
   ::
   ::  +tail: reverse +feis.
   ::
   ++  tail
     |=  m=@
     ^-  @
-    (feen 4 65.535 65.536 (mul 65.535 65.536) eff m)
+    (feen 4 0xffff 0x1.0000 (mul 0xffff 0x1.0000) eff m)
   ::
   ::  +fee: "Fe" in B&R (2002).
   ::

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3839,11 +3839,10 @@
   ::
   ++  fe
     |=  [r=@ a=@ b=@ prf=$-([j=@ r=@] @) m=@]
-    ^-  @
     =/  j  1
     =/  ell  (mod m a)
     =/  arr  (div m a)
-    |-
+    |-  ^-  @
     ::
     ?:  (gth j r)
       ?.  =((mod r 2) 0)
@@ -3878,7 +3877,6 @@
   ::
   ++  fen
     |=  [r=@ a=@ b=@ prf=$-([j=@ r=@] @) m=@]
-    ^-  @
     =/  j  r
     ::
     =/  ahh
@@ -3907,7 +3905,7 @@
         ale
       ahh
     ::
-    |-
+    |-  ^-  @
     ?:  (lth j 1)
       (add (mul arr a) ell)
     =/  f  (prf (sub j 1) ell)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3781,7 +3781,7 @@
     cry
   ::
   ::  +feis: a four-round generalised Feistel cipher over the domain
-  ::         [2^16, 2^32 - 1].
+  ::         [0, 2^32 - 2^16 - 1].
   ::
   ::    See: Black & Rogaway (2002), Ciphers for arbitrary finite domains.
   ::

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3747,6 +3747,7 @@
           df4d.225e.2d56.7fd6.1395.a3f8.c582
     (cut 3 [a 1] b)
   --
+::
 ++  ob
   |%
   ::  +fein: conceal structure, v3.
@@ -3799,6 +3800,15 @@
   ::
   ::  +fee: "Fe" in B&R (2002).
   ::
+  ::    A Feistel cipher given the following parameters:
+  ::
+  ::    r:    number of Feistel rounds
+  ::    a, b: parameters such that ab >= k
+  ::    k:    value such that the domain of the cipher is [0, k - 1]
+  ::    prf:  a gate denoting a family of pseudorandom functions indexed by
+  ::          its first argument and taking its argument second as input
+  ::    m:    an input value in the domain [0, k - 1]
+  ::
   ++  fee
     |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
@@ -3809,6 +3819,9 @@
   ::
   ::  +feen: "Fe^-1" in B&R (2002).
   ::
+  ::    Reverses a Feistel cipher constructed with parameters described in
+  ::    +fee.
+  ::
   ++  feen
     |=  [r=@ a=@ b=@ k=@ prf=$-([j=@ r=@] @) m=@]
     ^-  @
@@ -3818,6 +3831,8 @@
     (fen r a b prf c)
   ::
   ::  +fe:  "fe" in B&R (2002).
+  ::
+  ::    An internal function to +fee.
   ::
   ::    Note that this implementation differs slightly from the reference paper
   ::    to support some legacy behaviour.  See urbit/arvo#1105.
@@ -3833,6 +3848,16 @@
     ?:  (gth j r)
       ?.  =((mod r 2) 0)
         (add (mul arr a) ell)
+      ::
+      :: Note that +fe differs from B&R (2002)'s "fe" below, as a previous
+      :: implementation of this cipher contained a bug such that certain inputs
+      :: could encipher to the same output.
+      ::
+      :: To correct these problem cases while also preserving the cipher's
+      :: legacy behaviour on most inputs, we check for a problem case (which
+      :: occurs when 'arr' is equal to 'a') and, if detected, use an alternate
+      :: permutation instead.
+      ::
       ?:  =(arr a)
         (add (mul arr a) ell)
       (add (mul ell a) arr)
@@ -3865,6 +3890,12 @@
     ?.  =((mod r 2) 0)
       (mod m a)
     (div m a)
+    ::
+    :: Similar to the comment in +fe, +fen differs from B&R (2002)'s "fe^-1"
+    :: here in order to preserve the legacy cipher's behaviour on most inputs.
+    ::
+    :: Here problem cases can be identified by 'ahh' equating with 'a'; we
+    :: correct those cases by swapping the values of 'ahh' and 'ale'.
     ::
     =/  ell
     ?:  =(ale a)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -3806,7 +3806,7 @@
   ::    a, b: parameters such that ab >= k
   ::    k:    value such that the domain of the cipher is [0, k - 1]
   ::    prf:  a gate denoting a family of pseudorandom functions indexed by
-  ::          its first argument and taking its argument second as input
+  ::          its first argument and taking its second argument as input
   ::    m:    an input value in the domain [0, k - 1]
   ::
   ++  fee
@@ -3819,7 +3819,7 @@
   ::
   ::  +feen: "Fe^-1" in B&R (2002).
   ::
-  ::    Reverses a Feistel cipher constructed with parameters described in
+  ::    Reverses a Feistel cipher constructed with parameters as described in
   ::    +fee.
   ::
   ++  feen

--- a/tests/sys/hoon/auras.hoon
+++ b/tests/sys/hoon/auras.hoon
@@ -1,5 +1,109 @@
 /+  *test
 |%
+++  test-parse-p
+  ;:  weld
+    %+  expect-eq
+      !>  ~zod
+      !>  `@p`0
+    ::
+    %+  expect-eq
+      !>  ~lex
+      !>  `@p`200
+    ::
+    %+  expect-eq
+      !>  ~binzod
+      !>  `@p`512
+    ::
+    %+  expect-eq
+      !>  ~samzod
+      !>  `@p`1.024
+    ::
+    %+  expect-eq
+      !>  ~poldec-tonteg
+      !>  `@p`9.896.704
+    ::
+    %+  expect-eq
+      !>  ~nidsut-tomdun
+      !>  `@p`15.663.360
+    ::
+    %+  expect-eq
+      !>  ~morlyd-mogmev
+      !>  `@p`3.108.299.008
+    ::
+    %+  expect-eq
+      !>  ~fipfes-morlyd
+      !>  `@p`479.733.505
+    ::
+    %+  expect-eq
+      !>  ~dilwes-fadnel
+      !>  `@p`23.554.048
+    ::
+    %+  expect-eq
+      !>  ~fipfes-dilwes
+      !>  `@p`529.511.092
+    ::
+    %+  expect-eq
+      !>  ~hossev-roppec
+      !>  `@p`1.859.915.444
+    ::
+    %+  expect-eq
+      !>  ~fipfes-hossev
+      !>  `@p`145.391.618
+    ::
+  ==
+::
+++  test-render-p
+  ;:  weld
+    %+  expect-eq
+      !>  '~zod'
+      !>  (scot %p 0)
+    ::
+    %+  expect-eq
+      !>  '~lex'
+      !>  (scot %p 200)
+    ::
+    %+  expect-eq
+      !>  '~binzod'
+      !>  (scot %p 512)
+    ::
+    %+  expect-eq
+      !>  '~samzod'
+      !>  (scot %p 1.024)
+    ::
+    %+  expect-eq
+      !>  '~poldec-tonteg'
+      !>  (scot %p 9.896.704)
+    ::
+    %+  expect-eq
+      !>  '~nidsut-tomdun'
+      !>  (scot %p 15.663.360)
+    ::
+    %+  expect-eq
+      !>  '~morlyd-mogmev'
+      !>  (scot %p 3.108.299.008)
+    ::
+    %+  expect-eq
+      !>  '~fipfes-morlyd'
+      !>  (scot %p 479.733.505)
+    ::
+    %+  expect-eq
+      !>  '~dilwes-fadnel'
+      !>  (scot %p 23.554.048)
+    ::
+    %+  expect-eq
+      !>  '~fipfes-dilwes'
+      !>  (scot %p 529.511.092)
+    ::
+    %+  expect-eq
+      !>  '~hossev-roppec'
+      !>  (scot %p 1.859.915.444)
+    ::
+    %+  expect-eq
+      !>  '~fipfes-hossev'
+      !>  (scot %p 145.391.618)
+    ::
+  ==
+::
 ++  test-parse-q
   ;:  weld
     %+  expect-eq

--- a/tests/sys/hoon/ob.hoon
+++ b/tests/sys/hoon/ob.hoon
@@ -1,0 +1,75 @@
+/+  *test
+|%
+++  test-fein-fynd-inverses
+  ;:  weld
+    %+  expect-eq
+      !>  0
+      !>  (fynd:ob (fein:ob 0))
+    ::
+    %+  expect-eq
+      !>  15.663.360
+      !>  (fynd:ob (fein:ob 15.663.360))
+    ::
+    %+  expect-eq
+      !>  1.208.402.137
+      !>  (fynd:ob (fein:ob 1.208.402.137))
+    ::
+    %+  expect-eq
+      !>  123.456.789.012.345
+      !>  (fynd:ob (fein:ob 123.456.789.012.345))
+    ::
+  ==
+::
+++  test-fein-fynd-match-reference-vals
+  ;:  weld
+    %+  expect-eq
+      !>  1.897.766.331
+      !>  (fein:ob 123.456.789)
+    ::
+    %+  expect-eq
+      !>  1.208.402.137
+      !>  (fein:ob 15.663.360)
+    ::
+    %+  expect-eq
+      !>  15.663.360
+      !>  (fynd:ob 1.208.402.137)
+    ::
+    %+  expect-eq
+      !>  123.456.789
+      !>  (fynd:ob 1.897.766.331)
+    ::
+  ==
+::
+++  test-feis-tail-inverses
+  ;:  weld
+    %+  expect-eq
+      !>  15.663.360
+      !>  (tail:ob (feis:ob 15.663.360))
+    ::
+    %+  expect-eq
+      !>  1.208.402.137
+      !>  (tail:ob (feis:ob 1.208.402.137))
+    ::
+  ==
+::
+++  test-feis-tail-match-reference-vals
+  ;:  weld
+    %+  expect-eq
+      !>  2.060.458.291
+      !>  (feis:ob 123.456.789)
+    ::
+    %+  expect-eq
+      !>  1.195.593.620
+      !>  (feis:ob 15.663.360)
+    ::
+    %+  expect-eq
+      !>  1.107.963.580
+      !>  (tail:ob 123.456.789)
+    ::
+    %+  expect-eq
+      !>  15.663.360
+      !>  (tail:ob 1.195.593.620)
+    ::
+  ==
+::
+--

--- a/tests/sys/hoon/ob.hoon
+++ b/tests/sys/hoon/ob.hoon
@@ -18,6 +18,14 @@
       !>  123.456.789.012.345
       !>  (fynd:ob (fein:ob 123.456.789.012.345))
     ::
+    %+  expect-eq
+      !>  4.267.685.634
+      !>  (fynd:ob (fein:ob 4.267.685.634))
+    ::
+    %+  expect-eq
+      !>  1.625.882.369
+      !>  (fynd:ob (fein:ob 1.625.882.369))
+    ::
   ==
 ::
 ++  test-fein-fynd-match-reference-vals
@@ -49,6 +57,14 @@
     %+  expect-eq
       !>  1.208.402.137
       !>  (tail:ob (feis:ob 1.208.402.137))
+    ::
+    %+  expect-eq
+      !>  4.267.685.634
+      !>  (tail:ob (feis:ob 4.267.685.634))
+    ::
+    %+  expect-eq
+      !>  1.625.882.369
+      !>  (tail:ob (feis:ob 1.625.882.369))
     ::
   ==
 ::

--- a/tests/sys/hoon/ob.hoon
+++ b/tests/sys/hoon/ob.hoon
@@ -72,4 +72,53 @@
     ::
   ==
 ::
+++  test-exhaustive-small
+  =/  a=(list @)  ~[5 9 2 6 4 0 8 7 1 10 3 11]
+  =/  b=(list @)  ~[2 1 0 3 10 4 9 5 7 11 6 8]
+  =/  c=(list @)  ~[10 6 7 1 0 11 3 9 5 2 8 4]
+  =/  d=(list @)  ~[11 0 3 5 9 8 6 10 4 1 2 7]
+  ::
+  =/  prf
+  |=  [j=@ r=@]
+  ^-  @
+  ?:  =(j 0)
+    (snag r a)
+  ?:  =(j 1)
+    (snag r b)
+  ?:  =(j 2)
+    (snag r c)
+  (snag r d)
+  ::
+  ::
+  =/  feis
+  |=  arg=@
+  ^-  @
+  (fee:ob 4 3 4 12 prf arg)
+  ::
+  =/  tail
+  |=  arg=@
+  ^-  @
+  (feen:ob 4 3 4 12 prf arg)
+  ::
+  =/  emm=(list @)  ~[0 1 2 3 4 5 6 7 8 9 10 11]
+  =/  semm=(set @)  (sy emm)
+  ::
+  =/  perm=(list @)  (turn emm feis)
+  =/  inv=(list @)  (turn perm tail)
+  =/  distincts=(set @)  (sy perm)
+  ::
+  ;:  weld
+    %+  expect-eq
+      !>  (lent perm)
+      !>  (lent ~(tap in distincts))
+    ::
+    %+  expect-eq
+      !>  &
+      !>  (roll perm |=([x=@ acc=?] &((~(has in semm) x) acc)))
+    ::
+    %+  expect-eq
+      !>  emm
+      !>  inv
+    ::
+  ==
 --


### PR DESCRIPTION
(Resolves #1105)

`+ob`, a core that implemented a permutation cipher for planet-sized atoms, contained a critical bug that allowed multiple inputs to encipher to the same output.  This created collisions between some planet-sized `@p` values.

The rewritten version corrects the bug, and also rewrites `+ob` to more clearly match both 1) the paper that the algorithm comes from, and 2) the parallel implementation in urbit-ob that has gone through a full-scale exhaustive test.

The rewritten version is also itself easier to test; this PR adds a small-scale exhaustive test, as well as small battery of sanity checks on `+ob` internals (including on `@p` values previously known to collide).

NOTE: One thing I'm observing here is that dojo may be lagging behind on changes to hoon.hoon.  For example, the following in `tests/sys/hoon/auras.hoon` passes:

```
    %+  expect-eq
      !>  ~dilwes-fadnel
      !>  `@p`23.554.048
    ::
    %+  expect-eq
      !>  ~fipfes-dilwes
      !>  `@p`529.511.092
```

but in dojo, I still get collisions:

```
> `@p`23.554.048
~dilwes-fadnel
> `@p`529.511.092
~dilwes-fadnel
```

Should I trust the test suite here?  I'd like to figure out what's going on, regardless.