### PR TITLE
Print selected talk audience more compactly

### DIFF
--- a/app/talk.hoon
+++ b/app/talk.hoon
@@ -2098,7 +2098,7 @@
     ::  render circle (as glyph if we can).
     ?~  moy
       =+  cha=(~(get by bound) one ~ ~)
-      =-  ?~(cha - "{u.cha ~} {-}")
+      =-  ?~(cha - "{u.cha ~}")
       ~(cr-phat cr one)
     (~(cr-curt cr one) u.moy)
   --


### PR DESCRIPTION
In a multi-target situation: if there is a bound glyph for a target, instead of showing both the glyph and the target, show just the glyph.

So, if I have `+` bound to `~dopzod/urbit-help`, `&` bound to `~paldev/music`, and set my audience with `;+,&`, then currently you'll see:

```
~palfun-foslup:talk[+ ~dopzod/urbit-help & ~paldev/music]
```

But after this PR, you'll see:

```
~palfun-foslup:talk[+ &]
```