### PR TITLE
add +grad to md mark

### DIFF
--- a/mar/md.hoon
+++ b/mar/md.hoon
@@ -16,4 +16,5 @@
   |%
   ++  mime  [/text/plain (as-octs (of-wain txt))]
   --
+++  grad  %mime
 --


### PR DESCRIPTION
The md mark didn't have a `+grad`, so it crashed if you ever changed an md file.

It also lacked a trailing newline.