### PR TITLE
updates %behn to no-op if its unix-duct is unset

### DIFF
--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -88,6 +88,10 @@
   ++  emit-doze
     |=  =date=(unit @da)
     ^+  event-core
+    ::  no-op if .unix-duct has not yet been set
+    ::
+    ?~  unix-duct.state
+      event-core
     ::  make sure we don't try to wake up in the past
     ::
     =?  date-unit  ?=(^ date-unit)  `(max now u.date-unit)


### PR DESCRIPTION
Various vanes set timers during the boot sequence, and `%behn` immediately gives `%doze` effects as appropriate. This combination was requiring that the `%born` event (new process notification) be injected as early as possible, and generally made %behn inflexible during boot.

I can't think of any reason why it might be harmful to defer the `%doze` effect -- any pending timers will be picked up and processed as soon as the `%born` event is injected.