### PR TITLE
fixes +rift-scry jet registration hint in %clay

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -4340,7 +4340,7 @@
 ::  +rift-scry: for a +rift
 ::
 ++  rift-scry
-  ~/  %rift-scry
+  ~%  %rift-scry  ..is  ~
   |=  who=ship
   ^-  (unit rift)
   =;  lyf


### PR DESCRIPTION
The core at +7 is not registered, so this hint was causing failed-registration printfs in the dashboard.