### PR TITLE
Behn pass errors to client vanes

### DIFF
--- a/app/aqua-behn.hoon
+++ b/app/aqua-behn.hoon
@@ -58,12 +58,12 @@
 ::  Received timer wake
 ::
 ++  wake
-  |=  [way=wire ~]
+  |=  [way=wire error=(unit tang)]
   ^-  (quip move _this)
   =.  this  apex  =<  abet
   ?>  ?=([@ *] way)
   =/  who  (,@p (slav %p i.way))
-  abet-pe:(take-wake:(pe who) t.way ~)
+  abet-pe:(take-wake:(pe who) t.way error)
 ::
 ++  pe
   |=  who=ship
@@ -114,12 +114,18 @@
     ..abet-pe
   ::
   ++  take-wake
-    |=  [way=wire ~]
-    ~?  debug=|  [who=who %aqua-behn-wake now]
+    |=  [way=wire error=(unit tang)]
+    ~?  debug=|  [who=who %aqua-behn-wake now error=error]
     =.  next-timer  ~
     =.  this
       %-  emit-aqua-events
-      [%event who [//behn/0v1n.2m9vh %wake ~]]~
+      :_  ~
+      ^-  aqua-event
+      :+  %event  who
+      :-  //behn/0v1n.2m9vh
+      ?~  error
+        [%wake ~]
+      [%crud %fail u.error]
     ..abet-pe
   --
 --

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -1374,6 +1374,12 @@
     ~/  %knap
     |=  [tea=wire hen=duct sih=sign:able]
     ^-  [(list move) _+>]
+    ::  if we got an error from behn, report it to %dill; TODO handle errors
+    ::
+    ?:  ?=([%wake ^] +.sih)
+      =/  =flog:dill  [%crud %wake u.error.sih]
+      [[hen %slip %d %flog flog]~ +>.$]
+    ::
     ?-  +<.sih
         %crud  [[[hen [%slip %d %flog +.sih]] ~] +>]
     ::
@@ -1421,6 +1427,8 @@
         ^-  [p=(list boon) q=fort]
         ?-  +<.sih
         ::
+            ::  only handles the non-error %wake case; error case above
+            ::
             %wake
           (~(wake am [our now fox ski]) hen)
         ::

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -28,12 +28,25 @@
   ::  +born: urbit restarted; refresh :next-wake and store wakeup timer duct
   ::
   ++  born  set-unix-wake(next-wake.state ~, unix-duct.state duct)
-  ::  +crud: error report; hand off to %dill to be printed
+  ::  +crud: handle failure of previous arvo event
   ::
   ++  crud
-    |=  [p=@tas q=tang]
+    |=  [tag=@tas error=tang]
     ^+  [moves state]
-    [[duct %slip %d %flog %crud p q]~ state]
+    ::  behn must get activated before other vanes in a %wake
+    ::
+    ::    TODO: uncomment this case after switching %crud tags
+    ::
+    ::    We don't know how to handle other errors, so relay them to %dill
+    ::    to be printed and don't treat them as timer failures.
+    ::
+    ::  ?.  =(%wake tag)
+    ::    ~&  %behn-crud-not-first-activation^tag
+    ::    [[duct %slip %d %flog %crud tag error]~ state]
+    ::
+    ?:  =(~ timers.state)  ~|  %behn-crud-no-timer^tag^error  !!
+    ::
+    (wake `error)
   ::  +rest: cancel the timer at :date, then adjust unix wakeup
   ::  +wait: set a new timer at :date, then adjust unix wakeup
   ::
@@ -45,9 +58,15 @@
   ::  +wake: unix says wake up; process the elapsed timer and set :next-wake
   ::
   ++  wake
+    |=  error=(unit tang)
     ^+  [moves state]
     ::
-    ?~  timers.state  ~|(%behn-wake-no-timer !!)
+    ?~  timers.state  ~|  %behn-wake-no-timer^error  !!
+    ::  if we errored, pop the timer and notify the client vane of the error
+    ::
+    ?^  error
+      =<  set-unix-wake
+      (emit-vane-wake(timers.state t.timers.state) duct.i.timers.state error)
     ::  if unix woke us too early, retry by resetting the unix wakeup timer
     ::
     ?:  (gth date.i.timers.state now)
@@ -56,7 +75,7 @@
     ::  pop first timer, tell vane it has elapsed, and adjust next unix wakeup
     ::
     =<  set-unix-wake
-    (emit-vane-wake(timers.state t.timers.state) duct.i.timers.state)
+    (emit-vane-wake(timers.state t.timers.state) duct.i.timers.state ~)
   ::  +wegh: produce memory usage report for |mass
   ::
   ++  wegh
@@ -74,7 +93,9 @@
   ++  event-core  .
   ::  +emit-vane-wake: produce a move to wake a vane; assumes no prior moves
   ::
-  ++  emit-vane-wake  |=(=^duct event-core(moves [duct %give %wake ~]~))
+  ++  emit-vane-wake
+    |=  [=^duct error=(unit tang)]
+    event-core(moves [duct %give %wake error]~)
   ::  +emit-doze: set new unix wakeup timer in state and emit move to unix
   ::
   ::    We prepend the unix %doze event so that it is handled first. Arvo must
@@ -182,11 +203,11 @@
   =^  moves  state
     ?-  -.task
       %born  born:event-core
-      %crud  (crud:event-core [p q]:task)
+      %crud  (crud:event-core [tag tang]:task)
       %rest  (rest:event-core date=p.task)
       %vega  vega:event-core
       %wait  (wait:event-core date=p.task)
-      %wake  wake:event-core
+      %wake  (wake:event-core error=~)
       %wegh  wegh:event-core
     ==
   [moves behn-gate]

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -363,7 +363,7 @@
           $%  [%made date=@da result=made-result:ford]  ::
           ==  ==                                        ::
               $:  $b                                    ::
-          $%  {$wake ~}                                ::  timer activate
+          $%  {$wake error=(unit tang)}                 ::  timer activate
           ==  ==                                        ::
               $:  @tas                                  ::  by any
           $%  {$crud p/@tas q/(list tank)}              ::
@@ -4118,6 +4118,11 @@
   ::
       $note  [[hen %give +.q.hin]~ ..^$]
       $wake
+    ::  TODO: handle behn errors
+    ::
+    ?^  error.q.hin
+      [[hen %slip %d %flog %crud %wake u.error.q.hin]~ ..^$]
+    ::
     =^  queued  cue.ruf  ~(get to cue.ruf)
     ::
     =/  queued-duct=duct       -.queued

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -42,7 +42,7 @@
           $%  {$woot p/ship q/coop}                     ::  acknowledgment
           ==  ==                                        ::
               $:  $b                                    ::  by %behn
-          $%  {$wake ~}                                ::  timer activate
+          $%  {$wake error=(unit tang)}                 ::  timer activate
           ==  ==                                        ::
               $:  $g                                    ::  by %gall
           $%  {$unto p/cuft:gall}                      ::  within agent
@@ -1028,6 +1028,11 @@
       ==
     ::
         $wake
+      ::  TODO: handle behn errors
+      ::
+      ?^  error.sih
+        +>.$(mow [[hen %slip %d %flog %crud %wake u.error.sih] mow])
+      ::
       ?>  ?=({?($of $ow) @ ~} tee)
       ?:  ?=($ow -.tee)
         abut:(ire-ix p.tee)

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -983,6 +983,12 @@
         abet:~(wake et hen our now urb.lex sub.lex etn.lex sap.lex)
       abet:(~(init et hen our now [urb sub etn sap]:lex) our (sein our))
     ::
+        [%b %wake ^]
+      ::  TODO: handle behn error
+      ::
+      ~&  %jael-wake-bad^u.error.hin
+      +>.$
+    ::
         [%j %vent *]
       %+  cute  hen  =<  abet
       (~(hear-vent et hen our now urb.lex sub.lex etn.lex sap.lex) p.hin)

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -423,23 +423,23 @@
   ++  able  ^?
     |%
     ++  note                                            ::  out request $->
-      $%  $:  $d                                        ::  to %dill
-      $%  {$flog p/flog:dill}                           ::
-      ==  ==  ==                                        ::
+      $%  $:  %d                                        ::  to %dill
+      $%  [$flog =flog:dill]
+      ==  ==  ==
     ++  gift                                            ::  out result <-$
-      $%  {$doze p/(unit @da)}                          ::  next alarm
-          {$mass p/mass}                                ::  memory usage
-          {$wake ~}                                    ::  wakeup
-      ==                                                ::
+      $%  [%doze p=(unit @da)]                          ::  next alarm
+          [%mass p=mass]                                ::  memory usage
+          [%wake error=(unit tang)]                     ::  wakeup or failed
+      ==
     ++  task                                            ::  in request ->$
-      $%  {$born ~}                                     ::  new unix process
-          {$crud p/@tas q/(list tank)}                  ::  error with trace
-          {$rest p/@da}                                 ::  cancel alarm
-          {$vega ~}                                     ::  report upgrade
-          {$wait p/@da}                                 ::  set alarm
-          {$wake ~}                                    ::  timer activate
-          {$wegh ~}                                    ::  report memory
-      ==                                                ::
+      $%  [%born ~]                                     ::  new unix process
+          [%crud tag=@tas =tang]                        ::  error with trace
+          [%rest p=@da]                                 ::  cancel alarm
+          [%vega ~]                                     ::  report upgrade
+          [%wait p=@da]                                 ::  set alarm
+          [%wake ~]                                     ::  timer activate
+          [%wegh ~]                                     ::  report memory
+      ==
     --  ::able
   --  ::behn
 ::                                                      ::::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7099,16 +7099,17 @@
 ++  unix-task                                           ::  input from unix
   $%  {$belt p/belt:dill}                               ::  dill: keyboard
       {$blew p/blew:dill}                               ::  dill: configure
-      {$boat ~}                                        ::  clay: reboot
-      {$born ~}                                        ::  eyre: new process
-      {$hail ~}                                        ::  dill: refresh
+      {$boat ~}                                         ::  clay: reboot
+      {$born ~}                                         ::  eyre: new process
+      [%crud tag=@tas =tang]                            ::  any vane: error report
+      {$hail ~}                                         ::  dill: refresh
       {$hear p/lane:ames q/@}                           ::  ames: input packet
-      {$hook ~}                                        ::  dill: hangup
+      {$hook ~}                                         ::  dill: hangup
       {$into p/desk q/? r/mode:clay}                    ::  clay: external edit
       {$they p/@ud q/httr:eyre}                         ::  eyre: in response
       {$this p/? q/clip:eyre r/httq:eyre}               ::  eyre: in request
-      {$thud ~}                                        ::  eyre: in cancel
-      {$wake ~}                                        ::  behn: wakeup
+      {$thud ~}                                         ::  eyre: in cancel
+      {$wake ~}                                         ::  behn: wakeup
   ==
 ::                                                      ::
 ::::                      ++azimuth                     ::  (2az) azimuth

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -225,7 +225,7 @@
       ==                                                ::
     ++  sign                                            ::  in result _<-
       $%  $:  $b                                        ::  to %behn
-      $%  {$wake ~}                                     ::  timer activate
+      $%  {$wake error=(unit tang)}                     ::  timer activate
       ==  ==                                            ::
           $:  %j                                        ::  from %jael
       $%  [%pubs public:able:jael]                      ::  public keys
@@ -1848,7 +1848,7 @@
     +$  seed  [who=ship lyf=life key=ring sig=(unit oath:pki)]
     ::
     ++  sign                                            ::  in result $<-
-      $%  {$b $wake ~}                                  ::  wakeup
+      $%  {$b $wake error=(unit tang)}                  ::  wakeup
           [%e %sigh p=cage]                             ::  marked http response
           [%j %vent p=vent-result]                      ::  ethereum changes
           [%a %woot p=ship q=coop]                      ::  message result


### PR DESCRIPTION
This sets the groundwork for future work for vanes to handle async errors. I just added stubs to the various vanes for now, but at least they now have the error information.

A `|reset` passed, but I have not done more detailed testing on this. Not sure if there's a convenient way to test. Maybe pH?