### PR TITLE
hardens %ames initialization

### DIFF
--- a/.travis/pin-parent-pill-pier.url
+++ b/.travis/pin-parent-pill-pier.url
@@ -1,1 +1,1 @@
-https://ci-piers.urbit.org/zod-0838dd9396cc6742e8bdd8dfee2e1bf5a782a50d.tgz
+https://ci-piers.urbit.org/zod-f9000e4ae042dd36f103da8c8f4e997a892b8697.tgz

--- a/.travis/test.js
+++ b/.travis/test.js
@@ -94,7 +94,7 @@ function aqua(urb) {
     urb.every(/TEST [^ ]* FAILED/, function(arg){
       throw Error(arg);
     });
-    return urb.line(":ph %run-all-tests");
+    return urb.line(":ph [%run-test %hi]");
   })
   .then(function(){
     return urb.expectEcho("ALL TESTS SUCCEEDED")

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -554,6 +554,14 @@
       %-  need  %-  need
       %-  (sloy-light ski)
       [[151 %noun] %j our %saxo da+now /(scot %p who)]
+    ::  +turf-scry: for network domains
+    ::
+    ++  turf-scry
+      ~/  %turf
+      ;;  (list turf)
+      %-  need  %-  need
+      %-  (sloy-light ski)
+      [[151 %noun] %j our %turf da+now ~]
     ::
     ++  vein                                            ::    vein:am
       ~/  %vein
@@ -1300,7 +1308,14 @@
       :_  fox  [hen [%pass wire %j %pubs p.bon]]~
     ::
         %bock
-      :_  fox  [hen %give %turf tuf.fox]~
+      ::  ignore %turf if we haven't yet learned a unix duct
+      ::
+      ::     Only happens during first boot.
+      ::
+      ?~  gad.fox
+        [~ fox]
+      :_  fox
+      [gad.fox %give %turf tuf.fox]~
     ::
         %brew
       :_  fox  [hen [%pass / %j %turf ~]]~
@@ -1323,9 +1338,13 @@
       :_  fox  [hen %pass wire i.q.q.bon %west p.bon t.q.q.bon r.bon]~
     ::
         %ouzo
+      ::  drop packet if we haven't yet learned a unix duct
+      ::
+      ::     Only happens during first boot.
+      ::
+      ?~  gad.fox
+        [~ fox]
       ::  ~&  [%send now p.bon `@p`(mug (shaf %flap q.bon))]
-      ~|  [%ames-bad-duct duct=gad.fox lane=p.bon]
-      ?>  ?=(^ gad.fox)
       :_  fox
       [[gad.fox [%give %send p.bon q.bon]] ~]
     ::
@@ -1333,6 +1352,12 @@
       :_  fox(tim `p.bon)
       %-  flop
       ^-  (list move)
+      ::  XX should this be the unix duct (gad.fox)?
+      ::
+      ::    It seems far more important that the duct be always
+      ::    predictable than that it be the unix duct, which
+      ::    may change, or be unset during first boot.
+      ::
       :-  [gad.fox %pass /ames %b %wait p.bon]
       ?~  tim.fox  ~
       [gad.fox %pass /ames %b %rest u.tim.fox]~
@@ -1386,10 +1411,6 @@
         %mack  ?~  +>.sih  $(sih [%g %nice ~])          ::  XX using old code
                $(sih [%g %mean `[%mack +>+.sih]])
     ::
-        %turf
-      =.  tuf.fox  turf.sih
-      [~ +>.$]
-    ::
         %pubs
       ?.  ?=([%pubs @ ~] tea)
         ~&  [%strange-pubs tea]
@@ -1432,6 +1453,12 @@
             %wake
           (~(wake am [our now fox ski]) hen)
         ::
+            %turf
+          ?:  =(tuf.fox turf.sih)
+            [~ fox]
+          =.  tuf.fox  turf.sih
+          [[%bock ~]~ fox]
+        ::
             ?(%mean %nice)                              ::  XX obsolete
           ?:  ?=([%ye ~] tea)
             [~ fox]
@@ -1469,8 +1496,10 @@
         ^-  [p=(list boon) q=fort]
         ?-    -.kyz
             %barn
-          :_  fox(gad hen)
-          [%bock ~]~
+          =:  gad.fox  hen
+              tuf.fox  ~(turf-scry am [our now fox ski])
+            ==
+          [[%bock ~]~ fox]
         ::
             %bonk
           :_  fox

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -2448,6 +2448,10 @@
     ?:  =(~ snaps.sap.lex)
       snap.snap
     $
+  ::
+      %turf
+    ?.  ?=(~ tyl)  [~ ~]
+    [~ ~ %noun !>(tuf.own.sub.lex)]
   ==
 ::                                                      ::  ++stay
 ++  stay                                                ::  preserve


### PR DESCRIPTION
As discussed briefly in urbit/urbit#1236, %ames initialization is particularly fragile, and requires special accommodation by the runtime. This PR makes the handling of the ames process/boot event `%barn` more robust, at the expense of dropping (and therefore subsequently retrying) packets sent during the boot sequence.