### PR TITLE
suppresses %clay file-change printfs for initial filesystem

### DIFF
--- a/lib/ph.hoon
+++ b/lib/ph.hoon
@@ -330,7 +330,7 @@
       ::
       :~
         ?.  %^  is-dojo-output  her  who  :-  uf
-            "+ /{(scow %p her)}/base/2/web/testing/udon"
+            "clay: committed initial filesystem (all)"
           ~
         [%test-done &]~
       ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -341,8 +341,11 @@
       {$warp p/ship q/riff}                             ::
       {$werp p/ship q/ship r/riff}                      ::
   ==  ==                                                ::
-      $:  $d                                            ::
-  $%  {$flog p/{$crud p/@tas q/(list tank)}}            ::  to %dill
+      $:  $d                                            ::  to %dill
+  $%  $:  $flog                                         ::
+          $%  {$crud p/@tas q/(list tank)}              ::
+              {$text p/tape}                            ::
+      ==  ==                                            ::
   ==  ==                                                ::
       $:  $f                                            ::
   $%  [%build live=? schematic=schematic:ford]          ::
@@ -1083,6 +1086,17 @@
   ++  print-changes
     |=  {wen/@da lem/nuri}
     ^+  +>
+    ::  skip full change output for initial filesystem
+    ::
+    ?:  ?&  =(%base syd)
+            |(=(1 let.dom) =(2 let.dom))
+        ==
+      =/  msg=tape
+        %+  weld
+          "clay: committed initial filesystem"
+        ?:(=(1 let.dom) " (hoon)" " (all)")
+      (emit (need hun) %pass / %d %flog %text msg)
+    ::
     =+  pre=`path`~[(scot %p her) syd (scot %ud let.dom)]
     ?-  -.lem
       %|  (print-to-dill '=' %leaf :(weld (trip p.lem) " " (spud pre)))


### PR DESCRIPTION
This is not a pressing issue -- consider it a UX feature request.

I've long found these printfs to be superfluous, but it's gotten much worse (imo) with the growth of userspace. This is really highlighted when you boot ships in :aqua.

The printfs are replaced with

```
clay: committed initial filesystem (hoon)
```

for `base/1`,  and

```
clay: committed initial filesystem (all)
```

for `base/2`