### PR TITLE
fixes clay boot printfs

### DIFF
--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -4072,13 +4072,8 @@
   |=  old=axle
   ^+  ..^$
   =?  old  ?=(%1 -.old)
-    ~&  desks=(turn ~(tap by dos.rom.ruf-1.old) head)
-    ~&  hoy=(turn ~(tap by hoy.ruf-1.old) head)
     (load-1-2 old)
-  ~&  hrm=[-.old ver]
   ?>  ?=(%2 -.old)
-  ~&  desks=(turn ~(tap by dos.rom.ruf-2.old) head)
-  ~&  hoy=(turn ~(tap by hoy.ruf-2.old) head)
   %_(..^$ ruf ruf-2.old)
 ::
 ++  load-1-2

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -1090,6 +1090,7 @@
     ::
     ?:  ?&  =(%base syd)
             |(=(1 let.dom) =(2 let.dom))
+            ?=([%& ^] lem)
         ==
       =/  msg=tape
         %+  weld


### PR DESCRIPTION
The new clay "initial filesystem" printfs introduced in #1139 were spuriously being triggered by any external syncs to any desk other than `%base`, if `%base` was mounted (because all mount-points are synced). This is fixed by checking that there are actual changes being made before printing.

Also removes some debug printfs in `+load`.