### PR TITLE
Do notation

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6687,6 +6687,7 @@
   ::                                            ::::::  miscellaneous
     {$mcts p/marl:hoot}                                 ::  ;=  list templating
     {$mccl p/hoon q/(list hoon)}                        ::  ;:  binary to nary
+    {$mchx p/hoon q/(list (pair spec hoon))}            ::  ;:  do notation
     {$mcnt p/hoon}                                      ::  ;/  [%$ [%$ p ~] ~]
     {$mcsg p/hoon q/(list hoon)}                        ::  ;~  kleisli arrow
     {$mcmc p/hoon q/hoon}                               ::  ;;  normalize
@@ -8763,6 +8764,28 @@
           ~      !!
         ==
       ==
+    ::
+        {$mchx *}
+      ?~  q.gen
+        ~|("open-mchx" !!)
+      =/  last-spec
+        |-  ^-  spec
+        ?~  t.q.gen
+          p.i.q.gen
+        $(q.gen t.q.gen)
+      |-  ^-  hoon
+      ?~  t.q.gen
+        q.i.q.gen
+      :^    %cnls
+          :+  %cnhp
+            :+  %cnhp
+              p.gen
+            [%ktcl p.i.q.gen]
+          [%ktcl last-spec]
+        q.i.q.gen
+      :+  %brts
+        p.i.q.gen
+      $(q.gen t.q.gen)
     ::
         {$mcnt *}  =+(zoy=[%rock %ta %$] [%clsg [zoy [%clsg [zoy p.gen] ~]] ~])
         {$mcsg *}                                       ::                  ;~
@@ -14030,6 +14053,7 @@
         [%sgzp *]  (rune '~!' ~ ~ (hoons ~[p q]:x))
         [%mcts *]  %ast-node-mcts
         [%mccl *]  (rune ';:' `'==' `[':(' spc ')'] (hoons [p q]:x))
+        [%mchx *]  (rune ';#' `'==' `[';#(' spc ')'] (hn p.x) (matches q.x))
         [%mcnt *]  (rune ';/' ~ ~ (hoons ~[p]:x))
         [%mcsg *]  (rune ';~' `'==' ~ (hoons [p q]:x))
         [%mcmc *]  (rune ';;' ~ ~ (hoons ~[p q]:x))
@@ -16638,6 +16662,7 @@
               %-  stew
               ^.  stet  ^.  limo
               :~  [':' (rune col %mccl expi)]
+                  ['#' (rune hax %mchx exp0)]
                   ['/' (rune net %mcnt expa)]
                   ['~' (rune sig %mcsg expi)]
                   [';' (rune mic %mcmc expb)]
@@ -16832,6 +16857,7 @@
     ::
     ++  glop  ~+((glue mash))                           ::  separated by space
     ++  gunk  ~+((glue muck))                           ::  separated list
+    ++  gink  ~+((glue mick))                           ::  separated <-- list
     ++  butt  |*  zor/rule                              ::  closing == if tall
               ?:(tol ;~(sfix zor ;~(plug gap duz)) zor)
     ++  ulva  |*  zor/rule                              ::  closing -- and tall
@@ -16844,6 +16870,9 @@
     ++  lomp  ;~(plug sym (punt ;~(pfix tis wyde)))     ::  typeable name
     ++  mash  ?:(tol gap ;~(plug com ace))              ::  list separator
     ++  muck  ?:(tol gap ace)                           ::  general separator
+    ++  mick  ?:  tol                                   ::  <-- separator
+                ;~(plug gap gal hep hep gap)
+              ace
     ++  teak  %+  knee  *tiki  |.  ~+                   ::  wing or hoon
               =+  ^=  gub
                   |=  {a/term b/$%({%& p/wing} {%| p/hoon})}
@@ -16877,6 +16906,7 @@
               ==
     ++  rack  (most mash ;~(gunk loaf loaf))            ::  list [hoon hoon]
     ++  ruck  (most mash ;~(gunk loan loaf))            ::  list [spec hoon]
+    ++  rock  (most mash ;~(gink loan loaf))            ::  list [spec <-- hoon]
     ++  rick  (most mash ;~(gunk rope loaf))            ::  list [wing hoon]
     ::
     ::    hoon contents
@@ -16909,6 +16939,7 @@
     ++  expx  |.(;~(gunk loaf wisp))                    ::  hoon and core tail
     ++  expy  |.(;~(gunk ropa loaf loaf))               ::  wings and two hoons
     ++  expz  |.(loaf(bug &))                           ::  hoon with tracing
+    ++  exp0  |.((butt ;~(gunk loaf rock)))             ::  ;#
     ::    spec contents
     ::
     ++  exqa  |.(loan)                                  ::  one hoon


### PR DESCRIPTION
I propose a new synthetic rune.  I'm open to suggestions on the name; as a placeholder I'm using `;#`.

I've tagged some of the Haskell people for review, but I'm also particularly interested in @frodwith, @belisarius222, and @joemfb's opinion.

### Motivation

Suppose we have a `ph` monad (as I do in the philip/individual-breaches branch), where "M a" is `(ph-data a)` and we have operations `ph-return` and `ph-bind`.  These have signatures:

```
++  ph-return
  |*  a=mold
  |=  arg=a
  ^-  (ph-data a)
  !!
::
++  ph-bind
  |*  a=mold
  |*  b=mold
  |=  [m-a=(ph-data a) fun=_|~(a *(ph-data b))]
  ^-  (ph-data b)
  !!
```

Then, we can chain together operations on this monad to form larger state machines.  In the ph example, we use this to create integration tests that are fully composable and wrappable.  This sort of composability of state machines has hardly ever been attained in Hoon code in the past.

Here's how we can chain together two operations, each of which produce values that any later operation can use.

```
%+  ((ph-bind ,[%booted who=@p]) ,~)
  (boot ~bud ~)
|=  [%booted who=@p]
%+  ((ph-bind ,[%boot-done whom=@p]) ,~)
  (check-ship-booted who)
|=  [%boot-done whom=@p]
~&  [who=who whom=whom]
((ph-return ,~) ~)
```

This is wonderfully composable and horribly ugly.  In my opinion, it's worth using even this because excessive boilerplate is better than unrolling the state machine.

However, even though reading this code is hard, writing it is fairly mechanical.  This suggests that a synthetic rune could clarify the code.

### Existing runes

Let's look at why our current runes don't handle what we need.

`;~` is the Kleisli arrow.  While this is useful for some things, it's not as generally useful as a convenient syntax writing in monadic style.  Consider:

```
%.  (boot ~bud ~)
;~  ph-bind
  |=  [%booted who=@p]
  (check-ship-booted ~bud)
::
  |=  [%boot-done whom=@p]
  ~&  [who=who whom=whom]
  ((ph-return ,~) ~)
==
```

This doesn't compile for a couple of reasons.  First, this approach only works if you can keep ph-bind sufficiently wet (as in `+biff`).  Working with wet gates in this manner in extremely finicky and requires many explicit casts to get right.

Secondly, the `~&` fails because `who` is not in scope.  This is killer because it means that to keep stuff in your subject you need to explicitly pass it from one operation to the next, which is extremely cumbersome.

`;:` is a left-associative rune that turns `;(add a b c)` into `(add (add a b) c)`.  This is useful for functions that are not generic, but it can't be used for generic functions, since each invocation requires a new version of the function.  Again, with sufficiently wet gates you may be able to get it working for simple operations, but this doesn't scale.

### Just do it

Thus, I propose `;#`.  It transforms the code above into:

```
;#  ph-bind
  [%booted who=@p]      <--  (boot ~bud ~)
  [%boot-done whom=@p]  <--  (check-ship-booted ~bud)
  ~                     <--  ~&  [who=who whom=whom]
                             (return:(ph ,~) ~)
==
```

This is dramatically easier to read and follow what's happening.  

This works nearly exactly like Haskell's do notation.  The main difference is that we specify the type rather than just a name for each operation result.  This doesn't feel overly burdensome, and it is in keeping with Hoon's general principle of being more explicit about types.  One of the most frustrating parts of Haskell for me is how the types are very non-obvious but aren't specified in the code.

The implementation is pretty straightforward; it's just a translation of the one to the other.

### One more example

A complete example with a simpler monad:

```
=>  |%
    ++  unit-return
      |*  a=mold
      |=  arg=a
      ^-  (unit a)
      `a
    ::
    ++  unit-bind
      |*  a=mold
      |*  b=mold
      |=  [m-a=(unit a) fun=$-(a (unit b))]
      ^-  (unit b)
      ?~  m-a
        ~
      (fun u.m-a)
    --
|=  a=@
;#  unit-bind
  b=@     <--  `a
  c=@     <--  ?:(=(0 b) ~ `(div 120 b))
  d=tape  <--  ?:  =(c 0)
                 ~  ::  don't disrespect ~zod
               `(scow %p c)
  f=tape  <--  `"120 divided by {(scow %ud a)} is {d} in @p"
==
```

Put this in `/gen/unit.hoon` and try `+unit 5`, `+unit 121`, and `+unit 0`.

### Open questions

- What glyphs to give this rune.

- Introducing `<--` is questionable.  We could omit it, in which case it would have the same shape as `?-`, and could be formatted kingside or queenside accordingly.

- If you `=+` a non-monadic variable in the the body of an operation, later operations don't see it.  We could either not support that or include a specific syntax for it, like `===` instead of `<--`.