### PR TITLE
add +bake

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -615,7 +615,7 @@
   ::                                                    ::
   ::                                                    ::
 ::
-::  +snoc Append an element to the end of a list.
+::  +snoc: append an element to the end of a list
 ::
 ++  snoc
   |*  [a/(list) b/*]
@@ -673,6 +673,13 @@
     |@  ++  $  ?:(*? ~ [i=(snag 0 a) t=$])
     --
   a
+::
+::  +bake: convert wet gate to dry gate by specifying argument mold
+::
+++  bake
+  |*  [f=gate a=mold]
+  |=  arg=a
+  (f arg)
 ::
 ++  lent                                                ::  length
   ~/  %lent


### PR DESCRIPTION
As described in #1145, wet gates are often more tricky to use than dry gates.  `+bake` takes a wet gate and a type and monomorphizes the wet gate into a dry gate with the given argument type.