### PR TITLE
Add =% for monadic operations

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -6688,6 +6688,7 @@
     {$mcts p/marl:hoot}                                 ::  ;=  list templating
     {$mccl p/hoon q/(list hoon)}                        ::  ;:  binary to nary
     {$mcnt p/hoon}                                      ::  ;/  [%$ [%$ p ~] ~]
+    {$mcgl p/spec q/hoon r/hoon s/hoon}                 ::  ;<  bind
     {$mcsg p/hoon q/(list hoon)}                        ::  ;~  kleisli arrow
     {$mcmc p/hoon q/hoon}                               ::  ;;  normalize
   ::                                            ::::::  compositions
@@ -8765,6 +8766,16 @@
       ==
     ::
         {$mcnt *}  =+(zoy=[%rock %ta %$] [%clsg [zoy [%clsg [zoy p.gen] ~]] ~])
+        {$mcgl *}
+      :^    %cnls
+          :+  %cnhp
+            q.gen
+          [%ktcl p.gen]
+        r.gen
+      :+  %brts
+        p.gen
+      s.gen
+    ::
         {$mcsg *}                                       ::                  ;~
       |-  ^-  hoon
       ?-  q.gen
@@ -14031,6 +14042,7 @@
         [%mcts *]  %ast-node-mcts
         [%mccl *]  (rune ';:' `'==' `[':(' spc ')'] (hoons [p q]:x))
         [%mcnt *]  (rune ';/' ~ ~ (hoons ~[p]:x))
+        [%mcgl *]  (rune ';<' ~ ~ (spec p.x) (hoons ~[q r s]:x))
         [%mcsg *]  (rune ';~' `'==' ~ (hoons [p q]:x))
         [%mcmc *]  (rune ';;' ~ ~ (hoons ~[p q]:x))
         [%tsbr *]  (rune ';;' ~ ~ ~[(spec p.x) (hn q.x)])
@@ -16639,6 +16651,7 @@
               ^.  stet  ^.  limo
               :~  [':' (rune col %mccl expi)]
                   ['/' (rune net %mcnt expa)]
+                  ['<' (rune gal %mcgl exp1)]
                   ['~' (rune sig %mcsg expi)]
                   [';' (rune mic %mcmc expb)]
               ==
@@ -16909,6 +16922,7 @@
     ++  expx  |.(;~(gunk loaf wisp))                    ::  hoon and core tail
     ++  expy  |.(;~(gunk ropa loaf loaf))               ::  wings and two hoons
     ++  expz  |.(loaf(bug &))                           ::  hoon with tracing
+    ++  exp1  |.(;~(gunk loan loaf loaf loaf))          ::  spec and three hoons
     ::    spec contents
     ::
     ++  exqa  |.(loan)                                  ::  one hoon


### PR DESCRIPTION
Refer to #1145 for a discussion of motivation and some alternatives.

This introduces a new synthetic rune `=%`.  This:

```
=%  a=@  b  c
d
```

Expands to this:

```
%+  (b a=@)
  c
|=  a=@
d
```

The intended use case is monadic operations.  Here's an idiomatic real-world example where I use it to boot two ships and have them `|hi` each other.  Note that each of these actions requires sending moves to another gall app and receiving multiple responses from that app.

```
=/  m  (ph ,~)
^-  data:m
=%  [%booted from=@p]     bind:m  (boot-ship ~bud ~)
=%  [%boot-done from=@p]  bind:m  (check-ship-booted from)
=%  [%booted to=@p]       bind:m  (boot-ship ~dev ~)
=%  [%boot-done to=@p]    bind:m  (check-ship-booted to)
(send-hi ~bud ~dev)
```

This assumes you have defined an explicitly parameterized monad that looks something like this:

```
++  ph
  |*  a=mold
  |%
  ++  data  !!
  ++  return
    |=  =a
    ^-  data
    !!
  ::
  ++  bind
    |*  b=mold
    |=  [m-b=(data:(ph b) fun=$-(b data)]
    ^-  data:
    !!
  --
```

Since bind is associative and monads compose, you can refactor this test:

```
++  full-boot
  |=  her=ship
  =/  m  (ph ,~)
  =%  [%booted from=@p]     bind:m  (boot-ship her ~)
  =%  [%boot-done from=@p]  bind:m  (check-ship-booted from)
  (return:m ~)
::
++  hi
  =%  ~  bind:m  (full-boot ~bud)
  =%  ~  bind:m  (full-boot ~dev)
  (send-hi ~bud ~dev)
```

This sort of composability of operations that include sending and receiving moves to other apps is something we've never properly had.  This rune provides a convenient syntax to do that.

You can also use this with wet gates if you prepend `_`.  The gates also don't have to "bind" operations.  For example:

```
=/  a=(list (unit @))  ~[`1 ~ `3 `4 ~]
=%  b=(unit @)  _murn  a
=%  c=@         _biff  b
?:  =(0 (mod c 2))
  ~
(some (scow %ub c))
```

The usual cautions around wet gates apply.  As is usual with wet gates, some extra casts may be necessary.  In this case, the `(list (unit @))` and `some` lines are important to assign the correct types and faces.

If the above code is confusing, consider adding some casts for documentation.  This is too many, but it gets the point across:

```
=/  a=(list (unit @))  ~[`1 ~ `3 `4 ~]
^-  (list tape)
=%  b=(unit @)  _murn  a
^-  (unit tape)
=%  c=@         _biff  b
^-  (unit tape)
?:  =(0 (mod c 2))
  ~
(some (scow %ub c))
```