### PR TITLE
Update %mint task structure in helm

### DIFF
--- a/lib/hood/helm.hoon
+++ b/lib/hood/helm.hoon
@@ -40,7 +40,7 @@
       $%  [%bonk wire ~]                                ::
           {$conf wire dock $load ship term}             ::
           {$flog wire flog:dill}                        ::
-          [%mint wire our=ship p=ship q=safe:rights:jael]
+          [%mint wire p=ship q=safe:rights:jael]
           {$nuke wire ship}                             ::
           {$serv wire ?(desk beam)}                     ::
           {$poke wire dock pear}                        ::
@@ -87,7 +87,7 @@
   ::  our new private key, as a +tree of +rite
   ::
   =/  rit  (sy [%jewel (my [lyf.u.sed key.u.sed] ~)] ~)
-  (emit %mint / our our rit)
+  (emit %mint / our rit)
 ::
 ++  poke-nuke                                         ::  initialize
   |=  him/ship  =<  abet


### PR DESCRIPTION
This now matches [the one in zuse](https://github.com/urbit/arvo/blob/master/sys/zuse.hoon#L1875).

Seems like something that was missed during single-homing?

Curiously, people who hadn't touched their `helm.hoon` were still able to rekey just fine. Only after recompiling `helm.hoon` did they run into problems with this.

(idk where to target this PR anymore)