### PR TITLE
remove +hard, replace with new ;;

### DIFF
--- a/lib/collections.hoon
+++ b/lib/collections.hoon
@@ -310,7 +310,7 @@
   |=  [seg=@ta out=term]
   %^  cat  3
     ?:(=(%$ out) out (cat 3 out '-'))
-    ((hard @tas) seg)
+    ;;(@tas seg)
   [our nam]
 ::
 ::  +allowed-by: checks if ship :who is allowed by the permission rules in :dic
@@ -402,7 +402,7 @@
   =/  entries=wain
     %+  turn  ~(tap by a)
     |=  b=[knot cord]
-    =/  c=[term cord]  ((hard ,[term cord]) b)
+    =/  c=[term cord]  ;;([term cord] b)
     (crip "  [{<-.c>} {<+.c>}]")
   ::
   ?~  entries  ~

--- a/lib/hall-legacy.hoon
+++ b/lib/hall-legacy.hoon
@@ -144,7 +144,7 @@
     %-  of  :~
       name+(ot nom+so mon+tors ~)
       text+(cu to-wain:format so)
-      tank+(ot dat+(cu ;;((list tank) blob)) ~)
+      tank+(ot dat+(cu (list tank) blob) ~)
     ==
   ::
   ++  blob  (cu cue (su fel:de-base64:mimes:html))

--- a/lib/hall-legacy.hoon
+++ b/lib/hall-legacy.hoon
@@ -144,7 +144,7 @@
     %-  of  :~
       name+(ot nom+so mon+tors ~)
       text+(cu to-wain:format so)
-      tank+(ot dat+(cu (hard (list tank)) blob) ~)
+      tank+(ot dat+(cu ;;((list tank) blob)) ~)
     ==
   ::
   ++  blob  (cu cue (su fel:de-base64:mimes:html))

--- a/lib/hood/kiln.hoon
+++ b/lib/hood/kiln.hoon
@@ -392,7 +392,7 @@
           (render "on sync" sud her syd)
         ~
       start-sync
-    =.  let  ?.  ?=($w p.p.u.rot)  let  ud:((hard cass:clay) q.q.r.u.rot)
+    =.  let  ?.  ?=($w p.p.u.rot)  let  ud:;;(cass:clay q.q.r.u.rot)
     =/  =wire  /kiln/sync/[syd]/(scot %p her)/[sud]
     ::  germ: merge mode for sync merges
     ::
@@ -625,7 +625,7 @@
         ?.  ?=($path p.pax)
           ~|  "strange path mark: {<p.pax>}"
           !!
-        [((hard path) q.q.pax) ?:(?=($null p.dif) ~ `[%dif dif])]
+        [;;(path q.q.pax) ?:(?=($null p.dif) ~ `[%dif dif])]
     :: ~&  >  kiln-made+[(turn can head) syd=syd +<.abet]
     =+  notated=(skid can |=({path a/(unit miso)} ?=(^ a)))
     =+  annotated=(turn `(list (pair path *))`-.notated head)

--- a/lib/oauth1.hoon
+++ b/lib/oauth1.hoon
@@ -86,7 +86,8 @@
   ^-  {key/@t sec/@t ~}
   ?.  =(~ `@`key)
     ~|  %oauth-bad-keys
-    ((hard {key/@t sec/@t ~}) (to-wain:format key))
+    ;;  {key/@t sec/@t ~}
+    (to-wain:format key)
   %+  mean-wall  %oauth-no-keys
   """
   Run |init-oauth1 {<`path`dom>}

--- a/lib/oauth2.hoon
+++ b/lib/oauth2.hoon
@@ -74,7 +74,8 @@
   ^-  {cid/@t cis/@t ~}
   ?.  =(~ `@`key)
     ~|  %oauth-bad-keys
-    ((hard {cid/@t cis/@t ~}) (to-wain key))
+    ;;  {cid/@t cis/@t ~}
+    (to-wain key)
   %+  mean-wall  %oauth-no-keys
   """
   Run |init-oauth2 {<`path`dom>}

--- a/lib/test/runner.hoon
+++ b/lib/test/runner.hoon
@@ -55,8 +55,9 @@
   ^-  test-func
   ::
   |.
-  ^-  tang
-  ((hard tang) .*(test-core nock.run-arm))
+  ;;  tang
+  .*  test-core
+  nock.run-arm
 ::  +has-test-prefix: does the arm define a test we should run?
 ::
 ++  has-test-prefix

--- a/mar/collections/action.hoon
+++ b/mar/collections/action.hoon
@@ -18,7 +18,7 @@
   ++  noun  action:collections
   ++  json
     |=  jon=^json
-    %-  (hard action:collections)
+    ;;  action:collections
     =<  (action jon)
     |%
     ++  action
@@ -68,7 +68,7 @@
       |=  jon=^json
       ^-  (set whom:clay)
       =/  x  ((ar:dejs (su:dejs fed:ag)) jon)
-      %-  (hard (set whom:clay))
+      ;;  (set whom:clay)
       %-  ~(run in (sy x))
       |=(w=@ [& w])
     --

--- a/sys/arvo.hoon
+++ b/sys/arvo.hoon
@@ -591,7 +591,7 @@
     ::
     ++  poke  |=  *                                     ::  47
               ^-  [(list ovum) *]
-              =>  .(+< ((hard ,[now=@da ovo=ovum]) +<))
+              =>  .(+< ;;([now=@da ovo=ovum] +<))
               ^-  [(list ovum) *]
               =.  +>.$
                 ?+  -.q.ovo
@@ -652,23 +652,23 @@
 =<  ::  Arvo structural interface
     ::
     |%
-    ++  come  |=  {@ @ @ (list ovum) vise pone}         ::   4
-              ^-  {(list ovum) _+>}
+    ++  come  |=  [@ @ @ (list ovum) vise pone]         ::   4
+              ^-  [(list ovum) _+>]
               ~&  %hoon-come
               =^  rey  +>+  (^come +<)
               [rey +>.$]
     ::
-    ++  load  |=  {@ @ @ (list ovum) vase pane}         ::  10
-              ^-  {(list ovum) _+>}
+    ++  load  |=  [@ @ @ (list ovum) vase pane]         ::  10
+              ^-  [(list ovum) _+>]
               ~&  %hoon-load
               =^  rey  +>+  (^load +<)
               [rey +>.$]
     ::
-    ++  peek  |=(* (^peek ((hard {@da path}) +<)))      ::  46
+    ++  peek  |=(* (^peek ;;([@da path] +<)))      ::  46
     ::
     ++  poke  |=  *                                     ::  47
               ^-  [(list ovum) *]
-              =>  .(+< ((hard ,[now=@da ovo=ovum]) +<))
+              =>  .(+< ;;([now=@da ovo=ovum] +<))
               =^  ova  +>+.$  (^poke now ovo)
               =|  out=(list ovum)
               |-  ^-  [(list ovum) *]
@@ -678,7 +678,7 @@
               ::
               ?:  ?=(%lyra -.q.i.ova)
                 %+  fall
-                  (vega now t.ova ({@ @} +.q.i.ova))
+                  (vega now t.ova ;;([@ @] +.q.i.ova))
                 [~ +>.^$]
               ::  iterate over effects, handling those on arvo proper
               ::  and passing the rest through as output
@@ -687,7 +687,7 @@
               =?  out  ?=(^ vov)  [+.vov out]
               $(ova t.ova)
     ::
-    ++  wish  |=(* (^wish ((hard @ta) +<)))             ::  22
+    ++  wish  |=(* (^wish ;;(@ta +<)))             ::  22
     --
 ::  Arvo implementation core
 ::
@@ -894,7 +894,7 @@
 ::
 ++  veer
   |=  [who=ship now=@da fav=curd]
-  =>  .(fav ((hard {$veer lal/@ta pax/path txt/@t}) fav))
+  =>  .(fav ;;({$veer lal/@ta pax/path txt/@t} fav))
   =-  ?:(?=(%| -.res) ((slog p.res) +>.$) p.res)
   ^=  res  %-  mule  |.
   ?:  =(%$ lal.fav)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -256,13 +256,6 @@
   --
 ::
 ++  fore  |*(a/$-(* *) |*(b/$-(* *) (pair a b)))        ::  pair before
-++  hard                                                ::  force remold
-  |*  han/$-(* *)
-  |=  fud/*  ^-  han
-  ~_  leaf+"hard"
-  =+  gol=(han fud)
-  ?>(=(gol fud) gol)
-::
 ::
 ++  head  |*(^ ,:+<-)                                   ::  get head
 ++  same  |*(* +<)                                      ::  identity
@@ -11187,7 +11180,7 @@
         $type
       =+  tyr=|.((dial dole))
       =+  vol=tyr(sut lum)
-      =+  cis=((hard tank) .*(vol [%9 2 %0 1]))
+      =+  cis=;;(tank .*(vol [%9 2 %0 1]))
       :^  ~   %palm
         [~ ~ ~ ~]
       [[%leaf '#' 't' '/' ~] cis ~]
@@ -11199,7 +11192,7 @@
       |-  ^-  (list tank)
       ?~  lum  ~
       ?@  lum  !!
-      [[%leaf (trip ((hard @) -.lum))] $(lum +.lum)]
+      [[%leaf (trip ;;(@ -.lum))] $(lum +.lum)]
     ::
         $wool
       :-  ~
@@ -14526,20 +14519,20 @@
       |=  [p=xpat n=*]
       ^-  plum
       ?-  p
-        %hoon      (hoon-to-plum 999 ((hard hoon) n))
-        %json      (json-to-plum ((hard json) n))
-        %manx      (manx-to-plum ((hard manx) n))
-        %nock      (nock-to-plum ((hard nock) n))
-        %path      (path-to-plum ((hard path) n))
-        %plum      ((hard plum) n)
-        %skin      (skin-to-plum ((hard skin) n))
-        %spec      (spec-to-plum ((hard spec) n))
-        %tape      (tape-to-plum ((hard tape) n))
-        %tour      (tour-to-plum ((hard tour) n))
+        %hoon      (hoon-to-plum 999 ;;(hoon n))
+        %json      (json-to-plum ;;(json n))
+        %manx      (manx-to-plum ;;(manx n))
+        %nock      (nock-to-plum ;;(nock n))
+        %path      (path-to-plum ;;(path n))
+        %plum      ;;(plum n)
+        %skin      (skin-to-plum ;;(skin n))
+        %spec      (spec-to-plum ;;(spec n))
+        %tape      (tape-to-plum ;;(tape n))
+        %tour      (tour-to-plum ;;(tour n))
         %type      =/  ttp  type-to-plum
-                   ((hard plum) .*(ttp(+< n) [9 2 0 1]))
+                   ;;(plum .*(ttp(+< n) [9 2 0 1]))
         %vase      =/  vtp  vase-to-plum
-                   =/  =plum  ((hard plum) .*(vtp(+< n) [9 2 0 1]))
+                   =/  =plum  ;;(plum .*(vtp(+< n) [9 2 0 1]))
                    (rune '!>' ~ ~ ~[plum])
         [%gate *]  (render-gate sample.p product.p)
         [%gear *]  '%gear'                              ::  XX TODO

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -908,7 +908,7 @@
                   %none
                 ::  ~&  %chew-none
                 =.  puz  (bilk:puz now)
-                (chow ((hard meal) (cue msg)))
+                (chow ;;(meal (cue msg)))
               ::
                   %fast
                 ::  ~&  %chew-fast
@@ -919,24 +919,24 @@
                 ?~  dey  +>.$
                 =.  puz  (bilk:puz now)
                 =^  key  diz  u.dey
-                (chow(aut sin) ((hard meal) (cue (dy:cub:sen:gus key bod))))
+                (chow(aut sin) ;;(meal (cue (dy:cub:sen:gus key bod))))
               ::
                   %full
                 ::  ~&  %chew-full
-                =/  mex  ((hard full:pact) (cue msg))
+                =/  mex  ;;(full:pact (cue msg))
                 =.  diz  (deng law.mex)
                 =/  wug  cluy:diz
                 ?>  =(lyf.wug from.lyf.mex)
                 =/  gey  (sev:gus to.lyf.mex)
                 =/  sem  (need (tear:as:q.gey pub:ex:cub.wug txt.mex))
-                =/  mes  ((hard (pair @ @)) (cue sem))
+                =/  mes  ;;((pair @ @) (cue sem))
                 =.  diz  (wasc:diz p.mes)
                 =.  puz  (bilk:puz now)
                 (west(msg q.mes))
               ::
                   %open
                 ::  ~&  %chew-open
-                =/  mex  ((hard open:pact) (cue msg))
+                =/  mex  ;;(open:pact (cue msg))
                 =.  diz  (deng law.mex)
                 =/  wug  cluy:diz
                 ?>  =(lyf.wug from.lyf.mex)
@@ -1269,7 +1269,7 @@
       =/  task=task:able
         ?.  ?=(%soft -.wrapped-task)
           wrapped-task
-        ((hard task:able) p.wrapped-task)
+        ;;(task:able p.wrapped-task)
       =.  any.ton.fox  eny
       =^  duy  ..knob  (knob hen task)
       [duy ..^$]

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -200,7 +200,7 @@
   =/  =task:able
     ?.  ?=(%soft -.wrapped-task)
       wrapped-task
-    ((hard task:able) p.wrapped-task)
+    ;;(task:able p.wrapped-task)
   ::
   =/  event-core  (per-event [our now hen] state)
   ::

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -611,7 +611,7 @@
     =*  pax  p.i.tay
     ?.  ?=($path p.pax)
       (mule |.(`~`~|([%expected-path got=p.pax] !!)))
-    $(tay t.tay, can (~(put by can) ((hard path) q.q.pax) q.i.tay))
+    $(tay t.tay, can (~(put by can) ;;(path q.q.pax) q.i.tay))
   ::
   ::  Queue a move.
   ::
@@ -1225,7 +1225,7 @@
               %.n
             ?~  cached=(~(get by mim.dom) pax)
               %.n
-            =(((hard mime) q.q.cag) u.cached)
+            =(;;(mime q.q.cag) u.cached)
           ::
           $(p.lem t.p.lem)
         ::  if the :mis mark is the target mark and the value is the same, no-op
@@ -1305,7 +1305,7 @@
           ^-  (pair path cage)
           ?>  ?=($ins -.mis)
           =+  =>((flop pax) ?~(. %$ i))
-          [pax - [%atom %t ~] ((hard @t) +>.q.q.p.mis)]
+          [pax - [%atom %t ~] ;;(@t +>.q.q.p.mis)]
       ::
           ~
       ::
@@ -1344,7 +1344,7 @@
         ?>  ?=($ins -.mis)
         ?.  ?=($mime p.p.mis)
           ~
-        `[pax ((hard mime) q.q.p.mis)]
+        `[pax ;;(mime q.q.p.mis)]
       ::
         ^-  (list (pair path mime))
         %+  murn  ink.nuz
@@ -1352,7 +1352,7 @@
         ^-  (unit (pair path mime))
         ?>  ?=($ins -.mis)
         ?>  ?=($mime p.p.mis)
-        `[pax ((hard mime) q.q.p.mis)]
+        `[pax ;;(mime q.q.p.mis)]
       ::
         ^-  (list (pair path mime))
         %+  murn  mut.nuz
@@ -1361,7 +1361,7 @@
         ?>  ?=($mut -.mis)
         ?.  ?=($mime p.p.mis)
           ~
-        `[pax ((hard mime) q.q.p.mis)]
+        `[pax ;;(mime q.q.p.mis)]
       ==
     ==
   ::
@@ -1391,7 +1391,7 @@
     |=  {pax/cage cay/cage}
     ?.  ?=($path p.pax)
       ~|(%clay-take-inserting-strange-path-mark !!)
-    [((hard path) q.q.pax) cay]
+    [;;(path q.q.pax) cay]
   ::
   ::  Handle result of diffing.
   ::
@@ -1420,7 +1420,7 @@
     ^-  (pair path (pair lobe cage))
     ?.  ?=($path p.pax)
       ~|(%clay-take-diffing-strange-path-mark !!)
-    =+  paf=((hard path) q.q.pax)
+    =+  paf=;;(path q.q.pax)
     [paf (page-to-lobe:ze [p q.q]:cay) (~(got by dig.u.dok) paf)]
   ::
   ::  Handle result of casting mutations.
@@ -1444,7 +1444,7 @@
         |=  {pax/cage cay/cage}
         ?.  ?=($path p.pax)
           ~|(%castify-bad-path-mark !!)
-        [((hard path) q.q.pax) cay]
+        [;;(path q.q.pax) cay]
     =.  muh.u.dok
           %-  malt
           %+  turn  cat
@@ -1492,7 +1492,7 @@
       ~|(%clay-take-mutating-strange-path-mark !!)
     ?:  ?=($null p.cay)
       ~
-    =+  paf=((hard path) q.q.pax)
+    =+  paf=;;(path q.q.pax)
     `[paf (~(got by muh.u.dok) paf) cay]
   ::
   ::  Now that dok is completely filled, we can apply the changes in the commit.
@@ -1615,7 +1615,7 @@
         |=  {pax/cage cay/cage}
         ?.  ?=($path-hash p.pax)
           ~|(%patch-bad-path-mark !!)
-        [-< -> +]:[((hard {path lobe}) q.q.pax) cay]
+        [-< -> +]:[;;({path lobe} q.q.pax) cay]
     ::  ~&  %canned
     ::  ~&  %checking-out
     =.  ank.dom  (map-to-ankh:ze (malt cat))
@@ -1676,10 +1676,10 @@
         |=  {pax/cage mim/cage}
         ?.  ?=($path p.pax)
           ~|(%ergo-bad-path-mark !!)
-        :-  ((hard path) q.q.pax)
+        :-  ;;(path q.q.pax)
         ?.  ?=($mime p.mim)
           ~
-        `((hard mime) q.q.mim)
+        `;;(mime q.q.mim)
     =+  mus=(must-ergo (turn ~(tap by can) head))
     %-  emil
     %+  turn  ~(tap by mus)
@@ -1759,9 +1759,9 @@
         :+  ~
           p.r.u.rut
         ?+  p.r.u.rut  ~|  %strange-w-over-nextwork  !!
-          $cass  !>(((hard cass) q.r.u.rut))
+          $cass  !>(;;(cass q.r.u.rut))
           $null  [[%atom %n ~] ~]
-          $nako  !>(~|([%harding [&1 &2 &3]:q.r.u.rut] ((hard nako) q.r.u.rut)))
+          $nako  !>(~|([%molding [&1 &2 &3]:q.r.u.rut] ;;(nako q.r.u.rut)))
         ==
       ?.  ?=($nako p.r.u.rut)  [?>(?=(^ ref) .)]:wake
       =+  rav=`rave`q.u.ruv
@@ -1771,7 +1771,7 @@
       =+  nex=(~(get by haw.u.ref) nez)
       ?~  nex  +>+.^$
       ?~  u.nex  +>+.^$  ::  should never happen
-      =.  nak.u.ref  `((hard nako) q.q.u.u.nex)
+      =.  nak.u.ref  `;;(nako q.q.u.u.nex)
       =.  +>+.^$
         ?:  =(0 let.dom)
           =<  ?>(?=(^ ref) .)
@@ -1793,7 +1793,7 @@
           haw.u.ref
         %+  ~(put by haw.u.ref)
           [p.p.u.rut q.p.u.rut q.u.rut]
-        `[p.r.u.rut !>(((hard arch) q.r.u.rut))]
+        `[p.r.u.rut !>(;;(arch q.r.u.rut))]
       ==
     ::
         $z
@@ -1956,7 +1956,7 @@
         ?.  ?=($blob p.bob)
           ~|  %plop-not-blob
           !!
-        =+  bol=((hard blob) q.q.bob)
+        =+  bol=;;(blob q.q.bob)
         ?-  -.bol
           $delta      [-.bol p.bol q.bol p.cay q.q.cay]
           $direct     [-.bol p.bol p.cay q.q.cay]
@@ -2731,11 +2731,11 @@
       |-  ^-  @t                      ::  (urge cord) would be faster
       =+  bol=(lobe-to-blob u.lob)
       ?:  ?=($direct -.bol)
-        ((hard @t) q.q.bol)
+        ;;(@t q.q.bol)
       ?>  ?=($delta -.bol)
       =+  txt=$(u.lob q.q.bol)
       ?>  ?=($txt-diff p.r.bol)
-      =+  dif=((hard (urge cord)) q.r.bol)
+      =+  dif=;;((urge cord) q.r.bol)
       =,  format
       =+  pac=(of-wain (lurk:differ (to-wain (cat 3 txt '\0a')) dif))
       (end 3 (dec (met 3 pac)) pac)
@@ -3009,13 +3009,12 @@
             ::  construct an empty mime cache
             ::
             :_  mim=*(map path mime)
-            %.  q.q.r.u.rot
-            %-  hard
-            $:  ank=*
-                let=@ud
-                hit=(map @ud tako)
-                lab=(map @tas @ud)
-            ==
+            ;;  $:  ank=*
+                    let=@ud
+                    hit=(map @ud tako)
+                    lab=(map @tas @ud)
+                ==
+            q.q.r.u.rot
         ?:  =(0 let.dum)
           (error:he %no-ali-desk ~)
         =+  (~(get by hit.dum) let.dum)
@@ -3643,8 +3642,8 @@
             ?.  ?=($path p.pax)
               [%ergo >[%expected-path got=p.pax]< ~]
             =*  mim  q.i.p.tay
-            =+  mit=?.(?=($mime p.mim) ~ `((hard mime) q.q.mim))
-            $(p.tay t.p.tay, nac :_(nac [((hard path) q.q.pax) mit]))
+            =+  mit=?.(?=($mime p.mim) ~ `;;(mime q.q.mim))
+            $(p.tay t.p.tay, nac :_(nac [;;(path q.q.pax) mit]))
         ?:  ?=({@ *} tan)  (error:he tan)
         =+  `can/(map path (unit mime))`(malt tan)
         ?~  hez
@@ -3780,7 +3779,7 @@
   =/  req=task:able
     ?.  ?=(%soft -.wrapped-task)
       wrapped-task
-    ((hard task:able) p.wrapped-task)
+    ;;(task:able p.wrapped-task)
   ::
   ::  only one of these should be going at once, so queue
   ::
@@ -4034,7 +4033,7 @@
     =*  wer  wer.req
     =*  pax  pax.req
     ?:  ?=({$question *} pax)
-      =+  ryf=((hard riff) res.req)
+      =+  ryf=;;(riff res.req)
       :_  ..^$
       :~  [hen %give %mack ~]
           =/  =wire
@@ -4046,7 +4045,7 @@
     =+  inx=(slav %ud i.t.t.pax)
     =^  mos  ruf
       =/  den  ((de our now ski hen ruf) wer syd)
-      abet:(take-foreign-update:den inx ((hard (unit rand)) res.req))
+      abet:(take-foreign-update:den inx ;;((unit rand) res.req))
     [[[hen %give %mack ~] mos] ..^$]
   ::
       $wegh
@@ -4147,7 +4146,7 @@
     :_  ..^$  :_  ~
     :*  hen  %give  %writ  ~
         ^-  {care case @tas}
-        [i.t.tea ((hard case) +>:(slay i.t.t.tea)) i.t.t.t.tea]
+        [i.t.tea ;;(case +>:(slay i.t.t.tea)) i.t.t.t.tea]
     ::
         `path`t.t.t.t.tea
         `cage`(result-to-cage:ford build-result.result.q.hin)
@@ -4226,7 +4225,7 @@
       ?>  ?=({@ @ @ @ @ *} t.tea)
       =+  her=(slav %p i.t.t.tea)
       =+  syd=(slav %tas i.t.t.t.tea)
-      =+  car=((hard care) i.t.t.t.t.tea)
+      =+  car=;;(care i.t.t.t.t.tea)
       =+  ^-  cas/case
           =+  (slay i.t.t.t.t.t.tea)
           ?>  ?=({~ %$ case} -)

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -414,7 +414,7 @@
             $reap  ?~  p.p.+>.sih
                      +>.$
                    (dump:(crud %reap u.p.p.+>.sih) %logo ~)
-            $diff  pump:(from ((hard dill-blit) q:`vase`+>+>.sih))
+            $diff  pump:(from ;;(dill-blit q:`vase`+>+>.sih))
           ==
         ::
             {$c $note *}
@@ -500,7 +500,7 @@
   =/  task=task:able
     ?.  ?=(%soft -.wrapped-task)
       wrapped-task
-    ((hard task:able) p.wrapped-task)
+    ;;(task:able p.wrapped-task)
   ::  the boot event passes thru %dill for initial duct distribution
   ::
   ?:  ?=(%boot -.task)

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -1063,7 +1063,7 @@
           (fail-turbo 404 message.build-result.result.sih)
         =/  cay=cage  (result-to-cage:ford build-result.result.sih)
         ?:  ?=($red-quri p.cay)
-          =+  url=(apex:en-purl ((hard quri) q.q.cay))
+          =+  url=(apex:en-purl ;;(quri q.q.cay))
           (give-thou 307 [location+(crip url)]~ ~)
           :: (give-html:abet 200 ~ (redir:xml url))
         ?.  ?=($mime p.cay)
@@ -1073,7 +1073,7 @@
           ::
           (exec-turbo-live tee-ses [%cast [p q]:bek %mime [%$ cay]])
         =+  cug=?~(ses ~ cug:(~(got by wup) u.ses))
-        =+  ((hard {mit/mite rez/octs}) q.q.cay)
+        =+  ;;({mit/mite rez/octs} q.q.cay)
         ::  TODO: This used to use dep for etag control.
         ::
         ::  =+  dep=(crip "W/{(en-json %s (scot %uv p.sih))}")
@@ -1089,7 +1089,7 @@
         ?:  =('~' p.tee)
           (eyre-them tee q.cay)
         =+  usr=(slav %ta p.tee)
-        =+  ((hard {pul/purl ^}) q.q.cay)
+        =+  ;;({pul/purl ^} q.q.cay)
         ?.  ?=(%& -.r.p.pul)
           ~&  [%auth-lost usr (head:en-purl p.pul)]
           (eyre-them tee q.cay)
@@ -1479,7 +1479,7 @@
         =*  pef  i.t.q.pok
         =+  but=t.t.q.pok                 ::  XX  =*
         ?+    pef  ~|(pfix-lost+`path`/~/[pef] !!)
-            $debug  ((hard perk) [%bugs but])
+            $debug  ;;(perk [%bugs but])
             $away  [%away ~]
             $ac
           ?~  but  ~|(no-host+`path`/~/[pef] !!)
@@ -1509,7 +1509,7 @@
             $on
           :-  %poll
           ?^  but  [(raid but %uv ~)]~
-          =+  dep=((hard (list {@ ~})) quy)
+          =+  dep=;;((list {@ ~}) quy)
           =<  ?~(. !! .)
           (turn dep |=({a/@tas ~} (slav %uv a)))
         ::
@@ -2328,7 +2328,7 @@
   =/  task=task:able
     ?.  ?=(%soft -.wrapped-task)
       wrapped-task
-    ((hard task:able) p.wrapped-task)
+    ;;(task:able p.wrapped-task)
   ::
   ^+  [*(list move) ..^$]
   ?:  ?=($wegh -.task)

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -2655,7 +2655,7 @@
         (return-result %success %call [type.u.slit-result p.val])
       ::
           %1
-        =/  blocked-paths=(list path)  ((hard (list path)) p.val)
+        =/  blocked-paths=(list path)  ;;((list path) p.val)
         (blocked-paths-to-receipt %call blocked-paths)
       ::
           %2
@@ -4776,7 +4776,7 @@
         (return-result %success %ride [type.u.slim-result p.val])
       ::
           %1
-        =/  blocked-paths=(list path)  ((hard (list path)) p.val)
+        =/  blocked-paths=(list path)  ;;((list path) p.val)
         (blocked-paths-to-receipt %ride blocked-paths)
       ::
           %2
@@ -6144,7 +6144,7 @@
   =/  task=task:able
     ?.  ?=(%soft -.wrapped-task)
       wrapped-task
-    ((hard task:able) p.wrapped-task)
+    ;;(task:able p.wrapped-task)
   ::  we wrap +per-event with a call that binds our event args
   ::
   =*  this-event  (per-event [our duct now scry-gate] state.ax)

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1304,7 +1304,7 @@
   ~%  %gall-call  +>   ~
   |=  {hen/duct hic/(hypo (hobo task:able))}
   ^+  [*(list move) ..^$]
-  =>  .(q.hic ?.(?=($soft -.q.hic) q.hic ((hard task:able) p.q.hic)))
+  =>  .(q.hic ?.(?=($soft -.q.hic) q.hic ;;(task:able p.q.hic)))
   ?-    -.q.hic
       $conf
     ?.  =(our p.p.q.hic)
@@ -1331,10 +1331,10 @@
     =*  dap  i.t.q.q.hic
     =*  him  p.q.hic
     ?:  ?=($ge i.q.q.hic)
-      =+  mes=((hard {@ud rook}) r.q.hic)
+      =+  mes=;;({@ud rook} r.q.hic)
       =<  mo-abet
       (mo-gawk:(mo-abed:mo hen) him dap mes)
-    =+  mes=((hard {@ud roon}) r.q.hic)
+    =+  mes=;;({@ud roon} r.q.hic)
     =<  mo-abet
     (mo-gawd:(mo-abed:mo hen) him dap mes)
   ::

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -1942,7 +1942,7 @@
       ~&  [%yikes cuz]
       +>.$
     ?>  ?=(%httr mar)
-    =+  raw-rep=~|(res ((hard httr:eyre) q.res))
+    =+  raw-rep=~|(res ;;(httr:eyre q.res))
     =+  rep=(httr-to-rpc-response raw-rep)
     ?:  ?=(%fail -.rep)
       ?:  =(405 p.hit.rep)

--- a/sys/vane/xmas.hoon
+++ b/sys/vane/xmas.hoon
@@ -453,23 +453,23 @@
         [~ & (maul clr)]
       ::
           $full
-        =+  mex=((hard {p/{p/life q/life} q/gree r/@}) (cue msg))
+        =+  mex=;;({p/{p/life q/life} q/gree r/@} (cue msg))
         =+  rig=(~(got by wyr) p.p.mex)
         =+  pas=(whom q.p.mex q.mex)
         =+  mes=(need (tear:as:(nol:nu:crub:crypto rig) pas r.mex))
-        =+  [key out]=((hard (pair @ux @ux)) (cue mes))
+        =+  [key out]=;;((pair @ux @ux) (cue mes))
         :-  :~  [%link ~2018.1.1 key]
                 [%meet q.mex]
             ==
         [& (maul out)]
       ::
           $open
-        =+  mex=((hard {p/{$~ q/life} q/gree r/@}) (cue msg))
+        =+  mex=;;({p/{$~ q/life} q/gree r/@} (cue msg))
         =+  pas=(whom q.p.mex q.mex)
         =+  out=(need (sure:as:(com:nu:crub:crypto pas) r.mex))
         [[%meet q.mex]~ & (maul r.mex)]
       ==
-  ++  maul  |=(@ `meal`((hard meal) (cue +<)))          ::  unpack message
+  ++  maul  |=(@ `meal`;;(meal (cue +<)))          ::  unpack message
   ++  whom                                              ::  select public key
     |=  {lyf/life gyr/gree}
     ^-  pass

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -3462,7 +3462,7 @@
       ++  sure                                          ::
         |=  txt=@
         ^-  (unit @ux)
-        =+  ((hard {sig/@ msg/@}) (cue txt))
+        =+  ;;({sig/@ msg/@} (cue txt))
         ?.  (veri:ed sig msg sgn.pub)  ~
         (some msg)
       ::                                                ::  ++seal:as:crub:
@@ -3483,7 +3483,7 @@
         ?>  =('b' (end 3 1 bpk))
         =+  pk=(rsh 8 1 (rsh 3 1 bpk))
         =+  shar=(shax (shar:ed pk cry.u.sek))
-        =+  ((hard {iv/@ len/@ cph/@}) (cue txt))
+        =+  ;;({iv/@ len/@ cph/@} (cue txt))
         =+  try=(~(de siva:aes shar ~) iv len cph)
         ?~  try  ~
         (sure:as:(com:nu:crub bpk) u.try)
@@ -3492,7 +3492,7 @@
     ++  de                                              ::  decrypt
       |=  {key/@J txt/@}
       ^-  (unit @ux)
-      =+  ((hard {iv/@ len/@ cph/@}) (cue txt))
+      =+  ;;({iv/@ len/@ cph/@} (cue txt))
       %^    ~(de sivc:aes (shaz key) ~)
           iv
         len
@@ -6353,7 +6353,7 @@
       |=  {bem/beam ced/noun:cred quy/quer}
       ^-  epic
       =+  qix=|-(`quay`?~(quy quy [[p q]:quy $(quy t.quy)]))
-      [(malt qix) ((hard cred) ced) bem]
+      [(malt qix) ;;(cred ced) bem]
   --  ::eyre
 ::                                                      ::
 ::::                      ++wired                       ::  wire formatting


### PR DESCRIPTION
The previous commit changed the semantics of ;; to just call the mold with the result of the hoon, rather than having it macroexpand to something like hard. By "hard" is meant applying the mold and then checking whether the result is unchanged. This second commit removes the +hard function itself, with the effect that there are no remaining mold "idempotence" tests in the system.

#1055