### PR TITLE
lte: restore lens control plane

### DIFF
--- a/app/aqua-eyre.hoon
+++ b/app/aqua-eyre.hoon
@@ -137,7 +137,7 @@
       ..abet-pe
     =.  http-requests  (~(del in http-requests) num)
     =.  this
-      (emit-aqua-events [%event who [//http/0v1n.2m9vh %they num res]]~)
+      (emit-aqua-events [%event who [//http/0v1n.2m9vh %receive num [%start [p.res q.res] r.res &]]]~)
     ..abet-pe
   ::
   ::  Got error in HTTP response

--- a/app/aqua.hoon
+++ b/app/aqua.hoon
@@ -461,7 +461,7 @@
       %event
     ~?  &(aqua-debug=| !?=(?(%belt %hear) -.q.ue.ae))
       raw-event=[who.ae -.q.ue.ae]
-    ~?  &(debug=& ?=(%they -.q.ue.ae))
+    ~?  &(debug=& ?=(%receive -.q.ue.ae))
       raw-event=[who.ae ue.ae]
     (push-events:(pe who.ae) [ue.ae]~)
   ==

--- a/app/lens.hoon
+++ b/app/lens.hoon
@@ -56,7 +56,6 @@
   =/  request-line  (parse-request-line url.request.inbound-request)
   =/  site  (flop site.request-line)
   ::
-  ~&  lens+inbound-request
   =/  jon=json
     (need (de-json:html q:(need body.request.inbound-request)))
   =/  com=command:lens
@@ -67,7 +66,6 @@
 ++  diff-lens-json
   |=  [=wire jon=json]
   ^-  (quip move _this)
-  ~&  [%diff-lens-json wire jon]
   ?~  jon
     [~ this]
   ?>  ?=(^ job.state)

--- a/app/lens.hoon
+++ b/app/lens.hoon
@@ -1,4 +1,7 @@
+/-  lens
 /+  *server
+/=  lens-mark  /:  /===/mar/lens/command
+                   /!noun/
 =,  format
 |%
 :: +move: output effect
@@ -8,29 +11,25 @@
 ::
 +$  card
   $%  [%connect wire binding:http-server term]
-      [%serve wire binding:http-server generator:http-server]
-      [%disconnect wire binding:http-server]
       [%http-response =http-event:http]
+      [%peel wire dock mark path]
       [%poke wire dock poke]
-      [%diff %json json]
+      [%pull wire dock ~]
   ==
 ::
 +$  poke
-  $%  [%modulo-bind app=term]
-      [%modulo-unbind app=term]
+  $%  [%lens-command command:lens]
   ==
 ::
 +$  state
-  $%  $:  %0   
-          session=(map term @t)
-          order=(list term)
-          cur=(unit [term @])
+  $%  $:  %0
+          job=(unit [=bone com=command:lens])
       ==
   ==
 ::
 --
 ::
-|_  [bow=bowl:gall sta=state]
+|_  [bow=bowl:gall state=state]
 ::
 ++  this  .
 ::
@@ -50,16 +49,56 @@
   %-  (require-authorization:app ost.bow move this)
   |=  =inbound-request:http-server
   ^-  (quip move _this)
+  ?^  job.state
+    :_  this
+    [ost.bow %http-response %start [%500 ~] ~ %.y]~
   ::
   =/  request-line  (parse-request-line url.request.inbound-request)
   =/  site  (flop site.request-line)
   ::
-  =/  htm
-    %-  manx-to-octs
-    ;div: successfully contacted lens
   ~&  lens+inbound-request
+  =/  jon=json
+    (need (de-json:html q:(need body.request.inbound-request)))
+  =/  com=command:lens
+    (json:grab:lens-mark jon)
+  :_  this(job.state (some [ost.bow com]))
+  [ost.bow %peel /sole [our.bow %dojo] %lens-json /sole]~
+::
+++  diff-lens-json
+  |=  [=wire jon=json]
+  ^-  (quip move _this)
+  ~&  [%diff-lens-json wire jon]
+  ?~  jon
+    [~ this]
+  ?>  ?=(^ job.state)
+  :_  this(job.state ~)
+  [bone.u.job.state %http-response (json-response:app (json-to-octs jon))]~
+::
+++  quit
+  |=  =wire
+  ^-  (quip move _this)
+  ~&  [%quit wire]
+  [~ this]
+::
+++  reap
+  |=  [=wire saw=(unit tang)]
+  ^-  (quip move _this)
+  ~&  [%reap wire]
+  ?^  saw
+    [((slog u.saw) ~) this]
+  ?>  ?=(^ job.state)
   :_  this
-  [ost.bow %http-response (html-response:app htm)]~
+  :~  [ost.bow %poke /sole [our.bow %dojo] %lens-command com.u.job.state]
+      [ost.bow %pull /sole [our.bow %dojo] ~]
+  ==
+::
+++  coup
+  |=  [=wire saw=(unit tang)]
+  ^-  (quip move _this)
+  ~&  [%coup wire]
+  ?^  saw
+    [((slog u.saw) ~) this]
+  [~ this]
 ::
 ::  +poke-handle-http-cancel: received when a connection was killed
 ::

--- a/app/lens.hoon
+++ b/app/lens.hoon
@@ -1,0 +1,79 @@
+/+  *server
+=,  format
+|%
+:: +move: output effect
+::
++$  move  [bone card]
+:: +card: output effect payload
+::
++$  card
+  $%  [%connect wire binding:http-server term]
+      [%serve wire binding:http-server generator:http-server]
+      [%disconnect wire binding:http-server]
+      [%http-response =http-event:http]
+      [%poke wire dock poke]
+      [%diff %json json]
+  ==
+::
++$  poke
+  $%  [%modulo-bind app=term]
+      [%modulo-unbind app=term]
+  ==
+::
++$  state
+  $%  $:  %0   
+          session=(map term @t)
+          order=(list term)
+          cur=(unit [term @])
+      ==
+  ==
+::
+--
+::
+|_  [bow=bowl:gall sta=state]
+::
+++  this  .
+::
+++  prep
+  |=  old=(unit *)
+  ^-  (quip move _this)
+  [~ this]
+::
+::  alerts us that we were bound. we need this because the vane calls back.
+::
+++  bound
+  |=  [wir=wire success=? binding=binding:http-server]
+  ^-  (quip move _this)
+  [~ this]
+::
+++  poke-handle-http-request
+  %-  (require-authorization:app ost.bow move this)
+  |=  =inbound-request:http-server
+  ^-  (quip move _this)
+  ::
+  =/  request-line  (parse-request-line url.request.inbound-request)
+  =/  site  (flop site.request-line)
+  ::
+  =/  htm
+    %-  manx-to-octs
+    ;div: successfully contacted lens
+  ~&  lens+inbound-request
+  :_  this
+  [ost.bow %http-response (html-response:app htm)]~
+::
+::  +poke-handle-http-cancel: received when a connection was killed
+::
+++  poke-handle-http-cancel
+  |=  =inbound-request:http-server
+  ^-  (quip move _this)
+  ::  the only long lived connections we keep state about are the stream ones.
+  ::
+  [~ this]
+::
+++  poke-noun
+  |=  a=*
+  ^-  (quip move _this)
+  ~&  poke+a
+  [~ this]
+::
+--

--- a/lib/hood/drum.hoon
+++ b/lib/hood/drum.hoon
@@ -80,6 +80,7 @@
   ::
   ?:  ?=($pawn myr)
   :~  [%base %collections]
+      [%home %lens]
       [%base %hall]
       [%base %talk]
       [%base %dojo]
@@ -87,6 +88,7 @@
       [%base %modulo]
   ==
   :~  [%home %collections]
+      [%home %lens]
       [%home %acme]
       [%home %dns]
       [%home %dojo]

--- a/lib/ph/azimuth.hoon
+++ b/lib/ph/azimuth.hoon
@@ -114,10 +114,10 @@
       :_  ~
       :*  %event
           who.pin
-          //http/0v1n.2m9vh
-          %they
+          //http-client/0v1n.2m9vh
+          %receive
           num.u.thus
-          [200 ~ `(as-octs:mimes:html resp)]
+          [%start [200 ~] `(as-octs:mimes:html resp) &]
       ==
     ::
     ++  logs-to-json

--- a/sys/vane/rver.hoon
+++ b/sys/vane/rver.hoon
@@ -675,6 +675,31 @@
   ::
   |=  [[our=@p eny=@ =duct now=@da scry=sley] state=server-state]
   |%
+  ::  +request-local: bypass authentication for local lens connections
+  ::
+  ++  request-local
+    |=  [secure=? =address =request:http]
+    ^-  [(list move) server-state]
+    ::
+    =/  act  [%app app=%lens]
+    =/  connection=outstanding-connection
+      [act [& secure address request] ~ 0]
+    ::
+    =.  connections.state
+      (~(put by connections.state) duct connection)
+    ::
+    :_  state
+    :_  ~
+    :^  duct  %pass  /run-app/[app.act]
+    ^-  note
+    :^  %g  %deal  [our our]
+    ::
+    ^-  cush:gall
+    :*  app.act
+        %poke
+        %handle-http-request
+        !>(inbound-request.connection)
+    ==
   ::  +request: starts handling an inbound http request
   ::
   ++  request
@@ -1784,7 +1809,13 @@
     ==
   ::
       %request
+    ~&  task
     =^  moves  server-state.ax  (request:server +.task)
+    [moves http-server-gate]
+  ::
+      %request-local
+    ~&  task
+    =^  moves  server-state.ax  (request-local:server +.task)
     [moves http-server-gate]
   ::
       %cancel-request

--- a/sys/vane/rver.hoon
+++ b/sys/vane/rver.hoon
@@ -1809,12 +1809,10 @@
     ==
   ::
       %request
-    ~&  task
     =^  moves  server-state.ax  (request:server +.task)
     [moves http-server-gate]
   ::
       %request-local
-    ~&  task
     =^  moves  server-state.ax  (request-local:server +.task)
     [moves http-server-gate]
   ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -2251,6 +2251,9 @@
           ::  starts handling an inbound http request
           ::
           [%request secure=? =address =request:http]
+          ::  starts handling an backdoor http request
+          ::
+          [%request-local secure=? =address =request:http]
           ::  cancels a previous request
           ::
           [%cancel-request ~]

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7488,16 +7488,52 @@
   ==
 ::
 ++  unix-task                                           ::  input from unix
-  $%  {$belt p/belt:dill}                               ::  dill: keyboard
-      {$blew p/blew:dill}                               ::  dill: configure
-      {$boat ~}                                         ::  clay: reboot
-      {$born ~}                                         ::  eyre: new process
-      [%crud tag=@tas =tang]                            ::  any vane: error report
-      {$hail ~}                                         ::  dill: refresh
-      {$hear p/lane:ames q/@}                           ::  ames: input packet
-      {$hook ~}                                         ::  dill: hangup
-      {$into p/desk q/? r/mode:clay}                    ::  clay: external edit
-      {$wake ~}                                         ::  behn: wakeup
+  $%  ::  %ames: new process
+      ::
+      [%barn ~]
+      ::  %dill: keyboard input
+      ::
+      [%belt p=belt:dill]
+      ::  %dill: configure terminal (resized)
+      ::
+      [%blew p=blew:dill]
+      ::  %clay: new process
+      ::
+      [%boat ~]
+      ::  %behn/%lient/%rver: new process
+      ::
+      [%born ~]
+      %cancel-request
+      ::  any vane: error report
+      ::
+      [%crud tag=@tas =tang]
+      ::  %dill: reset terminal configuration
+      ::
+      [%hail ~]
+      ::  %ames: hear packet
+      ::
+      [%hear p=lane:ames q=@]
+      ::  %clay: external edit
+      ::
+      [%into p=desk q=? r=mode:clay]
+      ::  %rver: learn ports of live http servers
+      ::
+      [%live insecure=@ud secure=(unit @ud)]
+      ::  %lient: hear (partial) http response
+      ::
+      [%receive id=@ud =http-event:http]
+      ::  %rver: starts handling an inbound http request
+      ::
+      [%request secure=? =address:http-server =request:http]
+      ::  %rver: starts handling an backdoor http request
+      ::
+      [%request-local secure=? =address:http-server =request:http]
+      ::  %behn: wakeup
+      ::
+      [%wake ~]
+      ::  %ames: send message
+      ::
+      [%want p=ship q=path r=*]
   ==
 ::                                                      ::
 ::::                      ++azimuth                     ::  (2az) azimuth


### PR DESCRIPTION
This PR is the dual of urbit/urbit#1277. %rver implements the new %request-local task (thanks @ixv!), and there's an incredibly basic, one-request-at-a-time lens app. Just enough to get the CI and pill staging back to a working state (on urbit/urbit).