### PR TITLE
remove ~&pure-mint from mint (prelude to jet decapitation)

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -10133,7 +10133,7 @@
     ~/  %mint
     |=  {gol/type gen/hoon}
     ^-  {p/type q/nock}
-    ~&  %pure-mint
+    ::~&  %pure-mint
     |^  ^-  {p/type q/nock}
     ?:  ?&(=(%void sut) !?=({$dbug *} gen))
       ?.  |(!vet ?=({$lost *} gen) ?=({$zpzp *} gen))


### PR DESCRIPTION
This message printed on each recursion of `mint:ut` radically slows down the hoon code, and must be disabled if the hoon implementation is to take the place of the C.