### PR TITLE
fixes the macro expansion of $> and $< specs

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -8319,7 +8319,7 @@
       ::
           {$bsld *}
         :+  %tsls
-          relative
+          relative:clear(mod q.mod)
         :+  %wtld
           [%wtts [%over ~[&/3] p.mod] ~[&/4]]
         $/2
@@ -8328,7 +8328,7 @@
       ::
           {$bsbn *}
         :+  %tsls
-          relative
+          relative:clear(mod q.mod)
         :+  %wtbn
           [%wtts [%over ~[&/3] p.mod] ~[&/4]]
         $/2


### PR DESCRIPTION
The expansions of `$>` and `$<` were infinitely recursive. These are new specs for building molds from parts of other `$%` molds. They are `?>`-style assertions against the head of the noun being cast or nest-checked. For example:

```
> `task:able:ames`[%west ~zod /foo 1]
[%west p=~zod q=/foo r=1]
>
> `$>(%west task:able:ames)`[%west ~zod /foo 1]
[%west p=~zod q=/foo r=1]
> 
> `$<(%west task:able:ames)`[%west ~zod /foo 1]
nest-fail
```

I think it would be very helpful to use these specs when building the `+note` and `+sign` molds for vanes, which are obviously subtypes of the `+task` and `+gift` types of the other vanes in the system. If there's interest, I'd be happy to do so now.