### PR TITLE
fix higher-order mold parameter-bunts

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -16731,21 +16731,18 @@
         %+  cook
           |=  [b=term c=(list term) e=spec]
           ^-  [term hoon]
-          :*  b
-              :+  %brtr
-                :-  %bscl
-                =-  ?>(?=(^ -) -)
-                %+  turn  c
-                |=  =term
-                ^-  spec
-                :+  %bsts
-                  term
-                [%bshp [%base %noun] [%base %noun]]
-              :-  %ktcl
-              :+  %made
-                [b c]
-              e
-          ==
+          :-  b
+          :+  %brtr
+            :-  %bscl
+            =-  ?>(?=(^ -) -)
+            %+  turn  c
+            |=  =term
+            ^-  spec
+            =/  tar  [%base %noun]
+            :+  %bsts  term
+            :+  %bssg  [%brts tar $/6]
+            [%bshp tar tar]
+          [%ktcl [%made [b c] e]]
         ;~  pfix  (jest '+*')
           ;~  plug
             ;~(pfix gap sym)

--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -321,7 +321,7 @@
   ::  input if it fits or a default value if it doesn't.
   ::
   ::  examples: * @ud ,[p=time q=?(%a %b)]
-  _|~(* +<)
+  $~(* $-(* *))
 ::
 +*  pair  [head tail]
   ::    dual tuple
@@ -16735,13 +16735,14 @@
           :+  %brtr
             :-  %bscl
             =-  ?>(?=(^ -) -)
+            ::  for each .term in .c, produce $=(term $~(* $-(* *)))
+            ::  ie {term}=mold
+            ::
             %+  turn  c
             |=  =term
             ^-  spec
             =/  tar  [%base %noun]
-            :+  %bsts  term
-            :+  %bssg  [%brts tar $/6]
-            [%bshp tar tar]
+            [%bsts term [%bssg tar [%bshp tar tar]]]
           [%ktcl [%made [b c] e]]
         ;~  pfix  (jest '+*')
           ;~  plug


### PR DESCRIPTION
This PR fixes higher-order molds (ie, `+*` specs) in cases where their parameters are bunted. It does so be explicitly defaulting the `$-` to an identity function.

Before:

```
> ((pair) [1 2])
[p=0 q=0]
> ((list) [1 2 3 ~])
~[0 0 0]
> ((tree) (sy 1 2 3 ~))
{0 0 0}
```

After:

```
> ((pair) [1 2])
[p=1 q=2]
> ((list) [1 2 3 ~])
~[1 2 3]
> ((tree) (sy 1 2 3 ~))
{1 2 3}
```