### PR TITLE
deduplicates vane interfaces (+note/+sign)

### DIFF
--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -8,7 +8,56 @@
 ::
 =+  protocol-version=3
 |%
-+=  move  [p=duct q=(wind note:able gift:able)]         ::  local move
++$  move  [p=duct q=(wind note gift:able)]              ::  local move
++$  note                                                ::  out request $->
+  $~  [%b %wait *@da]                                   ::
+  $%  $:  %b                                            ::    to %behn
+          $>  $?  %rest                                 ::  cancel timer
+                  %wait                                 ::  set timer
+              ==                                        ::
+          task:able:behn                                ::
+      ==                                                ::
+      $:  %d                                            ::    to %dill
+          $>(%flog task:able:dill)                      ::  log output
+      ==                                                ::
+      $:  %j                                            ::    to %jael
+          $>  $?  %meet                                 ::  neighbor
+                  %pubs                                 ::  view public keys
+                  %turf                                 ::  view domains
+                  %vein                                 ::  view private keys
+              ==                                        ::
+          task:able:jael                                ::
+      ==                                                ::
+      $:  %g                                            ::    to %gall
+          $>(%deal task:able:gall)                      ::  interact with apps
+      ==                                                ::
+      $:  @tas                                          ::    to any
+          $>(%west task:able)                           ::  deliver message
+  ==  ==                                                ::
++$  sign                                                ::  in result _<-
+  $~  [%b %wake ~]                                      ::
+  $%  $:  %b                                            ::    from %behn
+          $>(%wake gift:able:behn)                      ::  timer activate
+      ==                                                ::
+      $:  %j                                            ::    from %jael
+          $>  $?  %pubs                                 ::  public keys
+                  %turf                                 ::  bind to domains
+                  %vein                                 ::  private keys
+              ==                                        ::
+          gift:able:jael                                ::
+      ==                                                ::
+      $:  %g                                            ::    from %gall
+          $%  [%mean p=ares]                            ::  XX obsolete
+              [%nice ~]                                 ::  XX obsolete
+              $>(%unto gift:able:gall)                  ::  application ack
+      ==  ==                                            ::
+      $:  @tas                                          ::    from any
+          $%  [%crud p=@tas q=(list tank)]              ::  error report
+              $>  $?  %mack                             ::  message ack
+                      %woot                             ::  reaction message
+                  ==                                    ::
+              gift:able                                 ::
+  ==  ==  ==                                            ::
 ::  |pact: internal packet structures
 ::
 ++  pact
@@ -1294,7 +1343,7 @@
     ++  stay  fox
     ++  take                                            ::  accept response
       ~/  %take
-      |=  [tea=wire hen=duct hin=(hypo sign:able)]
+      |=  [tea=wire hen=duct hin=(hypo sign)]
       ^-  [(list move) _..^$]
       =.  any.ton.fox  eny
       =^  duy  ..knap
@@ -1402,7 +1451,7 @@
   ::
   ++  knap
     ~/  %knap
-    |=  [tea=wire hen=duct sih=sign:able]
+    |=  [tea=wire hen=duct sih=sign]
     ^-  [(list move) _+>]
     ::  if we got an error from behn, report it to %dill; TODO handle errors
     ::

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -52,7 +52,7 @@
               $>(%unto gift:able:gall)                  ::  application ack
       ==  ==                                            ::
       $:  @tas                                          ::    from any
-          $%  [%crud p=@tas q=(list tank)]              ::  error report
+          $%  $>(%crud vane-task)                       ::  XX strange
               $>  $?  %mack                             ::  message ack
                       %woot                             ::  reaction message
                   ==                                    ::

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -248,7 +248,7 @@
   =^  moves  state
     ?-  -.task
       %born  born:event-core
-      %crud  (crud:event-core [tag tang]:task)
+      %crud  (crud:event-core [p q]:task)
       %rest  (rest:event-core date=p.task)
       %drip  (drip:event-core move=p.task)
       %vega  vega:event-core

--- a/sys/vane/behn.hoon
+++ b/sys/vane/behn.hoon
@@ -5,8 +5,19 @@
 =,  behn
 |=  pit=vase
 =>  |%
-    +$  move  [p=duct q=(wind note:able gift:able)]
-    +$  sign  [%b %wake error=(unit tang)]
+    +$  move  [p=duct q=(wind note gift:able)]
+    +$  note                                            ::  out request $->
+      $~  [%b %wait *@da]                               ::
+      $%  $:  %b                                        ::   to self
+              $>(%wait task:able)                       ::  set timer
+          ==                                            ::
+          $:  %d                                        ::    to %dill
+              $>(%flog task:able:dill)                  ::  log output
+      ==  ==                                            ::
+    +$  sign
+      $~  [%b %wake ~]
+      $%  [%b $>(%wake gift:able)]
+      ==
     ::
     +$  behn-state
       $:  timers=(list timer)

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -525,8 +525,8 @@
           $>(%made gift:able:ford)                      ::
       ==                                                ::
       $:  @tas                                          ::  by any
-          $%  [%crud p=@tas q=(list tank)]              ::
-  ==  ==  ==                                            ::
+          $>(%crud vane-task)                           ::  XX strange
+  ==  ==                                                ::
 --
 ::
 ::  Old state types for ++load

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -4353,10 +4353,11 @@
     [mos ..^$]
   ::
       %west
-    =*  wer  wer.req
-    =*  pax  pax.req
+    =*  wer  p.req
+    =*  pax  q.req
+    =*  res  r.req
     ?:  ?=({%question *} pax)
-      =+  ryf=;;(riff res.req)
+      =+  ryf=;;(riff res)
       :_  ..^$
       :~  [hen %give %mack ~]
           =/  =wire
@@ -4368,7 +4369,7 @@
     =+  inx=(slav %ud i.t.t.pax)
     =^  mos  ruf
       =/  den  ((de our now ski hen ruf) wer syd)
-      abet:(take-foreign-answer:den inx ;;((unit rand) res.req))
+      abet:(take-foreign-answer:den inx ;;((unit rand) res))
     [[[hen %give %mack ~] mos] ..^$]
   ::
       %wegh

--- a/sys/vane/clay.hoon
+++ b/sys/vane/clay.hoon
@@ -469,57 +469,64 @@
 ::
 ++  move  {p/duct q/(wind note gift:able)}              ::  local move
 ++  note                                                ::  out request $->
-  $%  $:  $a                                            ::  to %ames
-  $%  {$want p/ship q/path r/*}                         ::
+  $~  [%b %wait *@da]                                   ::
+  $%  $:  %a                                            ::  to %ames
+          $>(%want task:able:ames)                      ::
+      ==                                                ::
+      $:  %b                                            ::  to %behn
+          $>  $?  %drip                                 ::
+                  %rest                                 ::
+                  %wait                                 ::
+              ==                                        ::
+          task:able:behn                                ::
+      ==                                                ::
+      $:  %c                                            ::  to %clay
+          $>  $?  %info                                 ::  internal edit
+                  %merg                                 ::  merge desks
+                  %warp                                 ::
+                  %werp                                 ::
+              ==                                        ::
+          task:able                                     ::
+      ==                                                ::
+      $:  %d                                            ::  to %dill
+          $>(%flog task:able:dill)                      ::
+      ==                                                ::
+      $:  %f                                            ::  to %ford
+          $>  $?  %build                                ::
+                  %keep                                 ::
+                  %wipe                                 ::
+              ==                                        ::
+          task:able:ford                                ::
   ==  ==                                                ::
-      $:  $c                                            ::  to %clay
-  $%  {$info q/@tas r/nori}                             ::  internal edit
-      {$merg p/@tas q/@p r/@tas s/case t/germ:clay}     ::  merge desks
-      {$warp p/ship q/riff}                             ::
-      {$werp p/ship q/ship r/riff}                      ::
-  ==  ==                                                ::
-      $:  $d                                            ::  to %dill
-  $%  $:  $flog                                         ::
-          $%  {$crud p/@tas q/(list tank)}              ::
-              {$text p/tape}                            ::
-      ==  ==                                            ::
-  ==  ==                                                ::
-      $:  $f                                            ::
-  $%  [%build live=? schematic=schematic:ford]          ::
-      [%keep compiler-cache=@ud build-cache=@ud]        ::
-      [%wipe percent-to-remove=@ud]                     ::
-  ==  ==                                                ::
-      $:  $b                                            ::
-  $%  {$wait p/@da}                                     ::
-      {$rest p/@da}                                     ::
-      {$drip p/vase}                                    ::
-  ==  ==  ==                                            ::
 ++  riot  (unit rant)                                   ::  response+complete
 ++  sign                                                ::  in result $<-
-          $%  $:  %y
-          $%  {$init-clad ~}
-          ==  ==
-              $:  $a                                    ::  by %ames
-          $%  {$woot p/ship q/coop}                     ::
-              {$send p/lane:ames q/@}                   ::  transmit packet
-          ==  ==                                        ::
-              $:  %b
-          $%  {$writ p/riot}                            ::
-          ==  ==
-              $:  $c                                    ::  by %clay
-          $%  {$note p/@tD q/tank}                      ::
-              {$mere p/(each (set path) (pair term tang))}
-              {$writ p/riot}                            ::
-          ==  ==                                        ::
-              $:  $f                                    ::
-          $%  [%made date=@da result=made-result:ford]  ::
-          ==  ==                                        ::
-              $:  $b                                    ::
-          $%  {$wake error=(unit tang)}                 ::  timer activate
-          ==  ==                                        ::
-              $:  @tas                                  ::  by any
-          $%  {$crud p/@tas q/(list tank)}              ::
-          ==  ==  ==                                    ::
+  $~  [%b %wake ~]                                      ::
+  $%  $:  %y                                            ::
+          $%  [%init-clad ~]                            ::
+      ==  ==                                            ::
+      $:  %a                                            ::  by %ames
+          $>  $?  %send                                 ::  XX strange
+                  %woot                                 ::
+              ==                                        ::
+          gift:able:ames                                ::
+      ==                                                ::
+      $:  %b                                            ::  by %behn
+          $%  $>(%wake gift:able:behn)                  ::  timer activate
+              $>(%writ gift:able)                       ::  XX %slip
+      ==  ==                                            ::
+      $:  %c                                            ::  by %clay
+          $>  $?  %mere                                 ::
+                  %note                                 ::
+                  %writ                                 ::
+              ==                                        ::
+          gift:able                                     ::
+      ==                                                ::
+      $:  %f                                            ::  by %ford
+          $>(%made gift:able:ford)                      ::
+      ==                                                ::
+      $:  @tas                                          ::  by any
+          $%  [%crud p=@tas q=(list tank)]              ::
+  ==  ==  ==                                            ::
 --
 ::
 ::  Old state types for ++load

--- a/sys/vane/dill.hoon
+++ b/sys/vane/dill.hoon
@@ -35,105 +35,97 @@
   $%  {$dill-belt p/(hypo dill-belt)}                   ::
   ==                                                    ::
 ++  move  {p/duct q/(wind note gift:able)}              ::  local move
-++  note-ames                                           ::  weird ames move
-  $%  {$wegh $~}                                        ::
-  ==                                                    ::
-++  note-behn                                           ::
-  $%  {$wegh $~}                                        ::
-  ==                                                    ::
-++  note-clay                                           ::
-  $%  {$merg p/@tas q/@p r/@tas s/case t/germ:clay}     ::  merge desks
-      {$warp p/ship q/riff:clay}                        ::  wait for clay hack
-      {$wegh $~}                                        ::
-      {$perm p/desk q/path r/rite:clay}                 ::  change permissions
-  ==                                                    ::
-++  note-dill                                           ::  note to self, odd
-  $%  {$crud p/@tas q/(list tank)}                      ::
-      {$heft $~}                                        ::
-      {$init p/ship}                                    ::
-      {$lyra p/@t q/@t}                                 ::  upgrade kernel
-      {$text p/tape}                                    ::
-      {$veer p/@ta q/path r/@t}                         ::  install vane
-      {$verb $~}                                        ::  verbose mode
-  ==                                                    ::
-++  note-eyre                                           ::
-  $%  {$wegh $~}                                        ::
-  ==                                                    ::
-++  note-ford                                           ::
-  $%  {$wegh $~}                                        ::
-  ==                                                    ::
-++  note-gall                                           ::
-  $%  {$conf dock $load ship desk}                      ::
-      {$deal p/sock q/cush:gall}                        ::
-      {$wegh $~}                                        ::
-  ==                                                    ::
-++  note-jael                                           ::
-  $%  $:  %dawn                                         ::  boot from keys
-          =seed:able:jael                               ::    identity params
-          spon=ship                                     ::    sponsor
-          czar=(map ship [=life =pass])                 ::    galaxy table
-          turf=(list turf)                              ::    domains
-          bloq=@ud                                      ::    block number
-          node=(unit purl:eyre)                         ::    gateway url
-          snap=(unit snapshot:jael)                     ::    head start
-      ==                                                ::
-      [%fake our=ship]                                  ::  boot fake
-      [%wegh ~]
-  ==                                                    ::
 ++  note                                                ::  out request $->
-  $%  {$a note-ames}                                    ::
-      {$b note-behn}                                    ::
-      {$c note-clay}                                    ::
-      {$d note-dill}                                    ::
-      {$e note-eyre}                                    ::
-      {$f note-ford}                                    ::
-      {$g note-gall}                                    ::
-      {$j note-jael}                                    ::
-  ==                                                    ::
-++  sign-ames                                           ::
-  $%  {$nice $~}                                        ::
-      {$send p/lane:ames q/@}                           ::
-      {$mass p/mass}                                    ::
-  ==                                                    ::
-++  sign-behn                                           ::
-  $%  {$mass p/mass}                                    ::
-      {$writ p/riot:clay}                               ::
-  ==                                                    ::
-++  sign-clay                                           ::
-  $%  {$mere p/(each (set path) (pair term tang))}      ::
-      {$note p/@tD q/tank}                              ::
-      {$writ p/riot:clay}                               ::
-      {$mass p/mass}                                    ::
-      {$mack p/(unit tang)}                             ::
-  ==                                                    ::
-++  sign-dill                                           ::
-  $%  {$blit p/(list blit)}                             ::
-  ==                                                    ::
-++  sign-eyre                                           ::
-  $%  {$mass p/mass}                                    ::
-  ==                                                    ::
-++  sign-ford                                           ::
-  $%  {$mass p/mass}                                    ::
-  ==                                                    ::
-++  sign-gall                                           ::
-  $%  {$onto p/(each suss:gall tang)}                   ::
-      {$unto p/cuft:gall}                               ::
-      {$mass p/mass}                                    ::
-  ==                                                    ::
-++  sign-jael                                           ::
-  $%  [%init p=ship]                                    ::
-      [%mass p=mass]
-  ==                                                    ::
+  $~  [%d %verb ~]                                      ::
+  $%  $:  %a                                            ::
+          $>(%wegh task:able:ames)                      ::
+      ==                                                ::
+      $:  %b                                            ::
+          $>(%wegh task:able:behn)                      ::
+      ==                                                ::
+      $:  %c                                            ::
+          $>  $?  %merg                                 ::  merge desks
+                  %perm                                 ::  change permissions
+                  %warp                                 ::  wait for clay hack
+                  %wegh                                 ::  memory measure
+              ==                                        ::
+          task:able:clay                                ::
+      ==                                                ::
+      $:  %d                                            ::
+          $>  $?  %crud                                 ::
+                  %heft                                 ::
+                  %init                                 ::  XX obsolete?
+                  %lyra                                 ::
+                  %text                                 ::
+                  %veer                                 ::
+                  %verb                                 ::
+              ==                                        ::
+          task:able:dill                                ::
+      ==                                                ::
+      $:  %e                                            ::
+          $>(%wegh task:able:eyre)                      ::
+      ==                                                ::
+      $:  %f                                            ::
+          $>(%wegh task:able:ford)                      ::
+      ==                                                ::
+      $:  %g                                            ::
+          $>  $?  %conf                                 ::
+                  %deal                                 ::
+                  %wegh                                 ::
+              ==                                        ::
+          task:able:gall                                ::
+      ==                                                ::
+      $:  %j                                            ::
+          $>  $?  %dawn                                 ::
+                  %fake                                 ::
+                  %wegh                                 ::
+              ==                                        ::
+          task:able:jael                                ::
+  ==  ==                                                ::
 ++  sign                                                ::  in result $<-
-  $%  {$a sign-ames}                                    ::
-      {$b sign-behn}                                    ::
-      {$c sign-clay}                                    ::
-      {$d sign-dill}                                    ::
-      {$e sign-eyre}                                    ::
-      {$f sign-ford}                                    ::
-      {$g sign-gall}                                    ::
-      {%j sign-jael}                                    ::
-  ==
+  $~  [%j %init *@p]                                    ::
+  $%  $:  %a                                            ::
+          $%  [%nice ~]                                 ::  XX obsolete
+              $>  $?  %mass                             ::
+                      %send                             ::  XX strange
+                  ==                                    ::
+              gift:able:ames                            ::
+      ==  ==                                            ::
+      $:  %b                                            ::
+          $%  $>(%mass gift:able:behn)                  ::
+              $>(%writ gift:able:clay)                  ::  XX %slip
+      ==  ==                                            ::
+      $:  %c                                            ::
+          $>  $?  %mack                                 ::  XX strange
+                  %mass                                 ::
+                  %mere                                 ::
+                  %note                                 ::
+                  %writ                                 ::
+              ==                                        ::
+          gift:able:clay                                ::
+      ==                                                ::
+      $:  %d                                            ::
+          $>(%blit gift:able:dill)                      ::
+      ==                                                ::
+      $:  %e                                            ::
+          $>(%mass gift:able:eyre)                      ::
+      ==                                                ::
+      $:  %f                                            ::
+          $>(%mass gift:able:ford)                      ::
+      ==                                                ::
+      $:  %g                                            ::
+          $>  $?  %mass                                 ::
+                  %onto                                 ::
+                  %unto                                 ::
+              ==                                        ::
+          gift:able:gall                                ::
+      ==                                                ::
+      $:  %j                                            ::
+          $>  $?  %init                                 ::
+                  %mass                                 ::
+              ==                                        ::
+          gift:able:jael                                ::
+  ==  ==                                                ::
 ::::::::                                                ::  dill tiles
 --
 =|  all/axle
@@ -508,7 +500,8 @@
     ?>  ?=(?(%dawn %fake) -.p.task)
     ?>  =(~ hey.all)
     =.  hey.all  `hen
-    =/  boot  ((soft note-jael) p.task)
+    =/  boot
+      ((soft $>($?(%dawn %fake) task:able:jael)) p.task)
     ?~  boot
       ~|  invalid-boot-event+hen  !!
     :_(..^$ [hen %pass / %j u.boot]~)

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -12,53 +12,61 @@
 |%                                                      ::  interfaces
 ++  move  {p/duct q/(wind note gift:able)}              ::  local move
 ++  note                                                ::  out request $->
-          $%  $:  $a                                    ::  to %ames
-          $%  {$want p/ship q/{path *}}                 ::
-          ==  ==                                        ::
-              $:  $b                                    ::  to  %behn
-          $%  {$wait p/@da}                             ::
-              {$rest p/@da}                             ::
-          ==  ==                                        ::
-              $:  $d                                    ::  to %dill
-          $%  {$flog p/{$crud p/@tas q/(list tank)}}    ::
-          ==  ==                                        ::
-              $:  $e                                    ::  to self
-          $%  {$thud ~}                                ::  proxied death
-              {$this p/? q/clip r/httq}                 ::  proxied request
-              {$meta vase}                              ::  type check
-          ==  ==                                        ::
-              $:  $f                                            ::
-          $%  [%build live=? schematic=schematic:ford]
-              [%kill ~]
-          ==  ==
-              $:  $g                                    ::  to %gall
-          $%  {$deal p/sock q/cush:gall}               ::  full transmission
-          ==  ==                                        ::
-              $:  %j                                    ::  to %jael
-          $%  [%turf ~]                                 ::  view domains
-          ==  ==  ==                                    ::
+  $~  [%b %wait *@da]                                   ::
+  $%  $:  %a                                            ::  to %ames
+          $>(%want task:able:ames)                      ::
+      ==                                                ::
+      $:  %b                                            ::  to  %behn
+          $>  $?  %rest                                 ::
+                  %wait                                 ::
+              ==                                        ::
+          task:able:behn                                ::
+      ==                                                ::
+      $:  %d                                            ::  to %dill
+          $>(%flog task:able:dill)                      ::
+      ==                                                ::
+      $:  %e                                            ::  to self
+          $%  [%meta vase]                              ::  type check
+              $>  $?  %this                             ::  proxied request
+                      %thud                             ::  proxied death
+                  ==                                    ::
+              task:able                                 ::
+      ==  ==                                            ::
+      $:  %f                                            ::
+          $>  $?  %build                                ::
+                  %kill                                 ::
+              ==                                        ::
+          task:able:ford                                ::
+      ==                                                ::
+      $:  %g                                            ::  to %gall
+          $>(%deal task:able:gall)                      ::  full transmission
+      ==                                                ::
+      $:  %j                                            ::  to %jael
+          $>(%turf task:able:jael)                      ::  view domains
+  ==  ==                                                ::
 ++  sign                                                ::  in result $<-
-          $%  $:  $a                                    ::  by %ames
-          $%  {$woot p/ship q/coop}                     ::  acknowledgment
-          ==  ==                                        ::
-              $:  $b                                    ::  by %behn
-          $%  {$wake error=(unit tang)}                 ::  timer activate
-          ==  ==                                        ::
-              $:  $g                                    ::  by %gall
-          $%  {$unto p/cuft:gall}                      ::  within agent
-          ==  ==                                        ::
-              $:  $e                                    ::  by self
-          $%  {$thou p/httr}                            ::  response for proxy
-          ==  ==                                        ::
-              $:  $f
-          $%  [%made date=@da result=made-result:ford]  ::
-          ==  ==
-              $:  %j                                    ::  from %jael
-          $%  [%turf turf=(list turf)]                  ::  bind to domains
-          ==  ==                                        ::
-              $:  @tas                                  ::  by any
-          $%  {$crud p/@tas q/(list tank)}              ::
-          ==  ==  ==                                    ::
+  $~  [%b %wake ~]                                      ::
+  $%  $:  %a                                            ::  by %ames
+          $>(%woot gift:able:ames)                      ::  acknowledgment
+      ==                                                ::
+      $:  %b                                            ::  by %behn
+          $>(%wake gift:able:behn)                      ::  timer activate
+      ==                                                ::
+      $:  %g                                            ::  by %gall
+          $>(%unto gift:able:gall)                      ::  within agent
+      ==                                                ::
+      $:  %e                                            ::  by self
+          $>(%thou gift:able)                           ::  response for proxy
+      ==                                                ::
+      $:  %f                                            ::  by %ford
+          $>(%made gift:able:ford)                      ::  build result
+      ==                                                ::
+      $:  %j                                            ::  by %jael
+          $>(%turf gift:able:jael)                      ::  bind to domains
+      ==                                                ::
+      $:  @tas                                          ::  by any
+          $%  [%crud p=@tas q=(list tank)]              ::
+  ==  ==  ==                                            ::
 ++  ixor  @t                                            ::  oryx hash
 ++  whir  $@  ~                                        ::  wire subset
           $%  {$ac p/hole q/whir}                       ::  cookied

--- a/sys/vane/eyre.hoon
+++ b/sys/vane/eyre.hoon
@@ -65,8 +65,8 @@
           $>(%turf gift:able:jael)                      ::  bind to domains
       ==                                                ::
       $:  @tas                                          ::  by any
-          $%  [%crud p=@tas q=(list tank)]              ::
-  ==  ==  ==                                            ::
+          $>(%crud vane-task)                           ::  XX strange
+  ==  ==                                                ::
 ++  ixor  @t                                            ::  oryx hash
 ++  whir  $@  ~                                        ::  wire subset
           $%  {$ac p/hole q/whir}                       ::  cookied

--- a/sys/vane/ford.hoon
+++ b/sys/vane/ford.hoon
@@ -144,45 +144,33 @@
   ==
 ::  +note: private request from ford to another vane
 ::
-+=  note
++$  note
+  $~  [%c %warp *@p *riff:clay]
   $%  ::  %c: to clay
       ::
       $:  %c
           ::  %warp: internal (intra-ship) file request
           ::
-          $%  $:  %warp
-                  ::  ship: target for request
-                  ::
-                  =ship
-                  ::  riff: clay request contents
-                  ::
-                  riff=riff:clay
-  ==  ==  ==  ==
+          $>(%warp task:able:clay)
+  ==  ==
 ::  +sign: private response from another vane to ford
 ::
-+=  sign
++$  sign
+  $~  [%c %writ *riot:clay]
   $?  ::  %c: from clay
       ::
+      ::    XX also from behn due to %slip asynchronicity
+      ::
       $:  ?(%b %c)
-          ::  %writ: internal (intra-ship) file response
-          ::
-          $%  $:  %writ
-                  ::  riot: response contents
+          $>  $?  ::  %writ: internal (intra-ship) file response
                   ::
-                  riot=riot:clay
+                  %writ
+                  ::  %wris: response to %mult; many changed files
+                  ::
+                  %wris
               ==
-              ::  %wris: response to %mult; many changed files
-              ::
-              $:  %wris
-                  ::  case: case of the new files
-                  ::
-                  ::    %wris can only return dates to us.
-                  ::
-                  case=[%da p=@da]
-                  ::  care-paths: the +care:clay and +path of each file
-                  ::
-                  care-paths=(set [care=care:clay =path])
-  ==  ==  ==  ==
+          gift:able:clay
+  ==  ==
 --
 |%
 ::  +axle: overall ford state
@@ -6259,6 +6247,8 @@
       ^-  [(list move) ford-state]
       ::
       ?>  ?=([@tas %wris *] sign)
+      =*  case-sign  p.sign
+      =*  care-paths-sign  q.sign
       =+  [ship desk date]=(raid:wired t.wire ~[%p %tas %da])
       =/  disc  [ship desk]
       ::
@@ -6281,7 +6271,7 @@
       =*  event-args  [[our i.ducts now scry-gate] state.ax]
       =*  rebuild  rebuild:(per-event event-args)
       =^  duct-moves  state.ax
-        (rebuild subscription p.case.sign disc care-paths.sign)
+        (rebuild subscription p.case-sign disc care-paths-sign)
       ::
       $(ducts t.ducts, moves (weld moves duct-moves))
     ::  +take-unblocks: unblock all builds waiting on this scry request
@@ -6290,6 +6280,7 @@
       ^-  [(list move) ford-state]
       ::
       ?>  ?=([@tas %writ *] sign)
+      =*  riot-sign  p.sign
       ::  scry-request: the +scry-request we had previously blocked on
       ::
       =/  =scry-request
@@ -6300,9 +6291,9 @@
       ::    If the result is `~`, the requested resource was not available.
       ::
       =/  scry-result=(unit cage)
-        ?~  riot.sign
+        ?~  riot-sign
           ~
-        `r.u.riot.sign
+        `r.u.riot-sign
       ::
       =/  ducts=(list ^duct)
         ~|  [%ford-take-missing-scry-request scry-request]

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -117,8 +117,8 @@
           $>(%look task)                                ::  set ethereum source
       ==                                                ::
       $:  @tas                                          ::
-  $%  [%init p=ship]                                    ::  report install
-      [%sunk p=ship q=rift]                             ::  report death
+  $%  $>(%init vane-task)                               ::  report install
+      $>(%sunk vane-task)                               ::  report death
   ==  ==  ==                                            ::
 ::                                                      ::
 +$  sign                                                ::  in result $<-

--- a/sys/vane/jael.hoon
+++ b/sys/vane/jael.hoon
@@ -94,10 +94,40 @@
       [%vent-result p=vent-result]                      ::  tmp workaround
   ==                                                    ::
 ++  card                                                ::  i/o action
-  (wind note:able gift)                                 ::
+  (wind note gift)                                      ::
 ::                                                      ::
 ++  move                                                ::  output
   {p/duct q/card}                                       ::
+::                                                      ::
++$  note                                                ::  out request $->
+  $~  [%b %wait *@da]                                   ::
+  $%  $:  %b                                            ::    to %behn
+          $>  $?  %rest                                 ::  cancel timer
+                  %wait                                 ::  set timer
+              ==                                        ::
+          task:able:behn                                ::
+      ==                                                ::
+      $:  %e                                            ::    to %eyre
+          $>(%hiss task:able:eyre)                      ::  http request
+      ==                                                ::
+      $:  %a                                            ::    to %ames
+          $>(%want task:able:ames)                      ::  send message
+      ==                                                ::
+      $:  %j                                            ::    to self
+          $>(%look task)                                ::  set ethereum source
+      ==                                                ::
+      $:  @tas                                          ::
+  $%  [%init p=ship]                                    ::  report install
+      [%sunk p=ship q=rift]                             ::  report death
+  ==  ==  ==                                            ::
+::                                                      ::
++$  sign                                                ::  in result $<-
+  $~  [%b %wake ~]                                      ::
+  $%  [%b $>(%wake gift:able:behn)]                     ::  wakeup
+      [%e $>(%sigh gift:able:eyre)]                     ::  marked http response
+      [%j $>(%vent gift)]                               ::  ethereum changes
+      [%a $>(%woot gift:able:ames)]                     ::  message result
+  ==                                                    ::
 --  ::
 ::                                                      ::::
 ::::                    # light                         ::  light cores
@@ -1125,7 +1155,7 @@
     %+  exec  [d ~ ~]
     :+  %pass
       /(scot %p our)/vent-result
-    ^-  note:able
+    ^-  note
     [%a %want who /j/(scot %p our)/vent-result %vent-result res]
   ::
   ++  extract-snap                                    ::  extract rewind point
@@ -1710,7 +1740,7 @@
   ::  +wrap-note: %pass a note using a made-up duct
   ::
   ++  wrap-note
-    |=  [wir=wire not=note:able]
+    |=  [wir=wire not=note]
     ^-  move
     :-  [/jael/eth-logic ~ ~]
     [%pass (weld /(scot %p our) wir) not]
@@ -2218,7 +2248,7 @@
     %+  exec  [d ~ ~]
     :+  %pass
       /(scot %p our)/vent-result
-    ^-  note:able
+    ^-  note
     [%a %want who /j/(scot %p our)/vent-result %vent-result res]
   ::                                                    ::  ++feed:su
   --

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7033,20 +7033,53 @@
       {$j gift:able:jael}
   ==
 ::
-++  unix-task                                           ::  input from unix
-  $%  {$belt p/belt:dill}                               ::  dill: keyboard
-      {$blew p/blew:dill}                               ::  dill: configure
-      {$boat ~}                                         ::  clay: reboot
-      {$born ~}                                         ::  eyre: new process
-      [%crud tag=@tas =tang]                            ::  any vane: error report
-      {$hail ~}                                         ::  dill: refresh
-      {$hear p/lane:ames q/@}                           ::  ames: input packet
-      {$hook ~}                                         ::  dill: hangup
-      {$into p/desk q/? r/mode:clay}                    ::  clay: external edit
-      {$they p/@ud q/httr:eyre}                         ::  eyre: in response
-      {$this p/? q/clip:eyre r/httq:eyre}               ::  eyre: in request
-      {$thud ~}                                         ::  eyre: in cancel
-      {$wake ~}                                         ::  behn: wakeup
++$  unix-task                                           ::  input from unix
+  $~  [%wake ~]
+  $%  ::  %ames: new process
+      ::
+      $>(%barn task:able:ames)
+      ::  %dill: keyboard input
+      ::
+      $>(%belt task:able:dill)
+      ::  %dill: configure terminal (resized)
+      ::
+      $>(%blew task:able:dill)
+      ::  %clay: new process
+      ::
+      $>(%boat task:able:clay)
+      ::  %behn/%eyre: new process
+      ::
+      [%born ~]
+      ::  any vane: error report
+      ::
+      [%crud tag=@tas =tang]
+      ::  %dill: reset terminal configuration
+      ::
+      $>(%hail task:able:dill)
+      ::  %ames: hear packet
+      ::
+      $>(%hear task:able:ames)
+      ::  %dill: hangup
+      ::
+      $>(%hook task:able:dill)
+      ::  %clay: external edit
+      ::
+      $>(%into task:able:clay)
+      ::  %eyre: learn ports of live http servers
+      ::
+      $>(%live task:able:eyre)
+      ::  %eyre: hear http response
+      ::
+      $>(%they task:able:eyre)
+      ::  %eyre: hear http request
+      ::
+      $>(%this task:able:eyre)
+      ::  %eyre: hear http request cancellation
+      ::
+      $>(%thud task:able:eyre)
+      ::  %behn: wakeup
+      ::
+      $>(%wake task:able:behn)
   ==
 ::                                                      ::
 ::::                      ++azimuth                     ::  (2az) azimuth

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -197,26 +197,6 @@
     ::                                                  ::::
   ++  able  ^?
     |%
-    ++  note                                            ::  out request $->
-      $%  $:  $b                                        ::  to %behn
-      $%  {$rest p/@da}                                 ::  cancel timer
-          {$wait p/@da}                                 ::  set timer
-      ==  ==                                            ::
-          $:  $d                                        ::  to %dill
-      $%  {$flog p/flog:dill}                           ::
-      ==  ==                                            ::
-          $:  %j                                        ::  to %jael
-      $%  [%meet =ship =life =pass]                     ::  neighbor
-          [%pubs =ship]                                 ::  view public keys
-          [%turf ~]                                     ::  view domains
-          [%vein ~]                                     ::  view private keys
-      ==  ==                                            ::
-          $:  $g                                        ::  to %gall
-      $%  {$deal p/sock q/cush:gall}                    ::
-      ==  ==                                            ::
-          $:  @tas                                      ::  to any
-      $%  {$west p/ship q/path r/*}                     ::
-      ==  ==  ==                                        ::
     ++  gift                                            ::  out result <-$
       $%  {$mack p/(unit tang)}                         ::  acknowledgement
           {$mass p/mass}                                ::  memory usage
@@ -224,27 +204,8 @@
           {$turf p/(list turf)}                         ::  bind to domains
           {$woot p/ship q/coop}                         ::  reaction message
       ==                                                ::
-    ++  sign                                            ::  in result _<-
-      $%  $:  $b                                        ::  to %behn
-      $%  {$wake error=(unit tang)}                     ::  timer activate
-      ==  ==                                            ::
-          $:  %j                                        ::  from %jael
-      $%  [%pubs public:able:jael]                      ::  public keys
-          [%turf turf=(list turf)]                      ::  bind to domains
-          [%vein =life vein=(map life ring)]            ::  private keys
-      ==  ==                                            ::
-          $:  $g                                        ::  from %gall
-      $%  {$unto p/cuft:gall}                           ::
-          {$mean p/ares}                                ::  XX old clean up
-          {$nice ~}                                    ::
-      ==  ==                                            ::
-          $:  @tas                                      ::
-      $%  {$crud p/@tas q/(list tank)}                  ::  by any
-          {$mack p/(unit tang)}                         ::  message ack
-          {$woot p/ship q/coop}                         ::  reaction message
-      ==  ==  ==                                        ::
     ++  task                                            ::  in request ->$
-      $%  {$barn ~}                                    ::  new unix process
+      $%  {$barn ~}                                     ::  new unix process
           {$bonk ~}                                     ::  reset the timer
           {$crud p/@tas q/(list tank)}                  ::  error with trace
           {$hear p/lane q/@}                            ::  receive packet

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -187,6 +187,31 @@
         [%transfer-proxy new=address]               ::  ChangedTransferProxy
     ==
   --
+::  +vane-task: general tasks shared across vanes
+::
++$  vane-task
+  $%  ::  i/o device replaced (reset state)
+      ::
+      [%born ~]
+      ::  error report
+      ::
+      [%crud p=@tas q=(list tank)]
+      ::  boot completed (XX legacy)
+      ::
+      [%init p=ship]
+      ::  peer discontinuity
+      ::
+      [%sunk p=ship q=rift]
+      ::  kernel upgraded
+      ::
+      [%vega ~]
+      ::  produce labeled state (for memory measurement)
+      ::
+      [%wegh ~]
+      ::  receive message via %ames
+      ::
+      [%west p=ship q=path r=*]
+  ==
 ::                                                      ::::
 ::::                      ++ames                          ::  (1a) network
   ::                                                    ::::
@@ -205,20 +230,21 @@
           {$woot p/ship q/coop}                         ::  reaction message
       ==                                                ::
     ++  task                                            ::  in request ->$
+      $~  [%vega ~]                                     ::
       $%  {$barn ~}                                     ::  new unix process
           {$bonk ~}                                     ::  reset the timer
-          {$crud p/@tas q/(list tank)}                  ::  error with trace
+          $>(%crud vane-task)                           ::  error with trace
           {$hear p/lane q/@}                            ::  receive packet
           {$halo p/lane q/@ r/ares}                     ::  hole with trace
           {$hole p/lane q/@}                            ::  packet failed
-          [%init p=ship]                                ::  report install
+          $>(%init vane-task)                           ::  report install
           {$kick p/@da}                                 ::  wake up
           {$nuke p/@p}                                  ::  toggle auto-block
-          {$sunk p=ship q=rift}                         ::  report death
-          {$vega ~}                                     ::  report upgrade
+          $>(%sunk vane-task)                           ::  report death
+          $>(%vega vane-task)                           ::  report upgrade
           {$wake ~}                                     ::  timer activate
-          {$wegh ~}                                     ::  report memory
-          {$west p/ship q/path r/*}                     ::  network request
+          $>(%wegh vane-task)                           ::  report memory
+          $>(%west vane-task)                           ::  network request
           {$want p/ship q/path r/*}                     ::  forward message
       ==                                                ::
     --  ::able
@@ -391,14 +417,15 @@
           [%meta p=vase]
       ==
     ++  task                                            ::  in request ->$
-      $%  [%born ~]                                     ::  new unix process
-          [%crud tag=@tas =tang]                        ::  error with trace
+      $~  [%vega ~]                                     ::
+      $%  $>(%born vane-task)                           ::  new unix process
+          $>(%crud vane-task)                           ::  error with trace
           [%rest p=@da]                                 ::  cancel alarm
           [%drip p=vase]                                ::  give in next event
-          [%vega ~]                                     ::  report upgrade
+          $>(%vega vane-task)                           ::  report upgrade
           [%wait p=@da]                                 ::  set alarm
           [%wake ~]                                     ::  timer activate
-          [%wegh ~]                                     ::  report memory
+          $>(%wegh vane-task)                           ::  report memory
       ==
     --  ::able
   --  ::behn
@@ -429,14 +456,15 @@
           {$wris p/{$da p/@da} q/(set (pair care path))}  ::  many changes
       ==                                                ::
     ++  task                                            ::  in request ->$
+      $~  [%vega ~]                                     ::
       $%  {$boat ~}                                     ::  pier rebooted
           {$cred nom/@ta cew/crew}                      ::  set permission group
           {$crew ~}                                     ::  permission groups
           {$crow nom/@ta}                               ::  group usage
-          {$crud p/@tas q/(list tank)}                  ::  error with trace
+          $>(%crud vane-task)                           ::  error with trace
           {$drop des/desk}                              ::  cancel pending merge
           {$info des/desk dit/nori}                     ::  internal edit
-          {$init our/@p}                                ::  report install
+          $>(%init vane-task)                           ::  report install
           {$into des/desk all/? fis/mode}               ::  external edit
           $:  $merg                                     ::  merge desks
               des/desk                                  ::  target
@@ -447,12 +475,12 @@
           {$dirk des/desk}                              ::  mark mount dirty
           {$ogre pot/$@(desk beam)}                     ::  delete mount point
           {$perm des/desk pax/path rit/rite}            ::  change permissions
-          {$sunk p=ship q=rift}                         ::  report death
-          {$vega ~}                                     ::  report upgrade
+          $>(%sunk vane-task)                           ::  report death
+          $>(%vega vane-task)                           ::  report upgrade
           {$warp wer/ship rif/riff}                     ::  internal file req
           {$werp who/ship wer/ship rif/riff}            ::  external file req
-          {$wegh ~}                                     ::  report memory
-          {$west wer/ship pax/path res/*}               ::  network request
+          $>(%wegh vane-task)                           ::  report memory
+          $>(%west vane-task)                           ::  network request
       ==                                                ::
     --  ::able
   ::
@@ -600,24 +628,25 @@
           {$verb ~}                                     ::  verbose mode
       ==                                                ::
     ++  task                                            ::  in request ->$
+      $~  [%vega ~]                                     ::
       $%  {$belt p/belt}                                ::  terminal input
           {$blew p/blew}                                ::  terminal config
           {$boot p/*}                                   ::  weird %dill boot
-          {$crud p/@tas q/(list tank)}                  ::  error with trace
+          $>(%crud vane-task)                           ::  error with trace
           {$flog p/flog}                                ::  wrapped error
           {$flow p/@tas q/(list gill:gall)}             ::  terminal config
           {$hail ~}                                     ::  terminal refresh
           {$heft ~}                                     ::  memory report
           {$hook ~}                                     ::  this term hung up
           {$harm ~}                                     ::  all terms hung up
-          {$init p/ship}                                ::  after gall ready
+          $>(%init vane-task)                           ::  after gall ready
           {$lyra p/@t q/@t}                             ::  upgrade kernel
-          {$noop ~}                                    ::  no operation
-          {$sunk p=ship q=rift}                         ::  report death
+          {$noop ~}                                     ::  no operation
+          $>(%sunk vane-task)                           ::  report death
           {$talk p/tank}                                ::
           {$text p/tape}                                ::
           {$veer p/@ta q/path r/@t}                     ::  install vane
-          {$vega ~}                                     ::  report upgrade
+          $>(%vega vane-task)                           ::  report upgrade
           {$verb ~}                                     ::  verbose mode
       ==                                                ::
     --  ::able
@@ -703,23 +732,24 @@
           [%vega p=@t q=@t]                             ::  drop-through
       ==                                                ::
     +=  task                                            ::  in request ->$
-      $%  [%born p=(list host)]                         ::  new unix process
-          [%crud p=@tas q=(list tank)]                  ::  XX rethink
+      $~  [%vega ~]                                     ::
+      $%  [%born p=(list host)]                         ::  XX vane-task
+          $>(%crud vane-task)                           ::  XX rethink
           [%hiss p=(unit user) q=mark r=cage]           ::  outbound user req
-          [%init p=@p]                                  ::  report install
+          $>(%init vane-task)                           ::  report install
           [%live p=@ud q=(unit @ud)]                    ::  http/s ports
           [%rule p=http-rule]                           ::  update config
           [%serv p=$@(desk beam)]                       ::  set serving root
-          [%sunk p=ship q=rift]                         ::  report death
+          $>(%sunk vane-task)                           ::  report death
           [%them p=(unit hiss)]                         ::  outbound request
           [%they p=@ud q=httr]                          ::  inbound response
           [%chis p=? q=clip r=httq]                     ::  IPC inbound request
           [%this p=? q=clip r=httq]                     ::  inbound request
           [%thud ~]                                     ::  inbound cancel
-          [%vega ~]                                     ::  report upgrade
-          [%wegh ~]                                     ::  report memory
+          $>(%vega vane-task)                           ::  report upgrade
+          $>(%wegh vane-task)                           ::  report memory
           [%well p=path q=(unit mime)]                  ::  put/del .well-known
-          [%west p=ship q=[path *]]                     ::  network request
+          $>(%west vane-task)                           ::  network request
           [%wise p=ship q=prox]                         ::  proxy notification
       ==                                                ::
     --  ::able
@@ -931,6 +961,7 @@
     ::  +task:able:ford: requests to ford
     ::
     +=  task
+      $~  [%vega ~]
       $%  ::  %build: perform a build, either live or once
           ::
           $:  %build
@@ -952,13 +983,13 @@
           [%kill ~]
           ::  %sunk: receive a report that a foreign ship has lost continuity
           ::
-          [%sunk =ship =rift]
+          $>(%sunk vane-task)
           ::  %vega: report kernel upgrade
           ::
-          [%vega ~]
+          $>(%vega vane-task)
           ::  %wegh: produce memory usage information
           ::
-          [%wegh ~]
+          $>(%wegh vane-task)
           ::  %wipe: wipes stored builds
           ::
           [%wipe percent-to-remove=@ud]
@@ -1643,13 +1674,14 @@
           {$mack p/(unit tang)}                         ::  message ack
       ==                                                ::
     ++  task                                            ::  incoming request
+      $~  [%vega ~]                                     ::
       $%  {$conf p/dock q/culm}                         ::  configure app
-          {$init p/ship}                                ::  set owner
+          $>(%init vane-task)                           ::  set owner
           {$deal p/sock q/cush}                         ::  full transmission
-          {$sunk p=ship q/rift}                         ::  report death
-          {$vega ~}                                     ::  report upgrade
-          {$west p/ship q/path r/*}                     ::  network request
-          {$wegh ~}                                     ::  report memory
+          $>(%sunk vane-task)                           ::  report death
+          $>(%vega vane-task)                           ::  report upgrade
+          $>(%west vane-task)                           ::  network request
+          $>(%wegh vane-task)                           ::  report memory
       ==                                                ::
     --  ::able
   ++  bitt  (map bone (pair ship path))                 ::  incoming subs
@@ -1792,6 +1824,7 @@
       action                                            ::  change
     ::
     +=  task                                            ::  in request ->$
+      $~  [%vega ~]                                     ::
       $%  [%burn p=ship q=safe]                         ::  destroy rights
           [%hail p=ship q=remote]                       ::  remote update
           $:  %dawn                                     ::  boot from keys
@@ -1813,13 +1846,13 @@
           [%meet =ship =life =pass]                     ::  met after breach
           [%snap snap=snapshot kick=?]                  ::  load snapshot
           [%turf ~]                                     ::  view domains
-          [%vega ~]                                     ::  report upgrade
+          $>(%vega vane-task)                           ::  report upgrade
           [%vein ~]                                     ::  view signing keys
           [%vent ~]                                     ::  view ethereum events
           [%vest ~]                                     ::  view public balance
           [%vine ~]                                     ::  view secret history
-          [%wegh ~]                                     ::  memory usage request
-          [%west p=ship q=path r=*]                     ::  remote request
+          $>(%wegh vane-task)                           ::  memory usage request
+          $>(%west vane-task)                           ::  remote request
           [%wind p=@ud]                                 ::  rewind before block
       ==                                                ::
     --                                                  ::
@@ -7051,10 +7084,10 @@
       ::
       ::    XX %eyre includes payload
       ::
-      [%born ~]
+      $>(%born vane-task)
       ::  any vane: error report
       ::
-      [%crud tag=@tas =tang]
+      $>(%crud vane-task)
       ::  %dill: reset terminal configuration
       ::
       $>(%hail task:able:dill)

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -1776,26 +1776,6 @@
           [%vent p=vent-result]                         ::  ethereum changes
       ==                                                ::
     ::                                                  ::
-    ++  note                                            ::  out request $->
-      =,  eyre                                          ::
-      $%  $:  %b                                        ::
-      $%  [%rest p=@da]                                 ::  cancel timer
-          [%wait p=@da]                                 ::  wait until
-      ==  ==                                            ::
-          $:  %e                                        ::
-      $%  [%hiss p=(unit user) q=mark r=cage]           ::  outbound user req
-      ==  ==                                            ::
-          $:  %a                                        ::
-      $%  [%want p=ship q=path r=*]                     ::  send message
-      ==  ==                                            ::
-          $:  %j                                        ::
-      $%  [%vent-result p=vent-result]                  ::  tmp workaround
-          [%look src=(each ship purl:eyre)]             ::
-      ==  ==                                            ::
-          $:  @tas                                      ::
-      $%  [%init p=ship]                                ::  report install
-          [%sunk p=ship q=rift]                         ::  report death
-      ==  ==  ==                                        ::
     ++  public                                          ::  public key state
       $:  life=life                                     ::  current key number
           pubs=(map life pass)                          ::  pubkeys by number
@@ -1807,12 +1787,6 @@
     ::
     +$  seed  [who=ship lyf=life key=ring sig=(unit oath:pki)]
     ::
-    ++  sign                                            ::  in result $<-
-      $%  {$b $wake error=(unit tang)}                  ::  wakeup
-          [%e %sigh p=cage]                             ::  marked http response
-          [%j %vent p=vent-result]                      ::  ethereum changes
-          [%a %woot p=ship q=coop]                      ::  message result
-      ==                                                ::
     ++  tally                                           ::  balance update
       %+  each  balance                                 ::  complete
       action                                            ::  change

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -384,13 +384,6 @@
     ::                                                  ::::
   ++  able  ^?
     |%
-    ++  note                                            ::  out request $->
-      $%  $:  %b                                        ::  to %behn
-      $%  [%wait p=@da]
-      ==  ==
-          $:  %d                                        ::  to %dill
-      $%  [%flog =flog:dill]
-      ==  ==  ==
     ++  gift                                            ::  out result <-$
       $%  [%doze p=(unit @da)]                          ::  next alarm
           [%mass p=mass]                                ::  memory usage

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -7049,6 +7049,8 @@
       $>(%boat task:able:clay)
       ::  %behn/%eyre: new process
       ::
+      ::    XX %eyre includes payload
+      ::
       [%born ~]
       ::  any vane: error report
       ::

--- a/tests/sys/vane/jael.hoon
+++ b/tests/sys/vane/jael.hoon
@@ -121,7 +121,7 @@
 ++  jael-take
   |=  $:  jael-gate=_jael-gate
           now=@da
-          take-args=[=wire =duct wrapped-task=(hypo sign:able:jael-gate)]
+          take-args=[=wire =duct wrapped-task=(hypo sign:jael-gate)]
           expected-moves=(list move:jael-gate)
       ==
   ^-  [tang _jael-gate]
@@ -141,7 +141,7 @@
 ++  jael-take-with-comparator
   |=  $:  jael-gate=_jael-gate
           now=@da
-          take-args=[=wire =duct wrapped-task=(hypo sign:able:jael-gate)]
+          take-args=[=wire =duct wrapped-task=(hypo sign:jael-gate)]
           move-comparator=$-((list move:jael-gate) tang)
       ==
   ^-  [tang _jael-gate]


### PR DESCRIPTION
This PR uses `$>` (fixed in #1176) to deduplicate the `+note` (outgoing "request") and `+sign` (incoming "response") interfaces of all the vanes, defining these interfaces in terms of the `+task` (incoming "request") and `+gift` (outgoing "response") interfaces of other vanes wherever possible. 

I've also moved all the `+note`/`+sign` definitions into the vanes themselves  -- some were previously in %zuse, but there's no reason for anything but the vanes (and their tests) to reference these.