### PR TITLE
More useful +diff and +sigh in gall apps

### DIFF
--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -682,12 +682,17 @@
       =+  ^=  arg  ^-  vase
           %-  slop
           ?:  =(0 p.u.cug)
-            [!>(`path`+.pax) !>(cag)]
+            [!>(`path`+.pax) (ap-cage cag)]
           [!>((slag (dec p.u.cug) `path`+.pax)) q.cag]
       =^  cam  +>.$  (ap-call q.u.cug arg)
       ?^  cam
         (ap-pump:(ap-lame q.u.cug u.cam) | her pax)
       (ap-pump & her pax)
+    ::
+    ++  ap-cage                                         ::  cage to tagged vase
+      |=  cag/cage
+      ^-  vase
+      (slop `vase`[[%atom %tas `p.cag] p.cag] q.cag)
     ::
     ++  ap-pump                                         ::  update subscription
       ~/  %ap-pump
@@ -1094,7 +1099,7 @@
       =+  ^=  arg  ^-  vase
           %-  slop
           ?:  =(0 p.u.cug)
-            [!>(`path`pax) !>(cag)]
+            [!>(`path`pax) (ap-cage cag)]
           [!>((slag (dec p.u.cug) `path`pax)) q.cag]
       =^  cam  +>.$  (ap-call q.u.cug arg)
       ?^  cam   (ap-lame q.u.cug u.cam)


### PR DESCRIPTION
Suppose `my-mark` has type `my-type`.

In gall apps, `+diff-my-mark` handles all `%diff` cards with mark `my-mark` and takes an argument of type `[wire my-type]`.

However, `+diff` handles all `%diff` cards not otherwise handled, and takes an argument of type `[wire cage]`.  A `cage` includes `vase`, which is very unhelpful (so it was never used).

This is obviously wrong.  This PR makes it so `+diff` takes an argument of type `[wire %my-mark my-type]`.  This gives us a well-typed value, so we can actually do something with this.

The same applies to `+sigh`, so I changed that too.

The motivation for this is in the `philip/trad` branch, where I would like to be able to handle all subscription results in a single arm because the library that creates this arm doesn't know until compile time what are the possible subscription results (it gets the types via `|*  mold` parameterization).  See https://github.com/urbit/arvo/blob/40c4ea45d22ce02b36033736e580555f6da83aab/lib/tapp.hoon#L149-L159 and the definition of `in-peer-data` https://github.com/urbit/arvo/blob/40c4ea45d22ce02b36033736e580555f6da83aab/lib/tapp.hoon#L3-L8