### PR TITLE
Replace errant nets-need with nest-need in error message.

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -17197,7 +17197,7 @@
       ~&  %nest-failed
       =+  foo=(skol ref)
       =+  bar=(skol sut)
-      ~&  %nets-need
+      ~&  %nest-need
       ~>  %slog.[0 bar]
       ~&  %nest-have
       ~>  %slog.[0 foo]


### PR DESCRIPTION
This one -- presumably a typo, unless I deeply misunderstand something -- has been annoying me for awhile.

(Note, if it's not immediately obvious: this one is in the body of `+nest`, not `+nets`.)