### PR TITLE
fix hoon.hoon nest: make %iron different from %zinc

### DIFF
--- a/sys/hoon.hoon
+++ b/sys/hoon.hoon
@@ -10544,10 +10544,12 @@
       |=  {mel/vair ram/vair}
       ^-  ?
       ?.  |(=(mel ram) =(%lead mel) =(%gold ram))  |
-      ?:  ?=($lead mel)  &
-      ?:  ?=($gold mel)  meet
-      =+  vay=?-(mel $iron %rite, $zinc %read)
-      dext(sut (peek vay 2), ref (peek(sut ref) vay 2))
+      ?-  mel
+        %lead  &
+        %gold  meet
+        %iron  dext(sut (peek(sut ref) %rite 2), ref (peek %rite 2))
+        %zinc  dext(sut (peek %read 2), ref (peek(sut ref) %read 2))
+      ==
     ::
     ++  deep
       |=  $:  dom/(map term tome)
@@ -10593,7 +10595,7 @@
                    ==
         {$core *}  ?.  ?=({$core *} ref)  sint
                    ?:  =(q.sut q.ref)  dext(sut p.sut, ref p.ref)
-                   ?&  =(q.p.q.sut q.p.q.ref)
+                   ?&  =(q.p.q.sut q.p.q.ref)  ::  same wet/dry
                        meet(sut q.q.sut, ref p.sut)
                        dext(sut q.q.ref, ref p.ref)
                        (deem(sut q.q.sut, ref q.q.ref) r.p.q.sut r.p.q.ref)


### PR DESCRIPTION
This commit fixes a jet mismatch in nest:ut. Recall that "iron" cores are meant to be contravariant in their sample, while "zinc" cores are covariant. This behavior is correctly implemented on lines 191-200 and 204-214 of ut_nest.c: the order of arguments passed to dext (and therefore the orientation of the subtyping check) is swapped between these two cases. Unfortunately, the code in hoon.hoon forgets to do this and treats iron cores as though they were zinc.

I would like to say that this closes the matter of the nest jet, but it does not. With this change applied, and nest decapitated, a ship now runs out of memory whenever it recompiles itself. Previously, a nest-decapitated binary would give rise to "type errors" on these operations. Currently, I believe this is a case of one problem covering up another, not an error with the fix below.
