### PR TITLE
ports async/tapp/stdio to lighter-than-eyre

### DIFF
--- a/app/example-tapp-fetch.hoon
+++ b/app/example-tapp-fetch.hoon
@@ -134,9 +134,13 @@
   (pure:m top-comments)
 ::
 ++  handle-take
-  |=  sign:tapp
+  |=  =sign:tapp
   =/  m  tapp-async
   ^-  form:m
+  ::  ignore %poke/peer acknowledgements
+  ::
+  ?.  ?=(%wake -.sign)
+    (pure:m top-comments)
   ;<  =state  bind:m  (handle-poke %noun 'fetch')
   =.  top-comments  state
   (pure:m top-comments)

--- a/gen/tapp-admin/cancel.hoon
+++ b/gen/tapp-admin/cancel.hoon
@@ -1,0 +1,3 @@
+:-  %say
+|=  [[now=@da eny=@uvJ bec=beak] ~ ~]
+[%tapp-admin %cancel]

--- a/gen/tapp-admin/restart.hoon
+++ b/gen/tapp-admin/restart.hoon
@@ -1,0 +1,3 @@
+:-  %say
+|=  [[now=@da eny=@uvJ bec=beak] ~ ~]
+[%tapp-admin %restart]

--- a/lib/stdio.hoon
+++ b/lib/stdio.hoon
@@ -35,8 +35,10 @@
   |=  [add=? =contract]
   =/  m  (async ,~)
   ^-  form:m
-  |=  async-input
-  [~ ~ (silt [add contract]~) %done ~]
+  |=  =async-input
+  =/  delta=contract-delta:async
+    ?.(add [%lose ~] [%gain ost.bowl.async-input])
+  [~ ~ (my [contract delta] ~) %done ~]
 ::
 ::  Send effect on current bone
 ::
@@ -224,7 +226,7 @@
   ?:  ?&  ?=([~ * %wake *] in.async-input)
           =(/(scot %da when) wire.u.in.async-input)
       ==
-    [~ ~ (silt [| %wait when]~) %fail %async-timeout ~]
+    [~ ~ (my [[%wait when] [%lose ~]] ~) %fail %async-timeout ~]
   =/  c-res  (computation async-input)
   ?.  ?=(%cont -.next.c-res)
     c-res

--- a/lib/stdio.hoon
+++ b/lib/stdio.hoon
@@ -165,6 +165,8 @@
 ::
 ::  Identity is immutable
 ::
+::    XX should be statefully cycled
+::
 ++  get-identity
   =/  m  (async ,@p)
   ^-  form:m

--- a/lib/stdio.hoon
+++ b/lib/stdio.hoon
@@ -133,6 +133,24 @@
 ::
 ::    ----
 ::
+::  Identity is immutable
+::
+++  get-identity
+  =/  m  (async ,@p)
+  ^-  form:m
+  |=  =async-input
+  [~ ~ ~ %done our.bowl.async-input]
+::
+::  Entropy is always increasing
+::
+++  get-entropy
+  =/  m  (async ,@uvJ)
+  ^-  form:m
+  |=  =async-input
+  [~ ~ ~ %done eny.bowl.async-input]
+::
+::    ----
+::
 ::  Time is what keeps everything from happening at once
 ::
 ++  get-time

--- a/lib/stdio.hoon
+++ b/lib/stdio.hoon
@@ -238,7 +238,8 @@
   |=  [[her=ship app=term] =poke-data]
   =/  m  (async ,~)
   ^-  form:m
-  (send-effect %poke / [her app] poke-data)
+  =/  =wire  /(scot %p her)/[app]
+  (send-effect %poke wire [her app] poke-data)
 ::
 ++  peer-app
   |=  [[her=ship app=term] =path]

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -389,7 +389,7 @@
   ++  sigh-tang
     |=  [=wire =tang]
     ^-  (quip move _this-tapp)
-    (oob-fail-async %failed-sigh tang)
+    (take-async bowl `[wire %sigh-tang tang])
   ::
   ::  Pass timer to async, or fail
   ::

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -78,10 +78,11 @@
 ::  Default handlers for all comands
 ::
 ++  default-tapp
+  =/  m  tapp-async
   ^-  tapp-core-all
-  |_  [bowl:gall state-type]
+  |_  [=bowl:gall state=state-type]
   ++  handle-init
-    *form:tapp-async
+    (pure:m state)
   ::
   ++  handle-poke
     |=(* (async-fail:async-lib %no-poke-handler ~))
@@ -90,8 +91,9 @@
   ::
   ++  handle-peer
     |=  =path
-    ~|  %default-tapp-no-sole
-    ?<  ?=([%sole *] path)
+    ^-  form:m
+    ?:  ?=([%sole *] path)
+      ~|  %default-tapp-no-sole  !!
     (async-fail:async-lib %no-peer-handler >path< ~)
   ::
   ++  handle-diff
@@ -101,12 +103,13 @@
     =>  |%
         ++  print-if-error
           |=  [msg=tape error=(unit tang)]
-          %.  *form:tapp-async
+          %.  (pure:m state)
           ?~  error
             same
           (slog [leaf+msg u.error])
         --
     |=  =sign
+    ^-  form:m
     ?:  ?=(%coup -.sign)
       (print-if-error "poke failed" error.sign)
     ?:  ?=(%reap -.sign)
@@ -126,8 +129,9 @@
   |=  handler=tapp-core-poke
   %-  create-tapp-poke-peer
   |_  [=bowl:gall state=state-type]
+  ++  handle-peer  ~(handle-peer default-tapp bowl state)
+  ::
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peer  handle-peer:default-tapp
   --
 ::
 ::  The form of a tapp that only handles pokes and peers
@@ -143,12 +147,13 @@
   |=  handler=tapp-core-poke-peer
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
+  ++  handle-init  ~(handle-init default-tapp bowl state)
+  ++  handle-peek  ~(handle-peek default-tapp bowl state)
+  ++  handle-diff  ~(handle-diff default-tapp bowl state)
+  ++  handle-take  ~(handle-take default-tapp bowl state)
+  ::
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
   ++  handle-peer  ~(handle-peer handler bowl state)
-  ++  handle-diff  handle-diff:default-tapp
-  ++  handle-take  handle-take:default-tapp
   --
 ::
 ::  The form of a tapp that only handles pokes and diffs
@@ -164,12 +169,13 @@
   |=  handler=tapp-core-poke-diff
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
+  ++  handle-init  ~(handle-init default-tapp bowl state)
+  ++  handle-peek  ~(handle-peek default-tapp bowl state)
+  ++  handle-peer  ~(handle-peer default-tapp bowl state)
+  ++  handle-take  ~(handle-take default-tapp bowl state)
+  ::
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
-  ++  handle-peer  handle-peer:default-tapp
   ++  handle-diff  ~(handle-diff handler bowl state)
-  ++  handle-take  handle-take:default-tapp
   --
 ::
 ::  The form of a tapp that only handles pokes, peers, and takes
@@ -186,11 +192,12 @@
   |=  handler=tapp-core-poke-peer-take
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
+  ++  handle-init  ~(handle-init default-tapp bowl state)
+  ++  handle-peek  ~(handle-peek default-tapp bowl state)
+  ++  handle-diff  ~(handle-diff default-tapp bowl state)
+  ::
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
   ++  handle-peer  ~(handle-peer handler bowl state)
-  ++  handle-diff  handle-diff:default-tapp
   ++  handle-take  ~(handle-take handler bowl state)
   --
 ::
@@ -209,9 +216,10 @@
   |=  handler=tapp-core-poke-peer-diff-take
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
+  ++  handle-init  ~(handle-init default-tapp bowl state)
+  ++  handle-peek  ~(handle-peek default-tapp bowl state)
+  ::
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
   ++  handle-peer  ~(handle-peer handler bowl state)
   ++  handle-diff  ~(handle-diff handler bowl state)
   ++  handle-take  ~(handle-take handler bowl state)

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -379,17 +379,10 @@
   ::
   ::  Pass response to async
   ::
-  ++  sigh-httr
-    |=  [=wire =httr:eyre]
+  ++  http-response
+    |=  [=wire response=client-response:http-client]
     ^-  (quip move _this-tapp)
-    (take-async bowl `[wire %sigh httr])
-  ::
-  ::  Failed http request
-  ::
-  ++  sigh-tang
-    |=  [=wire =tang]
-    ^-  (quip move _this-tapp)
-    (take-async bowl `[wire %sigh-tang tang])
+    (take-async bowl `[wire %http-response response])
   ::
   ::  Pass timer to async, or fail
   ::
@@ -417,11 +410,6 @@
     ^-  (quip move _this-tapp)
     =/  m  tapp-async
     ?~  active
-      ::  Can't cancel HTTP requests, so we might get answers after end
-      ::  of computation
-      ::
-      ?:  ?=([~ @ %sigh *] in.async-input)
-        `this-tapp
       ~|  %no-active-async
       ~|  ?~  in.async-input
             ~
@@ -522,8 +510,8 @@
     |=  [=contract =bone]
     ^-  (list move)
     ?-  -.contract
-      %wait  [bone %rest /note/(scot %da at.contract) at.contract]~
-      %hiss  ~  ::  can't cancel; will ignore response
+      %wait     [bone %rest /note/(scot %da at.contract) at.contract]~
+      %request  [bone %cancel-request / ~]~
     ==
   --
 --

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -12,7 +12,13 @@
 ++  card  card:tapp-sur
 ++  sign  sign:tapp-sur
 ++  contract  contract:tapp-sur
-++  command
++$  tapp-admin-in-poke-data
+  [%tapp-admin tapp-admin=?(%cancel %restart)]
++$  tapp-in-poke-data
+  $%  tapp-admin-in-poke-data
+      in-poke-data
+  ==
++$  command
   $%  [%init ~]
       [%poke =in-poke-data]
       [%peer =path]
@@ -264,9 +270,22 @@
   ::  Start a command
   ::
   ++  poke
-    |=  =in-poke-data
+    |=  =tapp-in-poke-data
     ^-  (quip move _this-tapp)
-    =.  waiting  (~(put to waiting) %poke in-poke-data)
+    ?:  ?=(tapp-admin-in-poke-data tapp-in-poke-data)
+      ?~  active
+        ~&  [%tapp-admin-idle dap.bowl]
+        `this-tapp
+      ?-  tapp-admin.tapp-in-poke-data
+          %cancel
+        (oob-fail-async %tapp-admin-cancel ~)
+      ::
+          %restart
+        =.  waiting  (~(put to waiting) (need ~(top to waiting)))
+        (oob-fail-async %tapp-admin-restart ~)
+      ==
+    ::
+    =.  waiting  (~(put to waiting) %poke tapp-in-poke-data)
     ?^  active
       ~&  [%waiting-until-current-async-finishes waiting]
       `this-tapp
@@ -436,9 +455,8 @@
     |=  [contracts=(set contract) err=(pair term tang)]
     ^-  (quip move _this-tapp)
     %-  %-  slog
-        :*  leaf+(trip dap.bowl)
-            leaf+"tapp command failed"
-            leaf+(trip p.err)
+        :*  leaf+(weld "tapp command failed in app/" (trip dap.bowl))
+            leaf+(weld "  %" (trip p.err))
             q.err
         ==
     (finish-async contracts)

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -33,169 +33,9 @@
 +$  tapp-peek
   [%noun ?(? (set contract))]
 ::
-::  Default handlers for all comands
-::
-++  default-tapp
-  ^-  tapp-core-all
-  |_  [bowl:gall state-type]
-  ++  handle-init
-    *form:tapp-async
-  ::
-  ++  handle-poke
-    |=(* (async-fail:async-lib %no-poke-handler ~))
-  ::
-  ++  handle-peek  _~
-  ::
-  ++  handle-peer
-    |=  =path
-    ~|  %default-tapp-no-sole
-    ?<  ?=([%sole *] path)
-    (async-fail:async-lib %no-peer-handler >path< ~)
-  ::
-  ++  handle-diff
-    |=(* (async-fail:async-lib %no-diff-handler ~))
-  ::
-  ++  handle-take
-    |=(* (async-fail:async-lib %no-take-handler ~))
-  --
-::
-::  The form of a tapp that only handles pokes
-::
-++  tapp-core-poke
-  $_  ^|
-  |_  [bowl:gall state-type]
-  ++  handle-poke
-    |~  in-poke-data
-    *form:tapp-async
-  --
-::
-++  create-tapp-poke
-  |=  handler=tapp-core-poke
-  %-  create-tapp-poke-peer
-  |_  [=bowl:gall state=state-type]
-  ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peer  handle-peer:default-tapp
-  --
-::
-::  The form of a tapp that only handles pokes and peers
-::
-++  tapp-core-poke-peer
-  $_  ^|
-  |_  [bowl:gall state-type]
-  ++  handle-poke
-    |~  in-poke-data
-    *form:tapp-async
-  ::
-  ++  handle-peer
-    |~  path
-    *form:tapp-async
-  --
-::
-++  create-tapp-poke-peer
-  |=  handler=tapp-core-poke-peer
-  %-  create-tapp-all
-  |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
-  ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
-  ++  handle-peer  ~(handle-peer handler bowl state)
-  ++  handle-diff  handle-diff:default-tapp
-  ++  handle-take  handle-take:default-tapp
-  --
-::
-::  The form of a tapp that only handles pokes and diffs
-::
-++  tapp-core-poke-diff
-  $_  ^|
-  |_  [bowl:gall state-type]
-  ++  handle-poke
-    |~  in-poke-data
-    *form:tapp-async
-  ::
-  ++  handle-diff
-    |~  [dock path in-peer-data]
-    *form:tapp-async
-  --
-::
-++  create-tapp-poke-diff
-  |=  handler=tapp-core-poke-diff
-  %-  create-tapp-all
-  |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
-  ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
-  ++  handle-peer  handle-peer:default-tapp
-  ++  handle-diff  ~(handle-diff handler bowl state)
-  ++  handle-take  handle-take:default-tapp
-  --
-::
-::  The form of a tapp that only handles pokes, peers, and takes
-::
-++  tapp-core-poke-peer-take
-  $_  ^|
-  |_  [bowl:gall state-type]
-  ++  handle-poke
-    |~  in-poke-data
-    *form:tapp-async
-  ::
-  ++  handle-peer
-    |~  path
-    *form:tapp-async
-  ::
-  ++  handle-take
-    |~  sign
-    *form:tapp-async
-  --
-::
-++  create-tapp-poke-peer-take
-  |=  handler=tapp-core-poke-peer-take
-  %-  create-tapp-all
-  |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
-  ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
-  ++  handle-peer  ~(handle-peer handler bowl state)
-  ++  handle-diff  handle-diff:default-tapp
-  ++  handle-take  ~(handle-take handler bowl state)
-  --
-::
-::  The form of a tapp that only handles pokes, peers, diffs, and takes
-::
-++  tapp-core-poke-peer-diff-take
-  $_  ^|
-  |_  [bowl:gall state-type]
-  ++  handle-poke
-    |~  in-poke-data
-    *form:tapp-async
-  ::
-  ++  handle-peer
-    |~  path
-    *form:tapp-async
-  ::
-  ++  handle-diff
-    |~  [dock path in-peer-data]
-    *form:tapp-async
-  ::
-  ++  handle-take
-    |~  sign
-    *form:tapp-async
-  --
-::
-++  create-tapp-poke-peer-diff-take
-  |=  handler=tapp-core-poke-peer-diff-take
-  %-  create-tapp-all
-  |_  [=bowl:gall state=state-type]
-  ++  handle-init  handle-init:default-tapp
-  ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  handle-peek:default-tapp
-  ++  handle-peer  ~(handle-peer handler bowl state)
-  ++  handle-diff  ~(handle-diff handler bowl state)
-  ++  handle-take  ~(handle-take handler bowl state)
-  --
-::
 ::  The form of a tapp
 ::
-++  tapp-core-all
++$  tapp-core-all
   $_  ^|
   |_  [bowl:gall state-type]
   ::
@@ -233,6 +73,135 @@
   ++  handle-take
     |~  sign
     *form:tapp-async
+  --
+::
+::  Default handlers for all comands
+::
+++  default-tapp
+  ^-  tapp-core-all
+  |_  [bowl:gall state-type]
+  ++  handle-init
+    *form:tapp-async
+  ::
+  ++  handle-poke
+    |=(* (async-fail:async-lib %no-poke-handler ~))
+  ::
+  ++  handle-peek  _~
+  ::
+  ++  handle-peer
+    |=  =path
+    ~|  %default-tapp-no-sole
+    ?<  ?=([%sole *] path)
+    (async-fail:async-lib %no-peer-handler >path< ~)
+  ::
+  ++  handle-diff
+    |=(* (async-fail:async-lib %no-diff-handler ~))
+  ::
+  ++  handle-take
+    |=(* (async-fail:async-lib %no-take-handler ~))
+  --
+::
+::  The form of a tapp that only handles pokes
+::
+++  tapp-core-poke
+  $_  ^|
+  |_  [bowl:gall state-type]
+  ++  handle-poke  handle-poke:*tapp-core-all
+  --
+::
+++  create-tapp-poke
+  |=  handler=tapp-core-poke
+  %-  create-tapp-poke-peer
+  |_  [=bowl:gall state=state-type]
+  ++  handle-poke  ~(handle-poke handler bowl state)
+  ++  handle-peer  handle-peer:default-tapp
+  --
+::
+::  The form of a tapp that only handles pokes and peers
+::
+++  tapp-core-poke-peer
+  $_  ^|
+  |_  [bowl:gall state-type]
+  ++  handle-poke  handle-poke:*tapp-core-all
+  ++  handle-peer  handle-peer:*tapp-core-all
+  --
+::
+++  create-tapp-poke-peer
+  |=  handler=tapp-core-poke-peer
+  %-  create-tapp-all
+  |_  [=bowl:gall state=state-type]
+  ++  handle-init  handle-init:default-tapp
+  ++  handle-poke  ~(handle-poke handler bowl state)
+  ++  handle-peek  handle-peek:default-tapp
+  ++  handle-peer  ~(handle-peer handler bowl state)
+  ++  handle-diff  handle-diff:default-tapp
+  ++  handle-take  handle-take:default-tapp
+  --
+::
+::  The form of a tapp that only handles pokes and diffs
+::
+++  tapp-core-poke-diff
+  $_  ^|
+  |_  [bowl:gall state-type]
+  ++  handle-poke  handle-poke:*tapp-core-all
+  ++  handle-diff  handle-diff:*tapp-core-all
+  --
+::
+++  create-tapp-poke-diff
+  |=  handler=tapp-core-poke-diff
+  %-  create-tapp-all
+  |_  [=bowl:gall state=state-type]
+  ++  handle-init  handle-init:default-tapp
+  ++  handle-poke  ~(handle-poke handler bowl state)
+  ++  handle-peek  handle-peek:default-tapp
+  ++  handle-peer  handle-peer:default-tapp
+  ++  handle-diff  ~(handle-diff handler bowl state)
+  ++  handle-take  handle-take:default-tapp
+  --
+::
+::  The form of a tapp that only handles pokes, peers, and takes
+::
+++  tapp-core-poke-peer-take
+  $_  ^|
+  |_  [bowl:gall state-type]
+  ++  handle-poke  handle-poke:*tapp-core-all
+  ++  handle-peer  handle-peer:*tapp-core-all
+  ++  handle-take  handle-take:*tapp-core-all
+  --
+::
+++  create-tapp-poke-peer-take
+  |=  handler=tapp-core-poke-peer-take
+  %-  create-tapp-all
+  |_  [=bowl:gall state=state-type]
+  ++  handle-init  handle-init:default-tapp
+  ++  handle-poke  ~(handle-poke handler bowl state)
+  ++  handle-peek  handle-peek:default-tapp
+  ++  handle-peer  ~(handle-peer handler bowl state)
+  ++  handle-diff  handle-diff:default-tapp
+  ++  handle-take  ~(handle-take handler bowl state)
+  --
+::
+::  The form of a tapp that only handles pokes, peers, diffs, and takes
+::
+++  tapp-core-poke-peer-diff-take
+  $_  ^|
+  |_  [bowl:gall state-type]
+  ++  handle-poke  handle-poke:*tapp-core-all
+  ++  handle-peer  handle-peer:*tapp-core-all
+  ++  handle-diff  handle-diff:*tapp-core-all
+  ++  handle-take  handle-take:*tapp-core-all
+  --
+::
+++  create-tapp-poke-peer-diff-take
+  |=  handler=tapp-core-poke-peer-diff-take
+  %-  create-tapp-all
+  |_  [=bowl:gall state=state-type]
+  ++  handle-init  handle-init:default-tapp
+  ++  handle-poke  ~(handle-poke handler bowl state)
+  ++  handle-peek  handle-peek:default-tapp
+  ++  handle-peer  ~(handle-peer handler bowl state)
+  ++  handle-diff  ~(handle-diff handler bowl state)
+  ++  handle-take  ~(handle-take handler bowl state)
   --
 ::
 ++  create-tapp-all

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -319,7 +319,7 @@
       [~ ~ %noun ?=(^ active)]
     ::
         [%x %tapp %contracts ~]
-      [~ ~ %noun ?~(active ~ contracts.u.active)]
+      [~ ~ %noun ?~(active ~ ~(key by contracts.u.active))]
     ::
         *
       (~(handle-peek handler bowl app-state) path)
@@ -452,7 +452,7 @@
   ::  Called on async failure
   ::
   ++  fail-async
-    |=  [contracts=(set contract) err=(pair term tang)]
+    |=  [contracts=(map contract bone) err=(pair term tang)]
     ^-  (quip move _this-tapp)
     %-  %-  slog
         :*  leaf+(weld "tapp command failed in app/" (trip dap.bowl))
@@ -464,7 +464,7 @@
   ::  Called on async success
   ::
   ++  done-async
-    |=  [contracts=(set contract) state=state-type]
+    |=  [contracts=(map contract bone) state=state-type]
     ^-  (quip move _this-tapp)
     =.  app-state  state
     (finish-async contracts)
@@ -472,7 +472,7 @@
   ::  Called whether async failed or succeeded
   ::
   ++  finish-async
-    |=  contracts=(set contract)
+    |=  contracts=(map contract bone)
     ^-  (quip move _this-tapp)
     =^  moves-1  this-tapp  (cancel-contracts contracts)
     =.  active   ~
@@ -512,17 +512,17 @@
   ::  Cancel outstanding contracts
   ::
   ++  cancel-contracts
-    |=  contracts=(set contract)
+    |=  contracts=(map contract bone)
     ^-  (quip move this-tapp)
-    [(zing (turn ~(tap in contracts) cancel-contract)) this-tapp]
+    [(zing (turn ~(tap by contracts) cancel-contract)) this-tapp]
   ::
   ::  Cancel individual contract
   ::
   ++  cancel-contract
-    |=  =contract
+    |=  [=contract =bone]
     ^-  (list move)
     ?-  -.contract
-      %wait  [ost.bowl %rest /note/(scot %da at.contract) at.contract]~
+      %wait  [bone %rest /note/(scot %da at.contract) at.contract]~
       %hiss  ~  ::  can't cancel; will ignore response
     ==
   --

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -33,6 +33,32 @@
 +$  tapp-peek
   [%noun ?(? (set contract))]
 ::
+::  Default handlers for all comands
+::
+++  default-tapp
+  ^-  tapp-core-all
+  |_  [bowl:gall state-type]
+  ++  handle-init
+    *form:tapp-async
+  ::
+  ++  handle-poke
+    |=(* (async-fail:async-lib %no-poke-handler ~))
+  ::
+  ++  handle-peek  _~
+  ::
+  ++  handle-peer
+    |=  =path
+    ~|  %default-tapp-no-sole
+    ?<  ?=([%sole *] path)
+    (async-fail:async-lib %no-peer-handler >path< ~)
+  ::
+  ++  handle-diff
+    |=(* (async-fail:async-lib %no-diff-handler ~))
+  ::
+  ++  handle-take
+    |=(* (async-fail:async-lib %no-take-handler ~))
+  --
+::
 ::  The form of a tapp that only handles pokes
 ::
 ++  tapp-core-poke
@@ -48,11 +74,7 @@
   %-  create-tapp-poke-peer
   |_  [=bowl:gall state=state-type]
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peer
-    |=  *
-    ~|  %default-tapp-no-sole
-    ?<  ?=([%sole *] +<)
-    (async-fail:async-lib %no-peer-handler >path< ~)
+  ++  handle-peer  handle-peer:default-tapp
   --
 ::
 ::  The form of a tapp that only handles pokes and peers
@@ -73,12 +95,12 @@
   |=  handler=tapp-core-poke-peer
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  *form:tapp-async
+  ++  handle-init  handle-init:default-tapp
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  _~
+  ++  handle-peek  handle-peek:default-tapp
   ++  handle-peer  ~(handle-peer handler bowl state)
-  ++  handle-diff  |=(* (async-fail:async-lib %no-diff-handler >path< ~))
-  ++  handle-take  |=(* (async-fail:async-lib %no-take-handler >path< ~))
+  ++  handle-diff  handle-diff:default-tapp
+  ++  handle-take  handle-take:default-tapp
   --
 ::
 ::  The form of a tapp that only handles pokes and diffs
@@ -99,12 +121,12 @@
   |=  handler=tapp-core-poke-diff
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  *form:tapp-async
+  ++  handle-init  handle-init:default-tapp
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  _~
-  ++  handle-peer  |=(* (async-fail:async-lib %no-peer-handler >path< ~))
+  ++  handle-peek  handle-peek:default-tapp
+  ++  handle-peer  handle-peer:default-tapp
   ++  handle-diff  ~(handle-diff handler bowl state)
-  ++  handle-take  |=(* (async-fail:async-lib %no-take-handler >path< ~))
+  ++  handle-take  handle-take:default-tapp
   --
 ::
 ::  The form of a tapp that only handles pokes, peers, and takes
@@ -129,11 +151,11 @@
   |=  handler=tapp-core-poke-peer-take
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  *form:tapp-async
+  ++  handle-init  handle-init:default-tapp
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  _~
+  ++  handle-peek  handle-peek:default-tapp
   ++  handle-peer  ~(handle-peer handler bowl state)
-  ++  handle-diff  |=(* (async-fail:async-lib %no-diff-handler >path< ~))
+  ++  handle-diff  handle-diff:default-tapp
   ++  handle-take  ~(handle-take handler bowl state)
   --
 ::
@@ -163,9 +185,9 @@
   |=  handler=tapp-core-poke-peer-diff-take
   %-  create-tapp-all
   |_  [=bowl:gall state=state-type]
-  ++  handle-init  *form:tapp-async
+  ++  handle-init  handle-init:default-tapp
   ++  handle-poke  ~(handle-poke handler bowl state)
-  ++  handle-peek  _~
+  ++  handle-peek  handle-peek:default-tapp
   ++  handle-peer  ~(handle-peer handler bowl state)
   ++  handle-diff  ~(handle-diff handler bowl state)
   ++  handle-take  ~(handle-take handler bowl state)

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -409,7 +409,13 @@
           wire.u.in.async-input
       !!
     =^  r=[moves=(list move) =eval-result:eval:m]  u.active
-      (take:eval:m u.active ost.bowl async-input)
+      =/  out
+        %-  mule  |.
+        (take:eval:m u.active ost.bowl async-input)
+      ?-  -.out
+        %&  p.out
+        %|  [[~ [%fail contracts.u.active %crash p.out]] u.active]
+      ==
     =>  .(active `(unit eval-form:eval:tapp-async)`active)  :: TMI
     =^  moves=(list move)  this-tapp
       ?-  -.eval-result.r
@@ -469,12 +475,19 @@
       :-  ~
       %-  from-form:eval:tapp-async
       ^-  form:tapp-async
-      ?-  -.u.next
-        %init  ~(handle-init handler bowl app-state)
-        %poke  (~(handle-poke handler bowl app-state) +.u.next)
-        %peer  (~(handle-peer handler bowl app-state) +.u.next)
-        %diff  (~(handle-diff handler bowl app-state) +.u.next)
-        %take  (~(handle-take handler bowl app-state) +.u.next)
+      =/  out
+        %-  mule  |.
+        ?-  -.u.next
+          %init  ~(handle-init handler bowl app-state)
+          %poke  (~(handle-poke handler bowl app-state) +.u.next)
+          %peer  (~(handle-peer handler bowl app-state) +.u.next)
+          %diff  (~(handle-diff handler bowl app-state) +.u.next)
+          %take  (~(handle-take handler bowl app-state) +.u.next)
+        ==
+      ?-  -.out
+        %&  p.out
+        %|  |=  async-input:async-lib
+            [~ ~ ~ %fail %crash p.out]
       ==
     (take-async bowl ~)
   ::

--- a/lib/tapp.hoon
+++ b/lib/tapp.hoon
@@ -25,13 +25,9 @@
 ::
 +$  move  (pair bone card)
 ++  tapp-async  (async state-type)
-+$  tapp-internal-state
-  $:  %0
-      waiting=(qeu command)
-      active=(unit eval-form:eval:tapp-async)
-  ==
 +$  tapp-state
-  $:  tapp-internal-state
+  $:  waiting=(qeu command)
+      active=(unit eval-form:eval:tapp-async)
       app-state=state-type
   ==
 +$  tapp-peek
@@ -240,32 +236,30 @@
   ::    Otherwise, upgrade, cancel and restart if active.
   ::
   ++  prep
-    |=  $=  old-state
-        %-  unit
-        $:  =tapp-internal-state
-            app-state=*
-        ==
+    |=  old-state=(unit)
     ^-  (quip move _this-tapp)
     ?~  old-state
       ~&  [%tapp-init dap.bowl]
       =.  waiting  (~(put to waiting) %init ~)
       start-async
     ::
-    =*  internal  tapp-internal-state.u.old-state
-    =/  old-app   ((soft state-type) app-state.u.old-state)
-    ?~  old-app
+    =/  old   ((soft tapp-state) u.old-state)
+    ?~  old
       ~&  [%tapp-reset dap.bowl]
-      =.  +<+.this-tapp  [internal *state-type]
-      ?^  active.internal
-        (oob-fail-async %reset ~)
-      [~ this-tapp]
+      ::  XX may break contracts!
+      ::  XX if active clam contracts only to abort transaction?
+      ::
+      `this-tapp
+    ::
+    ::  because the clam replaces the active continuation with
+    ::  the bunt of its mold, we must fail the transaction
     ::
     ~&  [%tapp-loaded dap.bowl]
-    =.  +<+.this-tapp  [internal u.old-app]
-    ?^  active.internal
+    =.  +<+.this-tapp  u.old
+    ?^  active
       =.  waiting  (~(put to waiting) (need ~(top to waiting)))
       (oob-fail-async %reset-restart ~)
-    [~ this-tapp]
+    `this-tapp
   ::
   ::  Start a command
   ::

--- a/sur/tapp.hoon
+++ b/sur/tapp.hoon
@@ -4,31 +4,30 @@
 ::  Possible async calls
 ::
 +$  card
-  $%  [%hiss wire ~ %httr %hiss hiss:eyre]
-      [%them wire ~]
-      [%wait wire @da]
+  $%  [%wait wire @da]
       [%rest wire @da]
       [%poke wire dock poke-data]
       [%peer wire dock path]
       [%pull wire dock ~]
       [%diff out-peer-data]
+      [%request wire request:http outbound-config:http-client]
+      [%cancel-request wire ~]
   ==
 ::
 ::  Possible async responses
 ::
 +$  sign
-  $%  [%sigh =httr:eyre]
-      [%sigh-tang =tang]
-      [%wake error=(unit tang)]
+  $%  [%wake error=(unit tang)]
       [%coup =dock error=(unit tang)]
       [%quit =dock =path]
       [%reap =dock =path error=(unit tang)]
+      [%http-response response=client-response:http-client]
   ==
 ::
 ::  Outstanding contracts
 ::
 +$  contract
   $%  [%wait at=@da]
-      [%hiss ~]
+      [%request ~]
   ==
 --

--- a/sur/tapp.hoon
+++ b/sur/tapp.hoon
@@ -18,6 +18,7 @@
 ::
 +$  sign
   $%  [%sigh =httr:eyre]
+      [%sigh-tang =tang]
       [%wake error=(unit tang)]
       [%coup =dock error=(unit tang)]
       [%quit =dock =path]

--- a/sur/tapp.hoon
+++ b/sur/tapp.hoon
@@ -18,7 +18,10 @@
 ::
 +$  sign
   $%  [%sigh =httr:eyre]
-      [%wake (unit tang)]
+      [%wake error=(unit tang)]
+      [%coup =dock error=(unit tang)]
+      [%quit =dock =path]
+      [%reap =dock =path error=(unit tang)]
   ==
 ::
 ::  Outstanding contracts

--- a/sys/vane/ames.hoon
+++ b/sys/vane/ames.hoon
@@ -28,9 +28,6 @@
               ==                                        ::
           task:able:jael                                ::
       ==                                                ::
-      $:  %g                                            ::    to %gall
-          $>(%deal task:able:gall)                      ::  interact with apps
-      ==                                                ::
       $:  @tas                                          ::    to any
           $>(%west task:able)                           ::  deliver message
   ==  ==                                                ::
@@ -1417,19 +1414,8 @@
       [gad.fox %pass /ames %b %rest u.tim.fox]~
     ::
         %raki
-      =*  her  p.bon
-      =/  moz=(list move)
-        [hen [%pass / %j %meet her life=q.bon pass=r.bon]]~
-      ::  poke :dns with an indirect binding if her is a planet we're spnsoring
-      ::
-      =?  moz  ?&  ?=(%duke (clan:title her))
-                   ?=(%king (clan:title our))
-                   =(our (~(sein-scry am [our now fox ski]) her))
-               ==
-        =/  cmd  [%meet her]
-        =/  pok  [%dns %poke `cage`[%dns-command !>(cmd)]]
-        :_  moz  [hen [%pass / %g %deal [our our] pok]]
-      [moz fox]
+      :_  fox
+      [hen [%pass / %j %meet who=p.bon life=q.bon pass=r.bon]]~
     ::
         %sake
       =/  =wire  /our/(scot %p our)

--- a/sys/vane/gall.hoon
+++ b/sys/vane/gall.hoon
@@ -1342,7 +1342,8 @@
         %wind  `%j
         %wipe  `%f
       ::
-        %request     `%l
+        %request         `%l
+        %cancel-request  `%l
         %serve       `%r
         %connect     `%r
         %disconnect  `%r

--- a/sys/vane/lient.hoon
+++ b/sys/vane/lient.hoon
@@ -281,9 +281,11 @@
   ++  cleanup-connection
     |=  id=@ud
     ^-  ^state
+    ?~  con=(~(get by connection-by-id.state) id)
+      state
     %_    state
       connection-by-id    (~(del by connection-by-id.state) id)
-      connection-by-duct  (~(del by connection-by-duct.state) duct)
+      connection-by-duct  (~(del by connection-by-duct.state) duct.u.con)
     ==
   --
 --

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -895,34 +895,6 @@
   ++  host  (each turf @if)                             ::  http host
   ++  hoke  %+  each   {$localhost ~}                  ::  local host
             ?($.0.0.0.0 $.127.0.0.1)                    ::
-  :: +http-config: full http-server configuration
-  ::
-  +=  http-config
-    $:  :: secure: PEM-encoded RSA private key and cert or cert chain
-        ::
-        secure=(unit [key=wain cert=wain])
-        :: proxy: reverse TCP proxy HTTP(s)
-        ::
-        proxy=?
-        :: log: keep HTTP(s) access logs
-        ::
-        log=?
-        :: redirect: send 301 redirects to upgrade HTTP to HTTPS
-        ::
-        ::   Note: requires certificate.
-        ::
-        redirect=?
-    ==
-  :: +http-rule: update configuration
-  ::
-  +=  http-rule
-    $%  :: %cert: set or clear certificate and keypair
-        ::
-        [%cert cert=(unit [key=wain cert=wain])]
-        :: %turf: add or remove established dns binding
-        ::
-        [%turf action=?(%put %del) =turf]
-    ==
   ++  httq                                              ::  raw http request
     $:  p/meth                                          ::  method
         q/@t                                            ::  unparsed url
@@ -2213,7 +2185,7 @@
           [%live insecure=@ud secure=(unit @ud)]
           ::  update http configuration
           ::
-          [%rule =http-rule:eyre]
+          [%rule =http-rule]
           ::  starts handling an inbound http request
           ::
           [%request secure=? =address =request:http]
@@ -2289,7 +2261,7 @@
         secure=(unit [key=wain cert=wain])
         :: proxy: reverse TCP proxy HTTP(s)
         ::
-        proxy=?
+        proxy=_|
         :: log: keep HTTP(s) access logs
         ::
         log=?
@@ -2298,6 +2270,16 @@
         ::   Note: requires certificate.
         ::
         redirect=?
+    ==
+  :: +http-rule: update configuration
+  ::
+  +$  http-rule
+    $%  :: %cert: set or clear certificate and keypair
+        ::
+        [%cert cert=(unit [key=wain cert=wain])]
+        :: %turf: add or remove established dns binding
+        ::
+        [%turf action=?(%put %del) =turf]
     ==
   ::  +address: client IP address
   ::

--- a/sys/zuse.hoon
+++ b/sys/zuse.hoon
@@ -2052,15 +2052,16 @@
       ==
     ::
     ++  task
+      $~  [%vega ~]
       $%  ::  event failure notification
           ::
-          [%crud p=@tas q=(list tank)]
+          $>(%crud vane-task)
           ::  system started up; reset open connections
           ::
-          [%born ~]
+          $>(%born vane-task)
           ::  report upgrade
           ::
-          [%vega ~]
+          $>(%vega vane-task)
           ::  fetches a remote resource
           ::
           [%request =request:http =outbound-config]
@@ -2072,7 +2073,7 @@
           [%receive id=@ud =http-event:http]
           ::  memory usage request
           ::
-          [%wegh ~]
+          $>(%wegh vane-task)
       ==
     --
   ::  +client-response: one or more client responses given to the caller
@@ -2166,20 +2167,21 @@
       ==
     ::
     ++  task
+      $~  [%vega ~]
       $%  ::  event failure notification
           ::
-          [%crud p=@tas q=(list tank)]
+          $>(%crud vane-task)
           ::  initializes ourselves with an identity
           ::
-          ::    TODO: Remove this once we single home.
-          ::
-          [%init our=@p]
+          $>(%init vane-task)
           ::  new unix process
+          ::
+          ::    XX use +vane-task
           ::
           [%born p=(list host)]
           ::  report upgrade
           ::
-          [%vega ~]
+          $>(%vega vane-task)
           ::  notifies us of the ports of our live http servers
           ::
           [%live insecure=@ud secure=(unit @ud)]
@@ -2209,7 +2211,7 @@
           [%disconnect =binding]
           ::  memory usage request
           ::
-          [%wegh ~]
+          $>(%wegh vane-task)
       ==
     ::
     --


### PR DESCRIPTION
This PR is the first half of #1194, ported onto lighter-than-eyre. (The second half is incoming but will take more time, specifically with regards to the bespoke oauth2 implementation in the GCP DNS integration.)

This also fixes a bug in the `%lient` http-connection cleanup, and refactors the %rver and %lient interface declarations.